### PR TITLE
Unescape the less than and greater than inequalities

### DIFF
--- a/01-numpy.html
+++ b/01-numpy.html
@@ -28,7 +28,7 @@
           <h1 class="title">Programming with Python</h1>
           <h2 class="subtitle">Analyzing Patient Data</h2>
 <div id="learning-objectives" class="objectives objectives">
-<h2>Learning Objectives</h2>
+<h2 id="learning-objectives" class="objectives objectives">Learning Objectives</h2>
 <ul>
 <li>Explain what a library is, and what libraries are used for.</li>
 <li>Load a Python library and use the things it contains.</li>
@@ -43,7 +43,7 @@
 <p>In order to load our inflammation data, we need to <strong>import</strong> a library called NumPy. In general you should use this library if you want to do fancy things with numbers, especially if you have matrices. We can load NumPy using:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> numpy</code></pre>
 <p>Importing a library is like getting a piece of lab equipment out of a storage locker and setting it up on the bench. Once it's done, we can ask the library to read our data file for us:</p>
-<pre class="sourceCode python"><code class="sourceCode python">numpy.loadtxt(fname=&amp;<span class="co">#39;inflammation-01.csv&amp;#39;, delimiter=&amp;#39;,&amp;#39;)</span></code></pre>
+<pre class="sourceCode python"><code class="sourceCode python">numpy.loadtxt(fname=<span class="st">&#39;inflammation-01.csv&#39;</span>, delimiter=<span class="st">&#39;,&#39;</span>)</code></pre>
 <pre class="output"><code>array([[ 0.,  0.,  1., ...,  3.,  0.,  0.],
        [ 0.,  1.,  2., ...,  1.,  0.,  1.],
        [ 0.,  1.,  1., ...,  2.,  1.,  1.],

--- a/01-numpy.html
+++ b/01-numpy.html
@@ -93,7 +93,7 @@
  [ 0.  0.  1. ...,  1.  1.  0.]]</code></pre>
 <p>Now that our data is in memory, we can start doing things with it. First, let's ask what <strong>type</strong> of thing <code>data</code> refers to:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="dt">type</span>(data)</code></pre>
-<pre class="output"><code>&amp;lt;type &#39;numpy.ndarray&#39;&amp;gt;</code></pre>
+<pre class="output"><code>&lt;type &#39;numpy.ndarray&#39;&gt;</code></pre>
 <p>The output tells us that <code>data</code> currently refers to an N-dimensional array created by the NumPy library. We can see what its <strong>shape</strong> is like this:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data.shape</code></pre>
 <pre class="output"><code>(60, 40)</code></pre>

--- a/01-numpy.md
+++ b/01-numpy.md
@@ -189,7 +189,7 @@ let's ask what **type** of thing `data` refers to:
 print type(data)
 ~~~
 ~~~ {.output}
-&lt;type 'numpy.ndarray'&gt;
+<type 'numpy.ndarray'>
 ~~~
 
 The output tells us that `data` currently refers to an N-dimensional array created by the NumPy library.

--- a/01-numpy.md
+++ b/01-numpy.md
@@ -36,7 +36,7 @@ Once it's done,
 we can ask the library to read our data file for us:
 
 ~~~ {.python}
-numpy.loadtxt(fname=&#39;inflammation-01.csv&#39;, delimiter=&#39;,&#39;)
+numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 ~~~
 ~~~ {.output}
 array([[ 0.,  0.,  1., ...,  3.,  0.,  0.],

--- a/02-func.html
+++ b/02-func.html
@@ -124,8 +124,8 @@ final = fahr_to_celsius(original)</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;final value of temp after all function calls:&#39;</span>, temp</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&amp;lt;ipython-input-12-ffd9b4dbd5f1&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 print &#39;final value of temp after all function calls:&#39;, temp
+&lt;ipython-input-12-ffd9b4dbd5f1&gt; in &lt;module&gt;()
+----&gt; 1 print &#39;final value of temp after all function calls:&#39;, temp
 
 NameError: name &#39;temp&#39; is not defined</code></pre>
 <pre class="output"><code>final value of temp after all function calls:</code></pre>
@@ -195,7 +195,7 @@ center(data, desired)
 <p>A string like this is called a <strong>docstring</strong>. We don't need to use triple quotes when we write one, but if we do, we can break the string across multiple lines:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> center(data, desired):
     <span class="co">&#39;&#39;&#39;Return a new array containing the original data centered around the desired value.</span>
-<span class="co">    Example: center([1, 2, 3], 0) =&amp;gt; [-1, 0, 1]&#39;&#39;&#39;</span>
+<span class="co">    Example: center([1, 2, 3], 0) =&gt; [-1, 0, 1]&#39;&#39;&#39;</span>
     <span class="kw">return</span> (data - data.mean()) + desired
 
 <span class="dt">help</span>(center)</code></pre>
@@ -203,7 +203,7 @@ center(data, desired)
 
 center(data, desired)
     Return a new array containing the original data centered around the desired value.
-    Example: center([1, 2, 3], 0) =&amp;gt; [-1, 0, 1]
+    Example: center([1, 2, 3], 0) =&gt; [-1, 0, 1]
 </code></pre>
 <h2 id="defining-defaults">Defining Defaults</h2>
 <p>We have passed parameters to functions in two ways: directly, as in <code>span(data)</code>, and by name, as in <code>numpy.loadtxt(fname='something.csv', delimiter=',')</code>. In fact, we can pass the filename to <code>loadtxt</code> without the <code>fname=</code>:</p>
@@ -213,13 +213,13 @@ center(data, desired)
 <pre class="sourceCode python"><code class="sourceCode python">numpy.loadtxt(<span class="st">&#39;inflammation-01.csv&#39;</span>, <span class="st">&#39;,&#39;</span>)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 TypeError                                 Traceback (most recent call last)
-&amp;lt;ipython-input-26-e3bc6cf4fd6a&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 numpy.loadtxt(&#39;inflammation-01.csv&#39;, &#39;,&#39;)
+&lt;ipython-input-26-e3bc6cf4fd6a&gt; in &lt;module&gt;()
+----&gt; 1 numpy.loadtxt(&#39;inflammation-01.csv&#39;, &#39;,&#39;)
 
 /Users/gwilson/anaconda/lib/python2.7/site-packages/numpy/lib/npyio.pyc in loadtxt(fname, dtype, comments, delimiter, converters, skiprows, usecols, unpack, ndmin)
     775     try:
     776         # Make sure we&#39;re dealing with a proper dtype
---&amp;gt; 777         dtype = np.dtype(dtype)
+--&gt; 777         dtype = np.dtype(dtype)
     778         defconv = _getconv(dtype)
     779 
 
@@ -227,7 +227,7 @@ TypeError: data type &quot;,&quot; not understood</code></pre>
 <p>To understand what's going on, and make our own functions easier to use, let's re-define our <code>center</code> function like this:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> center(data, desired=<span class="fl">0.0</span>):
     <span class="co">&#39;&#39;&#39;Return a new array containing the original data centered around the desired value (0 by default).</span>
-<span class="co">    Example: center([1, 2, 3], 0) =&amp;gt; [-1, 0, 1]&#39;&#39;&#39;</span>
+<span class="co">    Example: center([1, 2, 3], 0) =&gt; [-1, 0, 1]&#39;&#39;&#39;</span>
     <span class="kw">return</span> (data - data.mean()) + desired</code></pre>
 <p>The key change is that the second parameter is now written <code>desired=0.0</code> instead of just <code>desired</code>. If we call the function with two arguments, it works as it did before:</p>
 <pre class="sourceCode python"><code class="sourceCode python">test_data = numpy.zeros((<span class="dv">2</span>, <span class="dv">2</span>))
@@ -267,7 +267,7 @@ a: 1 b: 2 c: 77</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">help</span>(numpy.loadtxt)</code></pre>
 <pre class="output"><code>Help on function loadtxt in module numpy.lib.npyio:
 
-loadtxt(fname, dtype=&amp;lt;type &#39;float&#39;&amp;gt;, comments=&#39;#&#39;, delimiter=None, converters=None, skiprows=0, usecols=None, unpack=False, ndmin=0)
+loadtxt(fname, dtype=&lt;type &#39;float&#39;&gt;, comments=&#39;#&#39;, delimiter=None, converters=None, skiprows=0, usecols=None, unpack=False, ndmin=0)
     Load data from a text file.
     
     Each row in the text file must have the same number of values.
@@ -331,23 +331,23 @@ loadtxt(fname, dtype=&amp;lt;type &#39;float&#39;&amp;gt;, comments=&#39;#&#39;,
     
     Examples
     --------
-    &amp;gt;&amp;gt;&amp;gt; from StringIO import StringIO   # StringIO behaves like a file object
-    &amp;gt;&amp;gt;&amp;gt; c = StringIO(&quot;0 1\n2 3&quot;)
-    &amp;gt;&amp;gt;&amp;gt; np.loadtxt(c)
+    &gt;&gt;&gt; from StringIO import StringIO   # StringIO behaves like a file object
+    &gt;&gt;&gt; c = StringIO(&quot;0 1\n2 3&quot;)
+    &gt;&gt;&gt; np.loadtxt(c)
     array([[ 0.,  1.],
            [ 2.,  3.]])
     
-    &amp;gt;&amp;gt;&amp;gt; d = StringIO(&quot;M 21 72\nF 35 58&quot;)
-    &amp;gt;&amp;gt;&amp;gt; np.loadtxt(d, dtype={&#39;names&#39;: (&#39;gender&#39;, &#39;age&#39;, &#39;weight&#39;),
+    &gt;&gt;&gt; d = StringIO(&quot;M 21 72\nF 35 58&quot;)
+    &gt;&gt;&gt; np.loadtxt(d, dtype={&#39;names&#39;: (&#39;gender&#39;, &#39;age&#39;, &#39;weight&#39;),
     ...                      &#39;formats&#39;: (&#39;S1&#39;, &#39;i4&#39;, &#39;f4&#39;)})
     array([(&#39;M&#39;, 21, 72.0), (&#39;F&#39;, 35, 58.0)],
-          dtype=[(&#39;gender&#39;, &#39;|S1&#39;), (&#39;age&#39;, &#39;&amp;lt;i4&#39;), (&#39;weight&#39;, &#39;&amp;lt;f4&#39;)])
+          dtype=[(&#39;gender&#39;, &#39;|S1&#39;), (&#39;age&#39;, &#39;&lt;i4&#39;), (&#39;weight&#39;, &#39;&lt;f4&#39;)])
     
-    &amp;gt;&amp;gt;&amp;gt; c = StringIO(&quot;1,0,2\n3,0,4&quot;)
-    &amp;gt;&amp;gt;&amp;gt; x, y = np.loadtxt(c, delimiter=&#39;,&#39;, usecols=(0, 2), unpack=True)
-    &amp;gt;&amp;gt;&amp;gt; x
+    &gt;&gt;&gt; c = StringIO(&quot;1,0,2\n3,0,4&quot;)
+    &gt;&gt;&gt; x, y = np.loadtxt(c, delimiter=&#39;,&#39;, usecols=(0, 2), unpack=True)
+    &gt;&gt;&gt; x
     array([ 1.,  3.])
-    &amp;gt;&amp;gt;&amp;gt; y
+    &gt;&gt;&gt; y
     array([ 2.,  4.])
 </code></pre>
 <p>There's a lot of information here, but the most important part is the first couple of lines:</p>

--- a/02-func.md
+++ b/02-func.md
@@ -291,8 +291,8 @@ print 'final value of temp after all function calls:', temp
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&lt;ipython-input-12-ffd9b4dbd5f1&gt; in &lt;module&gt;()
-----&gt; 1 print 'final value of temp after all function calls:', temp
+<ipython-input-12-ffd9b4dbd5f1> in <module>()
+----> 1 print 'final value of temp after all function calls:', temp
 
 NameError: name 'temp' is not defined
 ~~~
@@ -478,7 +478,7 @@ we can break the string across multiple lines:
 ~~~ {.python}
 def center(data, desired):
     '''Return a new array containing the original data centered around the desired value.
-    Example: center([1, 2, 3], 0) =&gt; [-1, 0, 1]'''
+    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''
     return (data - data.mean()) + desired
 
 help(center)
@@ -488,7 +488,7 @@ Help on function center in module __main__:
 
 center(data, desired)
     Return a new array containing the original data centered around the desired value.
-    Example: center([1, 2, 3], 0) =&gt; [-1, 0, 1]
+    Example: center([1, 2, 3], 0) => [-1, 0, 1]
 
 ~~~
 
@@ -520,13 +520,13 @@ numpy.loadtxt('inflammation-01.csv', ',')
 ~~~ {.error}
 ---------------------------------------------------------------------------
 TypeError                                 Traceback (most recent call last)
-&lt;ipython-input-26-e3bc6cf4fd6a&gt; in &lt;module&gt;()
-----&gt; 1 numpy.loadtxt('inflammation-01.csv', ',')
+<ipython-input-26-e3bc6cf4fd6a> in <module>()
+----> 1 numpy.loadtxt('inflammation-01.csv', ',')
 
 /Users/gwilson/anaconda/lib/python2.7/site-packages/numpy/lib/npyio.pyc in loadtxt(fname, dtype, comments, delimiter, converters, skiprows, usecols, unpack, ndmin)
     775     try:
     776         # Make sure we're dealing with a proper dtype
---&gt; 777         dtype = np.dtype(dtype)
+--> 777         dtype = np.dtype(dtype)
     778         defconv = _getconv(dtype)
     779 
 
@@ -540,7 +540,7 @@ let's re-define our `center` function like this:
 ~~~ {.python}
 def center(data, desired=0.0):
     '''Return a new array containing the original data centered around the desired value (0 by default).
-    Example: center([1, 2, 3], 0) =&gt; [-1, 0, 1]'''
+    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''
     return (data - data.mean()) + desired
 ~~~
 
@@ -622,7 +622,7 @@ help(numpy.loadtxt)
 ~~~ {.output}
 Help on function loadtxt in module numpy.lib.npyio:
 
-loadtxt(fname, dtype=&lt;type 'float'&gt;, comments='#', delimiter=None, converters=None, skiprows=0, usecols=None, unpack=False, ndmin=0)
+loadtxt(fname, dtype=<type 'float'>, comments='#', delimiter=None, converters=None, skiprows=0, usecols=None, unpack=False, ndmin=0)
     Load data from a text file.
     
     Each row in the text file must have the same number of values.
@@ -686,23 +686,23 @@ loadtxt(fname, dtype=&lt;type 'float'&gt;, comments='#', delimiter=None, convert
     
     Examples
     --------
-    &gt;&gt;&gt; from StringIO import StringIO   # StringIO behaves like a file object
-    &gt;&gt;&gt; c = StringIO("0 1\n2 3")
-    &gt;&gt;&gt; np.loadtxt(c)
+    >>> from StringIO import StringIO   # StringIO behaves like a file object
+    >>> c = StringIO("0 1\n2 3")
+    >>> np.loadtxt(c)
     array([[ 0.,  1.],
            [ 2.,  3.]])
     
-    &gt;&gt;&gt; d = StringIO("M 21 72\nF 35 58")
-    &gt;&gt;&gt; np.loadtxt(d, dtype={'names': ('gender', 'age', 'weight'),
+    >>> d = StringIO("M 21 72\nF 35 58")
+    >>> np.loadtxt(d, dtype={'names': ('gender', 'age', 'weight'),
     ...                      'formats': ('S1', 'i4', 'f4')})
     array([('M', 21, 72.0), ('F', 35, 58.0)],
-          dtype=[('gender', '|S1'), ('age', '&lt;i4'), ('weight', '&lt;f4')])
+          dtype=[('gender', '|S1'), ('age', '<i4'), ('weight', '<f4')])
     
-    &gt;&gt;&gt; c = StringIO("1,0,2\n3,0,4")
-    &gt;&gt;&gt; x, y = np.loadtxt(c, delimiter=',', usecols=(0, 2), unpack=True)
-    &gt;&gt;&gt; x
+    >>> c = StringIO("1,0,2\n3,0,4")
+    >>> x, y = np.loadtxt(c, delimiter=',', usecols=(0, 2), unpack=True)
+    >>> x
     array([ 1.,  3.])
-    &gt;&gt;&gt; y
+    >>> y
     array([ 2.,  4.])
 
 ~~~

--- a/03-loop.html
+++ b/03-loop.html
@@ -90,8 +90,8 @@ d</code></pre>
 </ol>
 <pre class="sourceCode python"><code class="sourceCode python">print_characters(<span class="st">&#39;tin&#39;</span>)</code></pre>
 <h2 id="section" class="error"><sub>~</sub></h2>
-<p>IndexError Traceback (most recent call last) &lt;ipython-input-13-5bc7311e0bf3&gt; in &lt;module&gt;() ----&gt; 1 print_characters('tin')</p>
-<p>&lt;ipython-input-12-11460561ea56&gt; in print_characters(element) 3 print element[1] 4 print element[2] ----&gt; 5 print element[3] 6 7 print_characters('lead')</p>
+<p>IndexError Traceback (most recent call last) <ipython-input-13-5bc7311e0bf3> in <module>() ----&gt; 1 print_characters('tin')</p>
+<p><ipython-input-12-11460561ea56> in print_characters(element) 3 print element[1] 4 print element[2] ----&gt; 5 print element[3] 6 7 print_characters('lead')</p>
 <p>IndexError: string index out of range <sub>~</sub> {.output} t i n <sub>~</sub></p>
 <p>Here's a better approach:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> print_characters(element):

--- a/03-loop.md
+++ b/03-loop.md
@@ -100,13 +100,13 @@ print_characters('tin')
 ~~~ {.error}
 ---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
-&lt;ipython-input-13-5bc7311e0bf3&gt; in &lt;module&gt;()
-----&gt; 1 print_characters('tin')
+<ipython-input-13-5bc7311e0bf3> in <module>()
+----> 1 print_characters('tin')
 
-&lt;ipython-input-12-11460561ea56&gt; in print_characters(element)
+<ipython-input-12-11460561ea56> in print_characters(element)
       3     print element[1]
       4     print element[2]
-----&gt; 5     print element[3]
+----> 5     print element[3]
       6 
       7 print_characters('lead')
 

--- a/04-cond.html
+++ b/04-cond.html
@@ -72,16 +72,16 @@ color is: (10, 20, 30)</code></pre>
 <span class="dt">print</span> <span class="st">&#39;first element of color after change:&#39;</span>, color[<span class="dv">0</span>]</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 TypeError                                 Traceback (most recent call last)
-&amp;lt;ipython-input-11-9c3dd30a4e52&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 color[0] = 40
+&lt;ipython-input-11-9c3dd30a4e52&gt; in &lt;module&gt;()
+----&gt; 1 color[0] = 40
       2 print &#39;first element of color after change:&#39;, color[0]
 
 TypeError: &#39;tuple&#39; object does not support item assignment</code></pre>
 <p>If a tuple represents an RGB color, its red, green, and blue components can take on values between 0 and 255. The upper bound may seem odd, but it's the largest number that can be represented in an 8-bit byte (i.e., 2<sup>8</sup>-1). This makes it easy for computers to manipulate colors, while providing fine enough gradations to fool most human eyes, most of the time.</p>
 <p>Let's see what a few RGB colors actually look like:</p>
 <pre class="sourceCode python"><code class="sourceCode python">row = ImageGrid(<span class="dv">8</span>, <span class="dv">1</span>)
-row[<span class="dv">0</span>, <span class="dv">0</span>] = (<span class="dv">0</span>, <span class="dv">0</span>, <span class="dv">0</span>)   <span class="co"># no color =&amp;gt; black</span>
-row[<span class="dv">1</span>, <span class="dv">0</span>] = (<span class="dv">255</span>, <span class="dv">255</span>, <span class="dv">255</span>) <span class="co"># all colors =&amp;gt; white</span>
+row[<span class="dv">0</span>, <span class="dv">0</span>] = (<span class="dv">0</span>, <span class="dv">0</span>, <span class="dv">0</span>)   <span class="co"># no color =&gt; black</span>
+row[<span class="dv">1</span>, <span class="dv">0</span>] = (<span class="dv">255</span>, <span class="dv">255</span>, <span class="dv">255</span>) <span class="co"># all colors =&gt; white</span>
 row[<span class="dv">2</span>, <span class="dv">0</span>] = (<span class="dv">255</span>, <span class="dv">0</span>, <span class="dv">0</span>) <span class="co"># all red</span>
 row[<span class="dv">3</span>, <span class="dv">0</span>] = (<span class="dv">0</span>, <span class="dv">255</span>, <span class="dv">0</span>) <span class="co"># all green</span>
 row[<span class="dv">4</span>, <span class="dv">0</span>] = (<span class="dv">0</span>, <span class="dv">0</span>, <span class="dv">255</span>) <span class="co"># all blue</span>
@@ -108,7 +108,7 @@ c.show()</code></pre>
 <h2 id="conditionals">Conditionals</h2>
 <p>The other thing we need in order to create a heat map of our own is a way to pick a color based on a data value. The tool Python gives us for doing this is called a <strong>conditional statement</strong>, and looks like this:</p>
 <pre class="sourceCode python"><code class="sourceCode python">num = <span class="dv">37</span>
-<span class="kw">if</span> num &amp;gt; <span class="dv">100</span>:
+<span class="kw">if</span> num &gt; <span class="dv">100</span>:
     <span class="dt">print</span> <span class="st">&#39;greater&#39;</span>
 <span class="kw">else</span>:
     <span class="dt">print</span> <span class="st">&#39;not greater&#39;</span>
@@ -121,14 +121,14 @@ done
 <p>Conditional statements don't have to include an <code>else</code>. If there isn't one, Python simply does nothing if the test is false:</p>
 <pre class="sourceCode python"><code class="sourceCode python">num = <span class="dv">53</span>
 <span class="dt">print</span> <span class="st">&#39;before conditional...&#39;</span>
-<span class="kw">if</span> num &amp;gt; <span class="dv">100</span>:
+<span class="kw">if</span> num &gt; <span class="dv">100</span>:
     <span class="dt">print</span> <span class="st">&#39;53 is greater than 100&#39;</span>
 <span class="dt">print</span> <span class="st">&#39;...after conditional&#39;</span></code></pre>
 <pre class="output"><code>before conditional...
 ...after conditional</code></pre>
 <p>We can also chain several tests together using <code>elif</code>, which is short for &quot;else if&quot;. This makes it simple to write a function that returns the sign of a number:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> sign(num):
-    <span class="kw">if</span> num &amp;gt; <span class="dv">0</span>:
+    <span class="kw">if</span> num &gt; <span class="dv">0</span>:
         <span class="kw">return</span> <span class="dv">1</span>
     <span class="kw">elif</span> num == <span class="dv">0</span>:
         <span class="kw">return</span> <span class="dv">0</span>
@@ -139,13 +139,13 @@ done
 <pre class="output"><code>sign of -3: -1</code></pre>
 <p>One important thing to notice in the code above is that we use a double equals sign <code>==</code> to test for equality rather than a single equals sign because the latter is used to mean assignment. This convention was inherited from C, and while many other programming languages work the same way, it does take a bit of getting used to...</p>
 <p>We can also combine tests using <code>and</code> and <code>or</code>. <code>and</code> is only true if both parts are true:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> (<span class="dv">1</span> &amp;gt; <span class="dv">0</span>) and (-<span class="dv">1</span> &amp;gt; <span class="dv">0</span>):
+<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> (<span class="dv">1</span> &gt; <span class="dv">0</span>) and (-<span class="dv">1</span> &gt; <span class="dv">0</span>):
     <span class="dt">print</span> <span class="st">&#39;both parts are true&#39;</span>
 <span class="kw">else</span>:
     <span class="dt">print</span> <span class="st">&#39;one part is not true&#39;</span></code></pre>
 <pre class="output"><code>one part is not true</code></pre>
 <p>while <code>or</code> is true if either part is true:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> (<span class="dv">1</span> &amp;lt; <span class="dv">0</span>) or (<span class="st">&#39;left&#39;</span> &amp;lt; <span class="st">&#39;right&#39;</span>):
+<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> (<span class="dv">1</span> &lt; <span class="dv">0</span>) or (<span class="st">&#39;left&#39;</span> &lt; <span class="st">&#39;right&#39;</span>):
     <span class="dt">print</span> <span class="st">&#39;at least one test is true&#39;</span></code></pre>
 <pre class="output"><code>at least one test is true</code></pre>
 <p>In this case, &quot;either&quot; means &quot;either or both&quot;, not &quot;either one or the other but not both&quot;.</p>
@@ -154,7 +154,7 @@ done
 <pre class="sourceCode python"><code class="sourceCode python">numbers = [-<span class="dv">5</span>, <span class="dv">3</span>, <span class="dv">2</span>, -<span class="dv">1</span>, <span class="dv">9</span>, <span class="dv">6</span>]
 total = <span class="dv">0</span>
 <span class="kw">for</span> n in numbers:
-    <span class="kw">if</span> n &amp;gt;= <span class="dv">0</span>:
+    <span class="kw">if</span> n &gt;= <span class="dv">0</span>:
         total = total + n
 <span class="dt">print</span> <span class="st">&#39;sum of positive values:&#39;</span>, total</code></pre>
 <pre class="output"><code>sum of positive values: 20
@@ -163,7 +163,7 @@ total = <span class="dv">0</span>
 <pre class="sourceCode python"><code class="sourceCode python">pos_total = <span class="dv">0</span>
 neg_total = <span class="dv">0</span>
 <span class="kw">for</span> n in numbers:
-    <span class="kw">if</span> n &amp;gt;= <span class="dv">0</span>:
+    <span class="kw">if</span> n &gt;= <span class="dv">0</span>:
         pos_total = pos_total + n
     <span class="kw">else</span>:
         neg_total = neg_total + n
@@ -185,7 +185,7 @@ de</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python">square = ImageGrid(<span class="dv">5</span>, <span class="dv">5</span>)
 <span class="kw">for</span> x in <span class="dt">range</span>(square.width):
     <span class="kw">for</span> y in <span class="dt">range</span>(square.height):
-        <span class="kw">if</span> x &amp;lt; y:
+        <span class="kw">if</span> x &lt; y:
             square[x, y] = colors[<span class="st">&#39;Fuchsia&#39;</span>]
         <span class="kw">elif</span> x == y:
             square[x, y] = colors[<span class="st">&#39;Olive&#39;</span>]
@@ -207,7 +207,7 @@ heatmap = ImageGrid(width, height)</code></pre>
 <p>The third step is to decide <em>how</em> we are going to color the cells in the heat map. To keep things simple, we will use red, green, and blue as our colors, and compare data values to the data set's mean. Here's the code:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">for</span> x in <span class="dt">range</span>(width):
     <span class="kw">for</span> y in <span class="dt">range</span>(height):
-        <span class="kw">if</span> data[x, y] &amp;lt; data.mean():
+        <span class="kw">if</span> data[x, y] &lt; data.mean():
             heatmap[x, y] = colors[<span class="st">&#39;Red&#39;</span>]
         <span class="kw">elif</span> data[x, y] == data.mean():
             heatmap[x, y] = colors[<span class="st">&#39;Green&#39;</span>]
@@ -238,9 +238,9 @@ heatmap = ImageGrid(width, height, block_size=<span class="dv">5</span>)
 center = flipped.mean()
 <span class="kw">for</span> x in <span class="dt">range</span>(width):
     <span class="kw">for</span> y in <span class="dt">range</span>(height):
-        <span class="kw">if</span> flipped[x, y] &amp;lt; (<span class="fl">0.8</span> * center):
+        <span class="kw">if</span> flipped[x, y] &lt; (<span class="fl">0.8</span> * center):
             heatmap[x, y] = colors[<span class="st">&#39;Orchid&#39;</span>]
-        <span class="kw">elif</span> flipped[x, y] &amp;gt; (<span class="fl">1.2</span> * center):
+        <span class="kw">elif</span> flipped[x, y] &gt; (<span class="fl">1.2</span> * center):
             heatmap[x, y] = colors[<span class="st">&#39;HotPink&#39;</span>]
         <span class="kw">else</span>:
             heatmap[x, y] = colors[<span class="st">&#39;Fuchsia&#39;</span>]
@@ -255,9 +255,9 @@ heatmap.show()</code></pre>
     center = values.mean()
     <span class="kw">for</span> x in <span class="dt">range</span>(width):
         <span class="kw">for</span> y in <span class="dt">range</span>(height):
-            <span class="kw">if</span> values[x, y] &amp;lt; low_band * center:
+            <span class="kw">if</span> values[x, y] &lt; low_band * center:
                 result[x, y] = low_color
-            <span class="kw">elif</span> values[x, y] &amp;gt; high_band * center:
+            <span class="kw">elif</span> values[x, y] &gt; high_band * center:
                 result[x, y] = high_color
             <span class="kw">else</span>:
                 result[x, y] = mid_color
@@ -282,9 +282,9 @@ h.show()</code></pre>
     center = values.mean()
     <span class="kw">for</span> x in <span class="dt">range</span>(width):
         <span class="kw">for</span> y in <span class="dt">range</span>(height):
-            <span class="kw">if</span> values[x, y] &amp;lt; low_band * center:
+            <span class="kw">if</span> values[x, y] &lt; low_band * center:
                 result[x, y] = low_color
-            <span class="kw">elif</span> values[x, y] &amp;gt; high_band * center:
+            <span class="kw">elif</span> values[x, y] &gt; high_band * center:
                 result[x, y] = high_color
             <span class="kw">else</span>:
                 result[x, y] = mid_color

--- a/04-cond.md
+++ b/04-cond.md
@@ -116,8 +116,8 @@ print 'first element of color after change:', color[0]
 ~~~ {.error}
 ---------------------------------------------------------------------------
 TypeError                                 Traceback (most recent call last)
-&lt;ipython-input-11-9c3dd30a4e52&gt; in &lt;module&gt;()
-----&gt; 1 color[0] = 40
+<ipython-input-11-9c3dd30a4e52> in <module>()
+----> 1 color[0] = 40
       2 print 'first element of color after change:', color[0]
 
 TypeError: 'tuple' object does not support item assignment
@@ -136,8 +136,8 @@ Let's see what a few RGB colors actually look like:
 
 ~~~ {.python}
 row = ImageGrid(8, 1)
-row[0, 0] = (0, 0, 0)   # no color =&gt; black
-row[1, 0] = (255, 255, 255) # all colors =&gt; white
+row[0, 0] = (0, 0, 0)   # no color => black
+row[1, 0] = (255, 255, 255) # all colors => white
 row[2, 0] = (255, 0, 0) # all red
 row[3, 0] = (0, 255, 0) # all green
 row[4, 0] = (0, 0, 255) # all blue
@@ -186,7 +186,7 @@ and looks like this:
 
 ~~~ {.python}
 num = 37
-if num &gt; 100:
+if num > 100:
     print 'greater'
 else:
     print 'not greater'
@@ -215,7 +215,7 @@ Python simply does nothing if the test is false:
 ~~~ {.python}
 num = 53
 print 'before conditional...'
-if num &gt; 100:
+if num > 100:
     print '53 is greater than 100'
 print '...after conditional'
 ~~~
@@ -230,7 +230,7 @@ This makes it simple to write a function that returns the sign of a number:
 
 ~~~ {.python}
 def sign(num):
-    if num &gt; 0:
+    if num > 0:
         return 1
     elif num == 0:
         return 0
@@ -254,7 +254,7 @@ We can also combine tests using `and` and `or`.
 `and` is only true if both parts are true:
 
 ~~~ {.python}
-if (1 &gt; 0) and (-1 &gt; 0):
+if (1 > 0) and (-1 > 0):
     print 'both parts are true'
 else:
     print 'one part is not true'
@@ -266,7 +266,7 @@ one part is not true
 while `or` is true if either part is true:
 
 ~~~ {.python}
-if (1 &lt; 0) or ('left' &lt; 'right'):
+if (1 < 0) or ('left' < 'right'):
     print 'at least one test is true'
 ~~~
 ~~~ {.output}
@@ -288,7 +288,7 @@ we can write this:
 numbers = [-5, 3, 2, -1, 9, 6]
 total = 0
 for n in numbers:
-    if n &gt;= 0:
+    if n >= 0:
         total = total + n
 print 'sum of positive values:', total
 ~~~
@@ -303,7 +303,7 @@ We could equally well calculate the positive and negative sums in a single loop:
 pos_total = 0
 neg_total = 0
 for n in numbers:
-    if n &gt;= 0:
+    if n >= 0:
         pos_total = pos_total + n
     else:
         neg_total = neg_total + n
@@ -341,7 +341,7 @@ We can combine nesting and conditionals to create patterns in an image:
 square = ImageGrid(5, 5)
 for x in range(square.width):
     for y in range(square.height):
-        if x &lt; y:
+        if x < y:
             square[x, y] = colors['Fuchsia']
         elif x == y:
             square[x, y] = colors['Olive']
@@ -390,7 +390,7 @@ Here's the code:
 ~~~ {.python}
 for x in range(width):
     for y in range(height):
-        if data[x, y] &lt; data.mean():
+        if data[x, y] < data.mean():
             heatmap[x, y] = colors['Red']
         elif data[x, y] == data.mean():
             heatmap[x, y] = colors['Green']
@@ -428,9 +428,9 @@ heatmap = ImageGrid(width, height, block_size=5)
 center = flipped.mean()
 for x in range(width):
     for y in range(height):
-        if flipped[x, y] &lt; (0.8 * center):
+        if flipped[x, y] < (0.8 * center):
             heatmap[x, y] = colors['Orchid']
-        elif flipped[x, y] &gt; (1.2 * center):
+        elif flipped[x, y] > (1.2 * center):
             heatmap[x, y] = colors['HotPink']
         else:
             heatmap[x, y] = colors['Fuchsia']
@@ -455,9 +455,9 @@ def make_heatmap(values, low_color, mid_color, high_color, low_band, high_band, 
     center = values.mean()
     for x in range(width):
         for y in range(height):
-            if values[x, y] &lt; low_band * center:
+            if values[x, y] < low_band * center:
                 result[x, y] = low_color
-            elif values[x, y] &gt; high_band * center:
+            elif values[x, y] > high_band * center:
                 result[x, y] = high_color
             else:
                 result[x, y] = mid_color
@@ -504,9 +504,9 @@ def make_heatmap(values,
     center = values.mean()
     for x in range(width):
         for y in range(height):
-            if values[x, y] &lt; low_band * center:
+            if values[x, y] < low_band * center:
                 result[x, y] = low_color
-            elif values[x, y] &gt; high_band * center:
+            elif values[x, y] > high_band * center:
                 result[x, y] = high_color
             else:
                 result[x, y] = mid_color

--- a/05-defensive.html
+++ b/05-defensive.html
@@ -51,15 +51,15 @@
 <pre class="sourceCode python"><code class="sourceCode python">numbers = [<span class="fl">1.5</span>, <span class="fl">2.3</span>, <span class="fl">0.7</span>, -<span class="fl">0.001</span>, <span class="fl">4.4</span>]
 total = <span class="fl">0.0</span>
 <span class="kw">for</span> n in numbers:
-    <span class="kw">assert</span> n &amp;gt;= <span class="fl">0.0</span>, <span class="st">&#39;Data should only contain positive values&#39;</span>
+    <span class="kw">assert</span> n &gt;= <span class="fl">0.0</span>, <span class="st">&#39;Data should only contain positive values&#39;</span>
     total += n
 <span class="dt">print</span> <span class="st">&#39;total is:&#39;</span>, total</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&amp;lt;ipython-input-19-33d87ea29ae4&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-19-33d87ea29ae4&gt; in &lt;module&amp;gt;()
       2 total = 0.0
       3 for n in numbers:
-----&amp;gt; 4     assert n &amp;gt;= 0.0, &#39;Data should only contain positive values&#39;
+----&gt; 4     assert n &gt;= 0.0, &#39;Data should only contain positive values&#39;
       5     total += n
       6 print &#39;total is:&#39;, total
 
@@ -75,48 +75,48 @@ AssertionError: Data should only contain positive values</code></pre>
     <span class="co">&#39;&#39;&#39;Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.&#39;&#39;&#39;</span>
     <span class="kw">assert</span> <span class="dt">len</span>(rect) == <span class="dv">4</span>, <span class="st">&#39;Rectangles must contain 4 coordinates&#39;</span>
     x0, y0, x1, y1 = rect
-    <span class="kw">assert</span> x0 &amp;lt; x1, <span class="st">&#39;Invalid X coordinates&#39;</span>
-    <span class="kw">assert</span> y0 &amp;lt; y1, <span class="st">&#39;Invalid Y coordinates&#39;</span>
+    <span class="kw">assert</span> x0 &lt; x1, <span class="st">&#39;Invalid X coordinates&#39;</span>
+    <span class="kw">assert</span> y0 &lt; y1, <span class="st">&#39;Invalid Y coordinates&#39;</span>
     
     dx = x1 - x0
     dy = y1 - y0
-    <span class="kw">if</span> dx &amp;gt; dy:
+    <span class="kw">if</span> dx &gt; dy:
         scaled = <span class="dt">float</span>(dx) / dy
         upper_x, upper_y = <span class="fl">1.0</span>, scaled
     <span class="kw">else</span>:
         scaled = <span class="dt">float</span>(dx) / dy
         upper_x, upper_y = scaled, <span class="fl">1.0</span>
 
-    <span class="kw">assert</span> <span class="dv">0</span> &amp;lt; upper_x &amp;lt;= <span class="fl">1.0</span>, <span class="st">&#39;Calculated upper X coordinate invalid&#39;</span>
-    <span class="kw">assert</span> <span class="dv">0</span> &amp;lt; upper_y &amp;lt;= <span class="fl">1.0</span>, <span class="st">&#39;Calculated upper Y coordinate invalid&#39;</span>
+    <span class="kw">assert</span> <span class="dv">0</span> &lt; upper_x &lt;= <span class="fl">1.0</span>, <span class="st">&#39;Calculated upper X coordinate invalid&#39;</span>
+    <span class="kw">assert</span> <span class="dv">0</span> &lt; upper_y &lt;= <span class="fl">1.0</span>, <span class="st">&#39;Calculated upper Y coordinate invalid&#39;</span>
 
     <span class="kw">return</span> (<span class="dv">0</span>, <span class="dv">0</span>, upper_x, upper_y)</code></pre>
 <p>The preconditions on lines 2, 4, and 5 catch invalid inputs:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">1.0</span>, <span class="fl">2.0</span>) ) <span class="co"># missing the fourth coordinate</span></code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&amp;lt;ipython-input-21-3a97b1dcab70&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
+&lt;ipython-input-21-3a97b1dcab70&gt; in &lt;module&gt;()
+----&gt; 1 print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
 
-&amp;lt;ipython-input-20-408dc39f3915&amp;gt; in normalize_rectangle(rect)
+&lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
       1 def normalize_rectangle(rect):
       2     &#39;&#39;&#39;Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.&#39;&#39;&#39;
-----&amp;gt; 3     assert len(rect) == 4, &#39;Rectangles must contain 4 coordinates&#39;
+----&gt; 3     assert len(rect) == 4, &#39;Rectangles must contain 4 coordinates&#39;
       4     x0, y0, x1, y1 = rect
-      5     assert x0 &amp;lt; x1, &#39;Invalid X coordinates&#39;
+      5     assert x0 &lt; x1, &#39;Invalid X coordinates&#39;
 
 AssertionError: Rectangles must contain 4 coordinates</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> normalize_rectangle( (<span class="fl">4.0</span>, <span class="fl">2.0</span>, <span class="fl">1.0</span>, <span class="fl">5.0</span>) ) <span class="co"># X axis inverted</span></code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&amp;lt;ipython-input-22-f05ae7878a45&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
+&lt;ipython-input-22-f05ae7878a45&gt; in &lt;module&gt;()
+----&gt; 1 print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
 
-&amp;lt;ipython-input-20-408dc39f3915&amp;gt; in normalize_rectangle(rect)
+&lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
       3     assert len(rect) == 4, &#39;Rectangles must contain 4 coordinates&#39;
       4     x0, y0, x1, y1 = rect
-----&amp;gt; 5     assert x0 &amp;lt; x1, &#39;Invalid X coordinates&#39;
-      6     assert y0 &amp;lt; y1, &#39;Invalid Y coordinates&#39;
+----&gt; 5     assert x0 &lt; x1, &#39;Invalid X coordinates&#39;
+      6     assert y0 &lt; y1, &#39;Invalid Y coordinates&#39;
       7 
 
 AssertionError: Invalid X coordinates</code></pre>
@@ -127,13 +127,13 @@ AssertionError: Invalid X coordinates</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">0.0</span>, <span class="fl">5.0</span>, <span class="fl">1.0</span>) )</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&amp;lt;ipython-input-24-5f0ef7954aeb&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
+&lt;ipython-input-24-5f0ef7954aeb&gt; in &lt;module&gt;()
+----&gt; 1 print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
 
-&amp;lt;ipython-input-20-408dc39f3915&amp;gt; in normalize_rectangle(rect)
+&lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
      16 
-     17     assert 0 &amp;lt; upper_x &amp;lt;= 1.0, &#39;Calculated upper X coordinate invalid&#39;
----&amp;gt; 18     assert 0 &amp;lt; upper_y &amp;lt;= 1.0, &#39;Calculated upper Y coordinate invalid&#39;
+     17     assert 0 &lt; upper_x &lt;= 1.0, &#39;Calculated upper X coordinate invalid&#39;
+---&gt; 18     assert 0 &lt; upper_y &lt;= 1.0, &#39;Calculated upper Y coordinate invalid&#39;
      19 
      20     return (0, 0, upper_x, upper_y)
 
@@ -168,9 +168,9 @@ AssertionError: Calculated upper Y coordinate invalid</code></pre>
 <span class="kw">assert</span> range_overlap([ (<span class="fl">0.0</span>, <span class="fl">1.0</span>), (<span class="fl">0.0</span>, <span class="fl">2.0</span>), (-<span class="fl">1.0</span>, <span class="fl">1.0</span>) ]) == (<span class="fl">0.0</span>, <span class="fl">1.0</span>)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&amp;lt;ipython-input-25-d8be150fbef6&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-25-d8be150fbef6&gt; in &lt;module&gt;()
       1 assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
-----&amp;gt; 2 assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
+----&gt; 2 assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
       3 assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)
 
 AssertionError: </code></pre>
@@ -192,8 +192,8 @@ AssertionError: </code></pre>
 <span class="kw">assert</span> range_overlap([ (<span class="fl">0.0</span>, <span class="fl">1.0</span>), (<span class="fl">1.0</span>, <span class="fl">2.0</span>) ]) == <span class="ot">None</span></code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&amp;lt;ipython-input-26-d877ef460ba2&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
+&lt;ipython-input-26-d877ef460ba2&gt; in &lt;module&gt;()
+----&gt; 1 assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
       2 assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
 
 AssertionError: </code></pre>
@@ -217,12 +217,12 @@ AssertionError: </code></pre>
 <pre class="sourceCode python"><code class="sourceCode python">test_range_overlap()</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&amp;lt;ipython-input-29-cf9215c96457&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 test_range_overlap()
+&lt;ipython-input-29-cf9215c96457&gt; in &lt;module&gt;()
+----&gt; 1 test_range_overlap()
 
-&amp;lt;ipython-input-28-5d4cd6fd41d9&amp;gt; in test_range_overlap()
+&lt;ipython-input-28-5d4cd6fd41d9&gt; in test_range_overlap()
       1 def test_range_overlap():
-----&amp;gt; 2     assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
+----&gt; 2     assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
       3     assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
       4     assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
       5     assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)

--- a/05-defensive.html
+++ b/05-defensive.html
@@ -28,7 +28,7 @@
           <h1 class="title">Programming with Python</h1>
           <h2 class="subtitle">Defensive Programming</h2>
 <div id="learning-objectives" class="objectives objectives">
-<h2>Learning Objectives</h2>
+<h2 id="learning-objectives" class="objectives objectives">Learning Objectives</h2>
 <ul>
 <li>Explain what an assertion is.</li>
 <li>Add assertions to programs that correctly check the program's state.</li>
@@ -56,7 +56,7 @@ total = <span class="fl">0.0</span>
 <span class="dt">print</span> <span class="st">&#39;total is:&#39;</span>, total</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-19-33d87ea29ae4&gt; in &lt;module&amp;gt;()
+&lt;ipython-input-19-33d87ea29ae4&gt; in &lt;module&gt;()
       2 total = 0.0
       3 for n in numbers:
 ----&gt; 4     assert n &gt;= 0.0, &#39;Data should only contain positive values&#39;

--- a/05-defensive.md
+++ b/05-defensive.md
@@ -61,17 +61,17 @@ this piece of code halts as soon as the loop encounters a value that isn't posit
 numbers = [1.5, 2.3, 0.7, -0.001, 4.4]
 total = 0.0
 for n in numbers:
-    assert n &gt;= 0.0, 'Data should only contain positive values'
+    assert n >= 0.0, 'Data should only contain positive values'
     total += n
 print 'total is:', total
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-19-33d87ea29ae4&gt; in &lt;module&gt;()
+<ipython-input-19-33d87ea29ae4> in <module&gt;()
       2 total = 0.0
       3 for n in numbers:
-----&gt; 4     assert n &gt;= 0.0, 'Data should only contain positive values'
+----> 4     assert n >= 0.0, 'Data should only contain positive values'
       5     total += n
       6 print 'total is:', total
 
@@ -103,20 +103,20 @@ def normalize_rectangle(rect):
     '''Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.'''
     assert len(rect) == 4, 'Rectangles must contain 4 coordinates'
     x0, y0, x1, y1 = rect
-    assert x0 &lt; x1, 'Invalid X coordinates'
-    assert y0 &lt; y1, 'Invalid Y coordinates'
+    assert x0 < x1, 'Invalid X coordinates'
+    assert y0 < y1, 'Invalid Y coordinates'
     
     dx = x1 - x0
     dy = y1 - y0
-    if dx &gt; dy:
+    if dx > dy:
         scaled = float(dx) / dy
         upper_x, upper_y = 1.0, scaled
     else:
         scaled = float(dx) / dy
         upper_x, upper_y = scaled, 1.0
 
-    assert 0 &lt; upper_x &lt;= 1.0, 'Calculated upper X coordinate invalid'
-    assert 0 &lt; upper_y &lt;= 1.0, 'Calculated upper Y coordinate invalid'
+    assert 0 < upper_x <= 1.0, 'Calculated upper X coordinate invalid'
+    assert 0 < upper_y <= 1.0, 'Calculated upper Y coordinate invalid'
 
     return (0, 0, upper_x, upper_y)
 ~~~
@@ -129,15 +129,15 @@ print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-21-3a97b1dcab70&gt; in &lt;module&gt;()
-----&gt; 1 print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
+<ipython-input-21-3a97b1dcab70> in <module>()
+----> 1 print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
 
-&lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
+<ipython-input-20-408dc39f3915> in normalize_rectangle(rect)
       1 def normalize_rectangle(rect):
       2     '''Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.'''
-----&gt; 3     assert len(rect) == 4, 'Rectangles must contain 4 coordinates'
+----> 3     assert len(rect) == 4, 'Rectangles must contain 4 coordinates'
       4     x0, y0, x1, y1 = rect
-      5     assert x0 &lt; x1, 'Invalid X coordinates'
+      5     assert x0 < x1, 'Invalid X coordinates'
 
 AssertionError: Rectangles must contain 4 coordinates
 ~~~
@@ -148,14 +148,14 @@ print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-22-f05ae7878a45&gt; in &lt;module&gt;()
-----&gt; 1 print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
+<ipython-input-22-f05ae7878a45> in <module>()
+----> 1 print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
 
-&lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
+<ipython-input-20-408dc39f3915> in normalize_rectangle(rect)
       3     assert len(rect) == 4, 'Rectangles must contain 4 coordinates'
       4     x0, y0, x1, y1 = rect
-----&gt; 5     assert x0 &lt; x1, 'Invalid X coordinates'
-      6     assert y0 &lt; y1, 'Invalid Y coordinates'
+----> 5     assert x0 < x1, 'Invalid X coordinates'
+      6     assert y0 < y1, 'Invalid Y coordinates'
       7 
 
 AssertionError: Invalid X coordinates
@@ -181,13 +181,13 @@ print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-24-5f0ef7954aeb&gt; in &lt;module&gt;()
-----&gt; 1 print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
+<ipython-input-24-5f0ef7954aeb> in <module>()
+----> 1 print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
 
-&lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
+<ipython-input-20-408dc39f3915> in normalize_rectangle(rect)
      16 
-     17     assert 0 &lt; upper_x &lt;= 1.0, 'Calculated upper X coordinate invalid'
----&gt; 18     assert 0 &lt; upper_y &lt;= 1.0, 'Calculated upper Y coordinate invalid'
+     17     assert 0 < upper_x <= 1.0, 'Calculated upper X coordinate invalid'
+---> 18     assert 0 < upper_y <= 1.0, 'Calculated upper Y coordinate invalid'
      19 
      20     return (0, 0, upper_x, upper_y)
 
@@ -275,9 +275,9 @@ assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-25-d8be150fbef6&gt; in &lt;module&gt;()
+<ipython-input-25-d8be150fbef6> in <module>()
       1 assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
-----&gt; 2 assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
+----> 2 assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
       3 assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)
 
 AssertionError: 
@@ -344,8 +344,8 @@ assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-26-d877ef460ba2&gt; in &lt;module&gt;()
-----&gt; 1 assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
+<ipython-input-26-d877ef460ba2> in <module>()
+----> 1 assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
       2 assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
 
 AssertionError: 
@@ -390,12 +390,12 @@ test_range_overlap()
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-&lt;ipython-input-29-cf9215c96457&gt; in &lt;module&gt;()
-----&gt; 1 test_range_overlap()
+<ipython-input-29-cf9215c96457> in <module>()
+----> 1 test_range_overlap()
 
-&lt;ipython-input-28-5d4cd6fd41d9&gt; in test_range_overlap()
+<ipython-input-28-5d4cd6fd41d9> in test_range_overlap()
       1 def test_range_overlap():
-----&gt; 2     assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
+----> 2     assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
       3     assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
       4     assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
       5     assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)

--- a/05-defensive.md
+++ b/05-defensive.md
@@ -68,7 +68,7 @@ print 'total is:', total
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-<ipython-input-19-33d87ea29ae4> in <module&gt;()
+<ipython-input-19-33d87ea29ae4> in <module>()
       2 total = 0.0
       3 for n in numbers:
 ----> 4     assert n >= 0.0, 'Data should only contain positive values'

--- a/06-cmdline.html
+++ b/06-cmdline.html
@@ -276,7 +276,7 @@ count = <span class="dv">0</span>
 
 <span class="dt">print</span> count, <span class="st">&#39;lines in standard input&#39;</span></code></pre>
 <p>This little program reads lines from a special &quot;file&quot; called <code>sys.stdin</code>, which is automatically connected to the program's standard input. We don't have to open it --- Python and the operating system take care of that when the program starts up --- but we can do almost anything with it that we could do to a regular file. Let's try running it as if it were a regular command-line program:</p>
-<pre class="input"><code>$ python count-stdin.py &amp;lt; small-01.csv</code></pre>
+<pre class="input"><code>$ python count-stdin.py &lt; small-01.csv</code></pre>
 <pre class="output"><code>2 lines in standard input</code></pre>
 <p>A common mistake is to try to run something that reads from standard input like this:</p>
 <pre class="input"><code>$ count_stdin.py small-01.csv</code></pre>

--- a/06-cmdline.md
+++ b/06-cmdline.md
@@ -463,7 +463,7 @@ but we can do almost anything with it that we could do to a regular file.
 Let's try running it as if it were a regular command-line program:
 
 ~~~ {.input}
-$ python count-stdin.py &lt; small-01.csv
+$ python count-stdin.py < small-01.csv
 ~~~
 ~~~ {.output}
 2 lines in standard input

--- a/07-errors.html
+++ b/07-errors.html
@@ -51,14 +51,14 @@
 favorite_ice_cream()</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
-&amp;lt;ipython-input-1-9d0462a5b07c&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-1-9d0462a5b07c&gt; in &lt;module&gt;()
       1 from errors_01 import favorite_ice_cream
-----&amp;gt; 2 favorite_ice_cream()
+----&gt; 2 favorite_ice_cream()
 
 /Users/jhamrick/project/swc/novice/python/errors_01.pyc in favorite_ice_cream()
       5         &quot;strawberry&quot;
       6     ]
-----&amp;gt; 7     print ice_creams[3]
+----&gt; 7     print ice_creams[3]
 
 IndexError: list index out of range</code></pre>
 <p>This particular traceback has two levels. You can determine the number of levels by looking for the number of arrows on the left hand side. In this case:</p>
@@ -84,7 +84,7 @@ IndexError: list index out of range</code></pre>
     msg = <span class="st">&quot;hello, world!&quot;</span>
     <span class="dt">print</span> msg
      <span class="kw">return</span> msg</code></pre>
-<pre class="error"><code>  File &quot;&amp;lt;ipython-input-3-6bb841ea1423&amp;gt;&quot;, line 1
+<pre class="error"><code>  File &quot;&lt;ipython-input-3-6bb841ea1423&gt;&quot;, line 1
     def some_function()
                        ^
 SyntaxError: invalid syntax</code></pre>
@@ -94,7 +94,7 @@ SyntaxError: invalid syntax</code></pre>
     msg = <span class="st">&quot;hello, world!&quot;</span>
     <span class="dt">print</span> msg
      <span class="kw">return</span> msg</code></pre>
-<pre class="error"><code>  File &quot;&amp;lt;ipython-input-4-ae290e7659cb&amp;gt;&quot;, line 4
+<pre class="error"><code>  File &quot;&lt;ipython-input-4-ae290e7659cb&gt;&quot;, line 4
     return msg
     ^
 IndentationError: unexpected indent</code></pre>
@@ -106,7 +106,7 @@ IndentationError: unexpected indent</code></pre>
     msg = <span class="st">&quot;hello, world!&quot;</span>
     <span class="dt">print</span> msg
     <span class="kw">return</span> msg</code></pre>
-<pre class="error"><code>  File &quot;&amp;lt;ipython-input-5-653b36fbcd41&amp;gt;&quot;, line 4
+<pre class="error"><code>  File &quot;&lt;ipython-input-5-653b36fbcd41&gt;&quot;, line 4
     return msg
               ^
 IndentationError: unindent does not match any outer indentation level</code></pre>
@@ -117,8 +117,8 @@ IndentationError: unindent does not match any outer indentation level</code></pr
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> a</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&amp;lt;ipython-input-7-9d7b17ad5387&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 print a
+&lt;ipython-input-7-9d7b17ad5387&gt; in &lt;module&gt;()
+----&gt; 1 print a
 
 NameError: name &#39;a&#39; is not defined</code></pre>
 <p>Variable name errors come with some of the most informative error messages, which are usually of the form &quot;name 'the_variable_name' is not defined&quot;.</p>
@@ -126,8 +126,8 @@ NameError: name &#39;a&#39; is not defined</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> hello</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&amp;lt;ipython-input-8-9553ee03b645&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 print hello
+&lt;ipython-input-8-9553ee03b645&gt; in &lt;module&gt;()
+----&gt; 1 print hello
 
 NameError: name &#39;hello&#39; is not defined</code></pre>
 <p>The second is that you just forgot to create the variable before using it. In the following example, <code>count</code> should have been defined (e.g., with <code>count = 0</code>) before the for loop:</p>
@@ -136,9 +136,9 @@ NameError: name &#39;hello&#39; is not defined</code></pre>
 <span class="dt">print</span> <span class="st">&quot;The count is: &quot;</span> + <span class="dt">str</span>(count)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&amp;lt;ipython-input-9-dd6a12d7ca5c&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-9-dd6a12d7ca5c&gt; in &lt;module&gt;()
       1 for number in range(10):
-----&amp;gt; 2     count = count + number
+----&gt; 2     count = count + number
       3 print &quot;The count is: &quot; + str(count)
 
 NameError: name &#39;count&#39; is not defined</code></pre>
@@ -149,10 +149,10 @@ NameError: name &#39;count&#39; is not defined</code></pre>
 <span class="dt">print</span> <span class="st">&quot;The count is: &quot;</span> + <span class="dt">str</span>(count)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&amp;lt;ipython-input-10-d77d40059aea&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-10-d77d40059aea&gt; in &lt;module&gt;()
       1 Count = 0
       2 for number in range(10):
-----&amp;gt; 3     count = count + number
+----&gt; 3     count = count + number
       4 print &quot;The count is: &quot; + str(count)
 
 NameError: name &#39;count&#39; is not defined</code></pre>
@@ -168,10 +168,10 @@ Letter #2 is b
 Letter #3 is c</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
-&amp;lt;ipython-input-11-d817f55b7d6c&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-11-d817f55b7d6c&gt; in &lt;module&gt;()
       3 print &quot;Letter #2 is &quot; + letters[1]
       4 print &quot;Letter #3 is &quot; + letters[2]
-----&amp;gt; 5 print &quot;Letter #4 is &quot; + letters[3]
+----&gt; 5 print &quot;Letter #4 is &quot; + letters[3]
 
 IndexError: list index out of range</code></pre>
 <p>Here, Python is telling us that there is an <code>IndexError</code> in our code, meaning we tried to access a list index that did not exist. We get a similar error in the case of dictionaries:</p>
@@ -185,10 +185,10 @@ IndexError: list index out of range</code></pre>
 <span class="dt">print</span> <span class="st">&quot;The capital of Oregon is: &quot;</span> + us_state_capitals[<span class="st">&#39;oregon&#39;</span>]</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 KeyError                                  Traceback (most recent call last)
-&amp;lt;ipython-input-12-27fa113dd73c&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-12-27fa113dd73c&gt; in &lt;module&gt;()
       6 }
       7 
-----&amp;gt; 8 print &quot;The capital of Oregon is: &quot; + us_state_capitals[&#39;oregon&#39;]
+----&gt; 8 print &quot;The capital of Oregon is: &quot; + us_state_capitals[&#39;oregon&#39;]
 
 KeyError: &#39;oregon&#39;</code></pre>
 <p>In this case, we get a <code>KeyError</code>, which means that the key we requested (<code>'oregon'</code>, as the error message tells us) is not present in the dictionary. This might be because it genuinely does not exist in the dictionary, but it could <em>also</em> be due to a typo. This is similar to the case we discussed above, where you can sometimes receive a <code>NameError</code> due to a typo. For example:</p>
@@ -202,10 +202,10 @@ KeyError: &#39;oregon&#39;</code></pre>
 <span class="dt">print</span> <span class="st">&quot;The capital of Massachusetts is: &quot;</span> + us_state_capitals[<span class="st">&#39;massachussetts&#39;</span>]</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 KeyError                                  Traceback (most recent call last)
-&amp;lt;ipython-input-13-ae1dac4c6a45&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-13-ae1dac4c6a45&gt; in &lt;module&gt;()
       6 }
       7 
-----&amp;gt; 8 print &quot;The capital of Massachusetts is: &quot; + us_state_capitals[&#39;massachussetts&#39;]
+----&gt; 8 print &quot;The capital of Massachusetts is: &quot; + us_state_capitals[&#39;massachussetts&#39;]
 
 KeyError: &#39;massachussetts&#39;</code></pre>
 <h2 id="file-errors">File Errors</h2>
@@ -213,8 +213,8 @@ KeyError: &#39;massachussetts&#39;</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python">file_handle = <span class="dt">open</span>(<span class="st">&#39;myfile.txt&#39;</span>, <span class="st">&#39;r&#39;</span>)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 IOError                                   Traceback (most recent call last)
-&amp;lt;ipython-input-14-f6e1ac4aee96&amp;gt; in &amp;lt;module&amp;gt;()
-----&amp;gt; 1 file_handle = open(&#39;myfile.txt&#39;, &#39;r&#39;)
+&lt;ipython-input-14-f6e1ac4aee96&gt; in &lt;module&gt;()
+----&gt; 1 file_handle = open(&#39;myfile.txt&#39;, &#39;r&#39;)
 
 IOError: [Errno 2] No such file or directory: &#39;myfile.txt&#39;</code></pre>
 <p>One reason for receiving this error is that you specified an incorrect path to the file. For example, if I am currently in a folder called <code>myproject</code>, and I have a file in <code>myproject/writing/myfile.txt</code>, but I try to just open <code>myfile.txt</code>, this will fail. The correct path would be <code>writing/myfile. xt</code>. It is also possible (like with <code>NameError</code> and <code>KeyError</code>) that you just made a typo.</p>
@@ -223,9 +223,9 @@ IOError: [Errno 2] No such file or directory: &#39;myfile.txt&#39;</code></pre>
 file_handle.read()</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 IOError                                   Traceback (most recent call last)
-&amp;lt;ipython-input-15-b846479bc61f&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-15-b846479bc61f&gt; in &lt;module&gt;()
       1 file_handle = open(&#39;myfile.txt&#39;, &#39;w&#39;)
-----&amp;gt; 2 file_handle.read()
+----&gt; 2 file_handle.read()
 
 IOError: File not open for reading</code></pre>
 <div id="reading-error-messages" class="challenge">
@@ -243,19 +243,19 @@ IOError: File not open for reading</code></pre>
 print_friday_message()</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 KeyError                                  Traceback (most recent call last)
-&amp;lt;ipython-input-2-e4c4cbafeeb5&amp;gt; in &amp;lt;module&amp;gt;()
+&lt;ipython-input-2-e4c4cbafeeb5&gt; in &lt;module&gt;()
       1 from errors_02 import print_friday_message
-----&amp;gt; 2 print_friday_message()
+----&gt; 2 print_friday_message()
 
 /Users/jhamrick/project/swc/novice/python/errors_02.py in print_friday_message()
      13 
      14 def print_friday_message():
----&amp;gt; 15     print_message(&quot;Friday&quot;)
+---&gt; 15     print_message(&quot;Friday&quot;)
 
 /Users/jhamrick/project/swc/novice/python/errors_02.py in print_message(day)
       9         &quot;sunday&quot;: &quot;Aw, the weekend is almost over.&quot;
      10     }
----&amp;gt; 11     print messages[day]
+---&gt; 11     print messages[day]
      12 
      13 
 

--- a/07-errors.md
+++ b/07-errors.md
@@ -38,14 +38,14 @@ favorite_ice_cream()
 ~~~ {.error}
 ---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
-&lt;ipython-input-1-9d0462a5b07c&gt; in &lt;module&gt;()
+<ipython-input-1-9d0462a5b07c> in <module>()
       1 from errors_01 import favorite_ice_cream
-----&gt; 2 favorite_ice_cream()
+----> 2 favorite_ice_cream()
 
 /Users/jhamrick/project/swc/novice/python/errors_01.pyc in favorite_ice_cream()
       5         "strawberry"
       6     ]
-----&gt; 7     print ice_creams[3]
+----> 7     print ice_creams[3]
 
 IndexError: list index out of range
 ~~~
@@ -125,7 +125,7 @@ def some_function()
      return msg
 ~~~
 ~~~ {.error}
-  File "&lt;ipython-input-3-6bb841ea1423&gt;", line 1
+  File "<ipython-input-3-6bb841ea1423>", line 1
     def some_function()
                        ^
 SyntaxError: invalid syntax
@@ -147,7 +147,7 @@ def some_function():
      return msg
 ~~~
 ~~~ {.error}
-  File "&lt;ipython-input-4-ae290e7659cb&gt;", line 4
+  File "<ipython-input-4-ae290e7659cb>", line 4
     return msg
     ^
 IndentationError: unexpected indent
@@ -177,7 +177,7 @@ it *always* means that there is a problem with how your code is indented.
 >     return msg
 > ~~~
 > ~~~ {.error}
->   File "&lt;ipython-input-5-653b36fbcd41&gt;", line 4
+>   File "<ipython-input-5-653b36fbcd41>", line 4
 >     return msg
 >               ^
 > IndentationError: unindent does not match any outer indentation level
@@ -200,8 +200,8 @@ print a
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&lt;ipython-input-7-9d7b17ad5387&gt; in &lt;module&gt;()
-----&gt; 1 print a
+<ipython-input-7-9d7b17ad5387> in <module>()
+----> 1 print a
 
 NameError: name 'a' is not defined
 ~~~
@@ -222,8 +222,8 @@ print hello
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&lt;ipython-input-8-9553ee03b645&gt; in &lt;module&gt;()
-----&gt; 1 print hello
+<ipython-input-8-9553ee03b645> in <module>()
+----> 1 print hello
 
 NameError: name 'hello' is not defined
 ~~~
@@ -240,9 +240,9 @@ print "The count is: " + str(count)
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&lt;ipython-input-9-dd6a12d7ca5c&gt; in &lt;module&gt;()
+<ipython-input-9-dd6a12d7ca5c> in <module>()
       1 for number in range(10):
-----&gt; 2     count = count + number
+----> 2     count = count + number
       3 print "The count is: " + str(count)
 
 NameError: name 'count' is not defined
@@ -263,10 +263,10 @@ print "The count is: " + str(count)
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
-&lt;ipython-input-10-d77d40059aea&gt; in &lt;module&gt;()
+<ipython-input-10-d77d40059aea> in <module>()
       1 Count = 0
       2 for number in range(10):
-----&gt; 3     count = count + number
+----> 3     count = count + number
       4 print "The count is: " + str(count)
 
 NameError: name 'count' is not defined
@@ -298,10 +298,10 @@ Letter #3 is c
 ~~~ {.error}
 ---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
-&lt;ipython-input-11-d817f55b7d6c&gt; in &lt;module&gt;()
+<ipython-input-11-d817f55b7d6c> in <module>()
       3 print "Letter #2 is " + letters[1]
       4 print "Letter #3 is " + letters[2]
-----&gt; 5 print "Letter #4 is " + letters[3]
+----> 5 print "Letter #4 is " + letters[3]
 
 IndexError: list index out of range
 ~~~
@@ -323,10 +323,10 @@ print "The capital of Oregon is: " + us_state_capitals['oregon']
 ~~~ {.error}
 ---------------------------------------------------------------------------
 KeyError                                  Traceback (most recent call last)
-&lt;ipython-input-12-27fa113dd73c&gt; in &lt;module&gt;()
+<ipython-input-12-27fa113dd73c> in <module>()
       6 }
       7 
-----&gt; 8 print "The capital of Oregon is: " + us_state_capitals['oregon']
+----> 8 print "The capital of Oregon is: " + us_state_capitals['oregon']
 
 KeyError: 'oregon'
 ~~~
@@ -352,10 +352,10 @@ print "The capital of Massachusetts is: " + us_state_capitals['massachussetts']
 ~~~ {.error}
 ---------------------------------------------------------------------------
 KeyError                                  Traceback (most recent call last)
-&lt;ipython-input-13-ae1dac4c6a45&gt; in &lt;module&gt;()
+<ipython-input-13-ae1dac4c6a45> in <module>()
       6 }
       7 
-----&gt; 8 print "The capital of Massachusetts is: " + us_state_capitals['massachussetts']
+----> 8 print "The capital of Massachusetts is: " + us_state_capitals['massachussetts']
 
 KeyError: 'massachussetts'
 ~~~
@@ -377,8 +377,8 @@ file_handle = open('myfile.txt', 'r')
 ~~~ {.error}
 ---------------------------------------------------------------------------
 IOError                                   Traceback (most recent call last)
-&lt;ipython-input-14-f6e1ac4aee96&gt; in &lt;module&gt;()
-----&gt; 1 file_handle = open('myfile.txt', 'r')
+<ipython-input-14-f6e1ac4aee96> in <module>()
+----> 1 file_handle = open('myfile.txt', 'r')
 
 IOError: [Errno 2] No such file or directory: 'myfile.txt'
 ~~~
@@ -407,9 +407,9 @@ file_handle.read()
 ~~~ {.error}
 ---------------------------------------------------------------------------
 IOError                                   Traceback (most recent call last)
-&lt;ipython-input-15-b846479bc61f&gt; in &lt;module&gt;()
+<ipython-input-15-b846479bc61f> in <module>()
       1 file_handle = open('myfile.txt', 'w')
-----&gt; 2 file_handle.read()
+----> 2 file_handle.read()
 
 IOError: File not open for reading
 ~~~
@@ -432,19 +432,19 @@ IOError: File not open for reading
 > ~~~ {.error}
 > ---------------------------------------------------------------------------
 > KeyError                                  Traceback (most recent call last)
-> &lt;ipython-input-2-e4c4cbafeeb5&gt; in &lt;module&gt;()
+> <ipython-input-2-e4c4cbafeeb5> in <module>()
 >       1 from errors_02 import print_friday_message
-> ----&gt; 2 print_friday_message()
+> ----> 2 print_friday_message()
 > 
 > /Users/jhamrick/project/swc/novice/python/errors_02.py in print_friday_message()
 >      13 
 >      14 def print_friday_message():
-> ---&gt; 15     print_message("Friday")
+> ---> 15     print_message("Friday")
 > 
 > /Users/jhamrick/project/swc/novice/python/errors_02.py in print_message(day)
 >       9         "sunday": "Aw, the weekend is almost over."
 >      10     }
-> ---&gt; 11     print messages[day]
+> ---> 11     print messages[day]
 >      12 
 >      13 
 > 


### PR DESCRIPTION
This change seems sensible for both reading the input markdown, and the rendering as HTML.

Assuming there is not something in the template which deals with this (and my change is not needed), then I would guess this fix will be needed on all the other recently migrated lessons (and the migration script may need tweaking).

Update: Looking at a few of the other lessons with R and Python (by eye), I did not find any more unescaped inequalities.