### PR TITLE
adding problems with modifying lists in place

### DIFF
--- a/03-lists.md
+++ b/03-lists.md
@@ -119,8 +119,9 @@ primes [1, 3, 5, 7, 2]
 odds [1, 3, 5, 7, 2]
 ~~~
 
-This is because python stores a list in memory, and then can use multiple pointers to the same list.
-We should almost always explicitly use a list() command, so we do not modify a list we did not mean to:
+This is because python stores a list in memory, and then can use multiple names to refer to the same list.
+If all we want to do is copy a (simple) list, we can use the list() command, so we do not modify a list we did not mean to:
+
 ~~~ {.python}
 odds = [1, 3, 5, 7]
 primes = list(odds)
@@ -133,4 +134,4 @@ primes [1, 3, 5, 7, 2]
 odds [1, 3, 5, 7]
 ~~~
 
-This is different from how variables worked in lesson 1, and more similar to a spreadsheet.
+This is different from how variables worked in lesson 1, and more similar to how a spreadsheet works.

--- a/03-lists.md
+++ b/03-lists.md
@@ -102,3 +102,35 @@ print 'odds after reversing:', odds
 ~~~ {.output}
 [11, 7, 5, 3]
 ~~~
+
+While modifying in place, it is useful to remember that python treats lists in a slightly counterintuitive way.
+
+If we make a list and (attempt to) copy it then modify in place, we can cause all sorts of trouble:
+
+~~~ {.python}
+odds = [1, 3, 5, 7]
+primes = odds
+primes += [2]
+print 'primes:', primes
+print 'odds:', odds
+~~~
+~~~ {.output}
+primes [1, 3, 5, 7, 2]
+odds [1, 3, 5, 7, 2]
+~~~
+
+This is because python stores a list in memory, and then can use multiple pointers to the same list.
+We should almost always explicitly use a list() command, so we do not modify a list we did not mean to:
+~~~ {.python}
+odds = [1, 3, 5, 7]
+primes = list(odds)
+primes += [2]
+print 'primes:', primes
+print 'odds:', odds
+~~~
+~~~ {.output}
+primes [1, 3, 5, 7, 2]
+odds [1, 3, 5, 7]
+~~~
+
+This is different from how variables worked in lesson 1, and more similar to a spreadsheet.


### PR DESCRIPTION
added a short section to the lists lesson warning against modifying
lists in place when two or more variables are pointing to the same list.


It may be worth including a sticky note figure for this point? I think it is a worthwhile addition to the lesson as this point cost me several hours of bugfixing when learning, and we have explicitly talked about the opposite behaviour in lesson 1. 

Apologies for the slowness of this pull request. 