### PR TITLE
mention: from __future__ import division

### DIFF
--- a/06-func.md
+++ b/06-func.md
@@ -169,6 +169,16 @@ a/b is: 3
 float(a)/b is: 3.33333333333
 ~~~
 
+It is also possible to make Python use integer division that produces a floating point answer, by importing a feature that was added in later versions.  
+
+~~~ {.python}
+from __future__ import division
+print '10/3 is:', 10/3
+~~~
+~~~ {.output}
+10/3 is: 3.33333333333
+~~~
+
 Let's fix our `fahr_to_kelvin` function with this new knowledge:
 
 ~~~ {.python}


### PR DESCRIPTION
This is another way to fix a bug caused by expecting a floating point answer from integer division.  This could be helpful to users who are really uncomfortable with the way Python 2 does integer division.