### PR TITLE
Removal for function (too early in lesson program)

### DIFF
--- a/05-cond.md
+++ b/05-cond.md
@@ -65,18 +65,17 @@ which is short for "else if".
 This makes it simple to write a function that returns the sign of a number:
 
 ~~~ {.python}
-def sign(num):
-    if num > 0:
-        return 1
-    elif num == 0:
-        return 0
-    else:
-        return -1
+num = -3
 
-print 'sign of -3:', sign(-3)
+if num > 0:
+    print num,"is +ve"
+elif num == 0:
+    print num,"is 0"
+else:
+    print num,"is -ve"
 ~~~
 ~~~ {.output}
-sign of -3: -1
+"-3 is -ve"
 ~~~
 
 One important thing to notice in the code above is that we use a double equals sign `==` to test for equality


### PR DESCRIPTION
In this lesson there is an example that uses a function "def sign(num)" to illustrate some decision making capability. I don't know if this material has been reordered recently, but given that function definitions do not appear until the next lesson, I would argue that this be removed and just shown as a simple block of code that prints whether a number is -ve or +ve. I have suggested a potential replacement.