### PR TITLE
Corrected the assertion example

### DIFF
--- a/05-defensive.md
+++ b/05-defensive.md
@@ -61,7 +61,7 @@ this piece of code halts as soon as the loop encounters a value that isn't posit
 numbers = [1.5, 2.3, 0.7, -0.001, 4.4]
 total = 0.0
 for n in numbers:
-    assert n >= 0.0, 'Data should only contain positive values'
+    assert n > 0.0, 'Data should only contain positive values'
     total += n
 print 'total is:', total
 ~~~

--- a/05-defensive.md
+++ b/05-defensive.md
@@ -71,7 +71,7 @@ AssertionError                            Traceback (most recent call last)
 <ipython-input-19-33d87ea29ae4> in <module>()
       2 total = 0.0
       3 for n in numbers:
-----> 4     assert n >= 0.0, 'Data should only contain positive values'
+----> 4     assert n > 0.0, 'Data should only contain positive values'
       5     total += n
       6 print 'total is:', total
 


### PR DESCRIPTION
Maybe a bit pedantic but the assertion condition  (n>=0) and the error message (Data should only contain positive values) do not match. 
It has to be either 
1. "n>=0" and "Data should only contain non-negative values" or 
2. "n>0" and "Data should only contain positive values". 

I think the latter is better, and requesting a change. Thanks