### PR TITLE
Make exponentiation loop exercise more explicit

### DIFF
--- a/02-loop.md
+++ b/02-loop.md
@@ -213,12 +213,12 @@ so we should always use it when we can.
 > Exponentiation is built into Python:
 >
 > ~~~ {.python}
-> print 5**3
+> print 5 ** 3
 > 125
 > ~~~
 >
-> It also has a function called `pow` that calculates the same value.
-> Write a loop to calculate the same result.
+> Write a loop that calculates the same result as `5 ** 3` using
+> multiplication (and without exponentiation).
 
 > ## Reverse a string {.challenge}
 >


### PR DESCRIPTION
The mention of the pow function confuses people so that they think
they are supposed to use the pow function in their solution.
Here I've made the exercise more explicit by specifically telling
the students to use multiplication.
(I don't think the purpose of the exercise is to test whether students
remember that exponentiation is the same as multiplication.)