### PR TITLE
Update sample code files to py3k

### DIFF
--- a/10-cmdline.html
+++ b/10-cmdline.html
@@ -72,14 +72,14 @@
 <h2 id="command-line-arguments">Command-Line Arguments</h2>
 <p>Using the text editor of your choice, save the following in a text file called <code>sys-version.py</code>:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
-<span class="dt">print</span> <span class="st">&#39;version is&#39;</span>, sys.version</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;version is&#39;</span>, sys.version)</code></pre>
 <p>The first line imports a library called <code>sys</code>, which is short for “system”. It defines values such as <code>sys.version</code>, which describes which version of Python we are running. We can run this script from the command line like this:</p>
 <pre class="input"><code>$ python sys-version.py</code></pre>
 <pre class="output"><code>version is 2.7.5 |Anaconda 1.8.0 (x86_64)| (default, Oct 24 2013, 07:02:20)
 [GCC 4.0.1 (Apple Inc. build 5493)]</code></pre>
 <p>Create another file called <code>argv-list.py</code> and save the following text to it.</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
-<span class="dt">print</span> <span class="st">&#39;sys.argv is&#39;</span>, sys.argv</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;sys.argv is&#39;</span>, sys.argv)</code></pre>
 <p>The strange name <code>argv</code> stands for “argument values”. Whenever Python runs a program, it takes all of the values given on the command line and puts them in the list <code>sys.argv</code> so that the program can determine what they were. If we run this program with no arguments:</p>
 <pre class="input"><code>$ python argv-list.py</code></pre>
 <pre class="output"><code>sys.argv is [&#39;argv-list.py&#39;]</code></pre>
@@ -92,12 +92,13 @@
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
 <span class="ch">import</span> numpy
 
+
 <span class="kw">def</span> main():
     script = sys.argv[<span class="dv">0</span>]
     filename = sys.argv[<span class="dv">1</span>]
     data = numpy.loadtxt(filename, delimiter=<span class="st">&#39;,&#39;</span>)
     <span class="kw">for</span> m in data.mean(axis=<span class="dv">1</span>):
-        <span class="dt">print</span> m</code></pre>
+        <span class="dt">print</span>(m)</code></pre>
 <p>This function gets the name of the script from <code>sys.argv[0]</code>, because that’s where it’s always put, and the name of the file to process from <code>sys.argv[1]</code>. Here’s a simple test:</p>
 <pre class="input"><code>$ python readings-01.py inflammation-01.csv</code></pre>
 <p>There is no output because we have defined a function, but haven’t actually called it. Let’s add a call to <code>main</code>:</p>
@@ -105,12 +106,13 @@
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
 <span class="ch">import</span> numpy
 
+
 <span class="kw">def</span> main():
     script = sys.argv[<span class="dv">0</span>]
     filename = sys.argv[<span class="dv">1</span>]
     data = numpy.loadtxt(filename, delimiter=<span class="st">&#39;,&#39;</span>)
     <span class="kw">for</span> m in data.mean(axis=<span class="dv">1</span>):
-        <span class="dt">print</span> m
+        <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>and run that:</p>
@@ -200,12 +202,13 @@ main()</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
 <span class="ch">import</span> numpy
 
+
 <span class="kw">def</span> main():
     script = sys.argv[<span class="dv">0</span>]
     <span class="kw">for</span> filename in sys.argv[<span class="dv">1</span>:]:
         data = numpy.loadtxt(filename, delimiter=<span class="st">&#39;,&#39;</span>)
         <span class="kw">for</span> m in data.mean(axis=<span class="dv">1</span>):
-            <span class="dt">print</span> m
+            <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>and here it is in action:</p>
@@ -228,6 +231,7 @@ main()</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
 <span class="ch">import</span> numpy
 
+
 <span class="kw">def</span> main():
     script = sys.argv[<span class="dv">0</span>]
     action = sys.argv[<span class="dv">1</span>]
@@ -244,7 +248,7 @@ main()</code></pre>
             values = data.<span class="dt">max</span>(axis=<span class="dv">1</span>)
 
         <span class="kw">for</span> m in values:
-            <span class="dt">print</span> m
+            <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>This works:</p>
@@ -261,6 +265,7 @@ main()</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
 <span class="ch">import</span> numpy
 
+
 <span class="kw">def</span> main():
     script = sys.argv[<span class="dv">0</span>]
     action = sys.argv[<span class="dv">1</span>]
@@ -269,6 +274,7 @@ main()</code></pre>
            <span class="co">&#39;Action is not one of --min, --mean, or --max: &#39;</span> + action
     <span class="kw">for</span> f in filenames:
         process(f, action)
+
 
 <span class="kw">def</span> process(filename, action):
     data = numpy.loadtxt(filename, delimiter=<span class="st">&#39;,&#39;</span>)
@@ -281,7 +287,7 @@ main()</code></pre>
         values = data.<span class="dt">max</span>(axis=<span class="dv">1</span>)
 
     <span class="kw">for</span> m in values:
-        <span class="dt">print</span> m
+        <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>This is four lines longer than its predecessor, but broken into more digestible chunks of 8 and 12 lines.</p>
@@ -295,7 +301,7 @@ count = <span class="dv">0</span>
 <span class="kw">for</span> line in sys.stdin:
     count += <span class="dv">1</span>
 
-<span class="dt">print</span> count, <span class="st">&#39;lines in standard input&#39;</span></code></pre>
+<span class="dt">print</span>(count, <span class="st">&#39;lines in standard input&#39;</span>)</code></pre>
 <p>This little program reads lines from a special “file” called <code>sys.stdin</code>, which is automatically connected to the program’s standard input. We don’t have to open it — Python and the operating system take care of that when the program starts up — but we can do almost anything with it that we could do to a regular file. Let’s try running it as if it were a regular command-line program:</p>
 <pre class="input"><code>$ python count-stdin.py &lt; small-01.csv</code></pre>
 <pre class="output"><code>2 lines in standard input</code></pre>

--- a/10-cmdline.md
+++ b/10-cmdline.md
@@ -68,7 +68,7 @@ save the following in a text file called `sys-version.py`:
 
 ~~~ {.python}
 import sys
-print 'version is', sys.version
+print('version is', sys.version)
 ~~~
 
 The first line imports a library called `sys`,
@@ -90,7 +90,7 @@ Create another file called `argv-list.py` and save the following text to it.
 
 ~~~ {.python}
 import sys
-print 'sys.argv is', sys.argv
+print('sys.argv is', sys.argv)
 ~~~
 
 The strange name `argv` stands for "argument values".
@@ -136,12 +136,13 @@ $ cat readings-01.py
 import sys
 import numpy
 
+
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)
 ~~~
 
 This function gets the name of the script from `sys.argv[0]`,
@@ -165,12 +166,13 @@ $ cat readings-02.py
 import sys
 import numpy
 
+
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)
 
 main()
 ~~~
@@ -318,12 +320,13 @@ $ cat readings-03.py
 import sys
 import numpy
 
+
 def main():
     script = sys.argv[0]
     for filename in sys.argv[1:]:
         data = numpy.loadtxt(filename, delimiter=',')
         for m in data.mean(axis=1):
-            print m
+            print(m)
 
 main()
 ~~~
@@ -368,6 +371,7 @@ $ cat readings-04.py
 import sys
 import numpy
 
+
 def main():
     script = sys.argv[0]
     action = sys.argv[1]
@@ -384,7 +388,7 @@ def main():
             values = data.max(axis=1)
 
         for m in values:
-            print m
+            print(m)
 
 main()
 ~~~
@@ -422,6 +426,7 @@ $ cat readings-05.py
 import sys
 import numpy
 
+
 def main():
     script = sys.argv[0]
     action = sys.argv[1]
@@ -430,6 +435,7 @@ def main():
            'Action is not one of --min, --mean, or --max: ' + action
     for f in filenames:
         process(f, action)
+
 
 def process(filename, action):
     data = numpy.loadtxt(filename, delimiter=',')
@@ -442,7 +448,7 @@ def process(filename, action):
         values = data.max(axis=1)
 
     for m in values:
-        print m
+        print(m)
 
 main()
 ~~~
@@ -474,7 +480,7 @@ count = 0
 for line in sys.stdin:
     count += 1
 
-print count, 'lines in standard input'
+print(count, 'lines in standard input')
 ~~~
 
 This little program reads lines from a special "file" called `sys.stdin`,

--- a/code/argv-list.py
+++ b/code/argv-list.py
@@ -1,2 +1,4 @@
+from __future__ import print_function
+
 import sys
-print 'sys.argv is', sys.argv
+print('sys.argv is', sys.argv)

--- a/code/count-stdin.py
+++ b/code/count-stdin.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
+
 import sys
 
 count = 0
 for line in sys.stdin:
     count += 1
 
-print count, 'lines in standard input'
+print(count, 'lines in standard input')

--- a/code/errors-01.py
+++ b/code/errors-01.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
+
 def favorite_ice_cream():
     ice_creams = [
         "chocolate",
         "vanilla",
         "strawberry"
     ]
-    print ice_creams[3]
+    print(ice_creams[3])

--- a/code/errors-02.py
+++ b/code/errors-02.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 def print_message(day):
     messages = {
         "monday": "Hello, world!",
@@ -8,7 +10,7 @@ def print_message(day):
         "saturday": "Hooray for the weekend!",
         "sunday": "Aw, the weekend is almost over."
     }
-    print messages[day]
+    print(messages[day])
 
 
 def print_friday_message():

--- a/code/gen-inflammation.py
+++ b/code/gen-inflammation.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-'''Generate pseudo-random patient inflammation data for use in Python lessons.'''
+"""
+Generate pseudo-random patient inflammation data for use in Python lessons.
+"""
 
-import sys
 import random
 
 n_patients = 60
@@ -16,4 +17,4 @@ for p in range(n_patients):
     for d in range(n_days):
         upper = max(n_range - abs(d - middle), 0)
         vals.append(random.randint(upper/4, upper))
-    print ','.join([str(v) for v in vals])
+    print(','.join([str(v) for v in vals]))

--- a/code/readings-01.py
+++ b/code/readings-01.py
@@ -1,9 +1,12 @@
+from __future__ import print_function
+
 import sys
 import numpy
+
 
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)

--- a/code/readings-02.py
+++ b/code/readings-02.py
@@ -1,11 +1,14 @@
+from __future__ import print_function
+
 import sys
 import numpy
+
 
 def main():
     script = sys.argv[0]
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)
 
 main()

--- a/code/readings-03.py
+++ b/code/readings-03.py
@@ -1,11 +1,14 @@
+from __future__ import print_function
+
 import sys
 import numpy
+
 
 def main():
     script = sys.argv[0]
     for filename in sys.argv[1:]:
         data = numpy.loadtxt(filename, delimiter=',')
         for m in data.mean(axis=1):
-            print m
+            print(m)
 
 main()

--- a/code/readings-04.py
+++ b/code/readings-04.py
@@ -1,5 +1,8 @@
+from __future__ import print_function
+
 import sys
 import numpy
+
 
 def main():
     script = sys.argv[0]
@@ -17,6 +20,6 @@ def main():
             values = data.max(axis=1)
 
         for m in values:
-            print m
+            print(m)
 
 main()

--- a/code/readings-05.py
+++ b/code/readings-05.py
@@ -1,5 +1,8 @@
+from __future__ import print_function
+
 import sys
 import numpy
+
 
 def main():
     script = sys.argv[0]
@@ -9,6 +12,7 @@ def main():
            'Action is not one of --min, --mean, or --max: ' + action
     for f in filenames:
         process(f, action)
+
 
 def process(filename, action):
     data = numpy.loadtxt(filename, delimiter=',')
@@ -21,6 +25,6 @@ def process(filename, action):
         values = data.max(axis=1)
 
     for m in values:
-        print m
+        print(m)
 
 main()

--- a/code/readings-06.py
+++ b/code/readings-06.py
@@ -1,5 +1,8 @@
+from __future__ import print_function
+
 import sys
 import numpy
+
 
 def main():
     script = sys.argv[0]
@@ -13,6 +16,7 @@ def main():
         for f in filenames:
             process(f, action)
 
+
 def process(filename, action):
     data = numpy.loadtxt(filename, delimiter=',')
 
@@ -24,6 +28,6 @@ def process(filename, action):
         values = data.max(axis=1)
 
     for m in values:
-        print m
+        print(m)
 
 main()

--- a/code/sys-version.py
+++ b/code/sys-version.py
@@ -1,2 +1,4 @@
+from __future__ import print_function
+
 import sys
-print 'version is', sys.version
+print('version is', sys.version)


### PR DESCRIPTION
## Purpose
Per #127 , we would like to update these lessons to work with python 3. Might as well start somewhere!

## Summary of changes
All example files (mainly used in `10-cmdline.md`) have been updated to work with both Python 2 *and* 3. Sample code inside the markdown file has been updated accordingly. 

These changes were fairly minor, and mainly required using `print` as a function instead of a statement.

Minor changes were also made for PEP-8. The HTML was regenerated from `make preview`.

## Side effects/ Quirks
The sample code embedded in the lessons does not actually include `from __future__ import print_function`, mainly to reduce confusion while teaching the lesson. This statement is used in the runnable code files to ensure that things run with both Python 2 and 3 during the transition period.

No other lesson files were converted in this PR.