### PR TITLE
fix format for an example

### DIFF
--- a/06-cmdline.md
+++ b/06-cmdline.md
@@ -321,7 +321,7 @@ main()
 
 and here it is in action:
 
-~~~ {.input{
+~~~ {.input}
 $ python readings-03.py small-01.csv small-02.csv
 ~~~
 ~~~ {.output}


### PR DESCRIPTION
The formatting for an example has a syntax error which generates incorrect output.