### PR TITLE
Drop 'import ... as ...' syntax

### DIFF
--- a/01-numpy.md
+++ b/01-numpy.md
@@ -599,17 +599,16 @@ Neither result seems particularly likely,
 so either there's a mistake in our calculations
 or something is wrong with our data.
 
-It's very common to create an [alias](reference.html#alias) for a library when importing it
-in order to reduce the amount of typing we have to do.
-Here are our three plots side by side using aliases for `numpy` and `pyplot`:
+You can groups similar plots in a single figure using subplots.
+Here are our three plots side by side:
 
 ~~~ {.python}
-import numpy as np
-from matplotlib import pyplot as plt
+import numpy
+import matplotlib.pyplot
 
-data = np.loadtxt(fname='inflammation-01.csv', delimiter=',')
+data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 
-fig = plt.figure(figsize=(10.0, 3.0))
+fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))
 
 axes1 = fig.add_subplot(1, 3, 1)
 axes2 = fig.add_subplot(1, 3, 2)
@@ -626,7 +625,7 @@ axes3.plot(data.min(axis=0))
 
 fig.tight_layout()
 
-plt.show(fig)
+matplotlib.pyplot.show(fig)
 ~~~
 
 ![The Previous Plots as Subplots](fig/01-numpy_80_0.png)

--- a/08-cmdline.md
+++ b/08-cmdline.md
@@ -135,12 +135,12 @@ though we can call it whatever we want:
 
 ~~~ {.python}
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
-    data = np.loadtxt(filename, delimiter=',')
+    data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
         print m
 ~~~
@@ -160,12 +160,12 @@ Let's add a call to `main`:
 
 ~~~ {.python}
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
-    data = np.loadtxt(filename, delimiter=',')
+    data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
         print m
 
@@ -307,12 +307,12 @@ Here's our changed program
 
 ~~~ {.python}
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
     for filename in sys.argv[1:]:
-        data = np.loadtxt(filename, delimiter=',')
+        data = numpy.loadtxt(filename, delimiter=',')
         for m in data.mean(axis=1):
             print m
 
@@ -352,7 +352,7 @@ so we could just do this:
 
 ~~~ {.python}
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
@@ -360,7 +360,7 @@ def main():
     filenames = sys.argv[2:]
 
     for f in filenames:
-        data = np.loadtxt(f, delimiter=',')
+        data = numpy.loadtxt(f, delimiter=',')
 
         if action == '--min':
             values = data.min(axis=1)
@@ -402,7 +402,7 @@ so that the program fails fast:
 
 ~~~ {.python}
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
@@ -414,7 +414,7 @@ def main():
         process(f, action)
 
 def process(filename, action):
-    data = np.loadtxt(filename, delimiter=',')
+    data = numpy.loadtxt(filename, delimiter=',')
 
     if action == '--min':
         values = data.min(axis=1)

--- a/code/readings-01.py
+++ b/code/readings-01.py
@@ -1,9 +1,9 @@
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
-    data = np.loadtxt(filename, delimiter=',')
+    data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
         print m

--- a/code/readings-02.py
+++ b/code/readings-02.py
@@ -1,10 +1,10 @@
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
-    data = np.loadtxt(filename, delimiter=',')
+    data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
         print m
 

--- a/code/readings-03.py
+++ b/code/readings-03.py
@@ -1,10 +1,10 @@
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
     for filename in sys.argv[1:]:
-        data = np.loadtxt(filename, delimiter=',')
+        data = numpy.loadtxt(filename, delimiter=',')
         for m in data.mean(axis=1):
             print m
 

--- a/code/readings-04.py
+++ b/code/readings-04.py
@@ -1,5 +1,5 @@
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
@@ -7,7 +7,7 @@ def main():
     filenames = sys.argv[2:]
 
     for f in filenames:
-        data = np.loadtxt(f, delimiter=',')
+        data = numpy.loadtxt(f, delimiter=',')
 
         if action == '--min':
             values = data.min(axis=1)

--- a/code/readings-05.py
+++ b/code/readings-05.py
@@ -1,5 +1,5 @@
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
@@ -11,7 +11,7 @@ def main():
         process(f, action)
 
 def process(filename, action):
-    data = np.loadtxt(filename, delimiter=',')
+    data = numpy.loadtxt(filename, delimiter=',')
 
     if action == '--min':
         values = data.min(axis=1)

--- a/code/readings-06.py
+++ b/code/readings-06.py
@@ -1,5 +1,5 @@
 import sys
-import numpy as np
+import numpy
 
 def main():
     script = sys.argv[0]
@@ -14,7 +14,7 @@ def main():
             process(f, action)
 
 def process(filename, action):
-    data = np.loadtxt(filename, delimiter=',')
+    data = numpy.loadtxt(filename, delimiter=',')
 
     if action == '--min':
         values = data.min(axis=1)

--- a/reference.md
+++ b/reference.md
@@ -103,9 +103,6 @@ additive color model
 :   A way to represent colors as the sum of contributions from primary colors
     such as [red, green, and blue](#rgb).
 
-alias
-:   (a library): To give a [library](#library) a nickname while importing it.
-
 argument
 :   A value given to a function or program when it runs. 
     The term is often used interchangeably (and inconsistently) with [parameter](#parameter).


### PR DESCRIPTION
It's not worth introducing extra syntax just because folks might see
this in the wild.  As Greg said in 181e4635 (Starting to write
instructor's guide, 2015-02-15):

> In order to teach that, we must teach people a little about the
> mechanics of manipulating data with lists and file I/O so that their
> functions can do things they actually care about.  Our teaching
> order tries to show practical uses of every idea as soon as it is
> introduced; instructors should resist the temptation to explain the
> "other 90%" of the language as well.