### PR TITLE
Matplotlib fixes

### DIFF
--- a/01-numpy.md
+++ b/01-numpy.md
@@ -511,7 +511,7 @@ inflammation rises and falls over a 40-day period.
 > If you're using an IPython / Jupyter notebook,
 > you'll need to execute the following command
 > in order for your matplotlib images to appear
-> when `show()` is called:
+> in the notebook when `show()` is called:
 >
 > ~~~ {.python}
 > % matplotlib inline

--- a/01-numpy.md
+++ b/01-numpy.md
@@ -512,7 +512,11 @@ inflammation rises and falls over a 40-day period.
 > you'll need to execute the following command
 > in order for your matplotlib images to appear
 > when `show()` is called:
-> `% matplotlib inline`. 
+>
+> ~~~ {.python}
+> % matplotlib inline
+> ~~~
+>  
 > The `%` indicates an IPython magic function - 
 > a function that is only valid within the notebook environment. 
 > Note that you only have to execute this function once per notebook.

--- a/04-files.md
+++ b/04-files.md
@@ -40,14 +40,17 @@ the "something" we want to do is generate a set of plots for each file in our in
 Let's test it by analyzing the first three files in the list:
 
 ~~~ {.python}
+import numpy
+import matplotlib.pyplot
+
 filenames = glob.glob('*.csv')
 filenames = filenames[0:3]
 for f in filenames:
     print f
 
-    data = np.loadtxt(fname=f, delimiter=',')
+    data = numpy.loadtxt(fname=f, delimiter=',')
 
-    fig = plt.figure(figsize=(10.0, 3.0))
+    fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))
 
     axes1 = fig.add_subplot(1, 3, 1)
     axes2 = fig.add_subplot(1, 3, 2)


### PR DESCRIPTION
This PR:
* Corrects a number of typos in `01-numpy.md` relating to the use of `matplotlib.pyplot`
* Removes the use of abbreviated library names (`np` and `plt`) in `04-files.md`
* Adds a callout to `01-numpy.md` about `% matplotlib inline` 