### PR TITLE
Fix matplotlib and numpy imports

### DIFF
--- a/01-numpy.md
+++ b/01-numpy.md
@@ -490,6 +490,17 @@ Visualization deserves an entire lecture (or course) of its own,
 but we can explore a few features of Python's `matplotlib` library here.
 While there is no "official" plotting library,
 this package is the de facto standard.
+
+> ## Inline display {.callout}
+>
+> When using the Jupyter (IPython) notebook, we can keep graphical output 
+> associated with the code that created it together in the notebook by 
+> executing before actually importing anything from matplotlib:
+> 
+> ~~~ {.python}
+> %matplotlib inline
+> ~~~~
+
 First,
 we will import the `pyplot` module from `matplotlib`
 and use two of its functions to create and display a heat map of our data:
@@ -505,6 +516,14 @@ matplotlib.pyplot.show(image)
 Blue regions in this heat map are low values, while red shows high values.
 As we can see,
 inflammation rises and falls over a 40-day period.
+
+It is tedious to repeatedly type `matplotlib.pyplot`, so let us import the 
+module we are actually using:
+
+~~~ {.python}
+from matplotlib import pyplot
+~~~~
+
 Let's take a look at the average inflammation over time:
 
 ~~~ {.python}

--- a/04-files.md
+++ b/04-files.md
@@ -39,15 +39,26 @@ In our case,
 the "something" we want to do is generate a set of plots for each file in our inflammation dataset.
 Let's test it by analyzing the first three files in the list:
 
+> ## Inline display {.callout}
+>
+> When using the Jupyter (IPython) notebook, don'te forget to execute:
+> 
+> ~~~ {.python}
+> %matplotlib inline
+> ~~~~
+
 ~~~ {.python}
+import numpy
+from matplotlib import pyplot
+
 filenames = glob.glob('*.csv')
 filenames = filenames[0:3]
 for f in filenames:
     print f
 
-    data = np.loadtxt(fname=f, delimiter=',')
+    data = numpy.loadtxt(fname=f, delimiter=',')
 
-    fig = plt.figure(figsize=(10.0, 3.0))
+    fig = pyplot.figure(figsize=(10.0, 3.0))
 
     axes1 = fig.add_subplot(1, 3, 1)
     axes2 = fig.add_subplot(1, 3, 2)
@@ -63,7 +74,7 @@ for f in filenames:
     axes3.plot(data.min(axis=0))
 
     fig.tight_layout()
-    plt.show(fig)
+    pyplot.show(fig)
 ~~~
 
 ~~~ {.output}


### PR DESCRIPTION
Code examples are inconsistent with the imports that have already taken
place.
Introduced `%matplotlib inline` for Jupyter