### PR TITLE
DOC: maintains consistency in print statements 03-lists.md

### DIFF
--- a/03-lists.md
+++ b/03-lists.md
@@ -114,7 +114,7 @@ odds.append(11)
 print 'odds after adding a value:', odds
 ~~~
 ~~~ {.output}
-[1, 3, 5, 7, 11]
+odds after adding a value: [1, 3, 5, 7, 11]
 ~~~
 
 ~~~ {.python}
@@ -122,7 +122,7 @@ del odds[0]
 print 'odds after removing the first element:', odds
 ~~~
 ~~~ {.output}
-[3, 5, 7, 11]
+odds after removing the first element: [3, 5, 7, 11]
 ~~~
 
 ~~~ {.python}
@@ -130,5 +130,5 @@ odds.reverse()
 print 'odds after reversing:', odds
 ~~~
 ~~~ {.output}
-[11, 7, 5, 3]
+odds after reversing: [11, 7, 5, 3]
 ~~~


### PR DESCRIPTION
Related to #48
The output of the print statements in `python-novice-inflammation/03-lists.md`
is not currently shown for the last three code blocks. This pull request adds the output
to the `.md` file