### PR TITLE
Changed all print statments to print function calls

### DIFF
--- a/01-numpy.html
+++ b/01-numpy.html
@@ -62,14 +62,14 @@
 <p>Our call to <code>numpy.loadtxt</code> read our file, but didn’t save the data in memory. To do that, we need to <a href="reference.html#assignment">assign</a> the array to a <a href="reference.html#variable">variable</a>. A variable is just a name for a value, such as <code>x</code>, <code>current_temperature</code>, or <code>subject_id</code>. Python’s variables must begin with a letter and are <a href="reference.html#case-sensitive">case sensitive</a>. We can create a new variable by assigning a value to it using <code>=</code>. As an illustration, let’s step back and instead of considering a table of data, consider the simplest “collection” of data, a single value. The line below assigns the value <code>55</code> to a variable <code>weight_kg</code>:</p>
 <pre class="sourceCode python"><code class="sourceCode python">weight_kg = <span class="dv">55</span></code></pre>
 <p>Once a variable has a value, we can print it to the screen:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> weight_kg</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(weight_kg)</code></pre>
 <pre class="output"><code>55</code></pre>
 <p>and do arithmetic with it:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;weight in pounds:&#39;</span>, <span class="fl">2.2</span> * weight_kg</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;weight in pounds:&#39;</span>, <span class="fl">2.2</span> * weight_kg)</code></pre>
 <pre class="output"><code>weight in pounds: 121.0</code></pre>
 <p>We can also change a variable’s value by assigning it a new one:</p>
 <pre class="sourceCode python"><code class="sourceCode python">weight_kg = <span class="fl">57.5</span>
-<span class="dt">print</span> <span class="st">&#39;weight in kilograms is now:&#39;</span>, weight_kg</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;weight in kilograms is now:&#39;</span>, weight_kg)</code></pre>
 <pre class="output"><code>weight in kilograms is now: 57.5</code></pre>
 <p>As the example above shows, we can print several things at once by separating them with commas.</p>
 <p>If we imagine the variable as a sticky note with a name written on it, assignment is like putting the sticky note on a particular value:</p>
@@ -78,14 +78,14 @@
 </div>
 <p>This means that assigning a value to one variable does <em>not</em> change the values of other variables. For example, let’s store the subject’s weight in pounds in a variable:</p>
 <pre class="sourceCode python"><code class="sourceCode python">weight_lb = <span class="fl">2.2</span> * weight_kg
-<span class="dt">print</span> <span class="st">&#39;weight in kilograms:&#39;</span>, weight_kg, <span class="st">&#39;and in pounds:&#39;</span>, weight_lb</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;weight in kilograms:&#39;</span>, weight_kg, <span class="st">&#39;and in pounds:&#39;</span>, weight_lb)</code></pre>
 <pre class="output"><code>weight in kilograms: 57.5 and in pounds: 126.5</code></pre>
 <div class="figure">
 <img src="fig/python-sticky-note-variables-02.svg" alt="Creating Another Variable" /><p class="caption">Creating Another Variable</p>
 </div>
 <p>and then change <code>weight_kg</code>:</p>
 <pre class="sourceCode python"><code class="sourceCode python">weight_kg = <span class="fl">100.0</span>
-<span class="dt">print</span> <span class="st">&#39;weight in kilograms is now:&#39;</span>, weight_kg, <span class="st">&#39;and weight in pounds is still:&#39;</span>, weight_lb</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;weight in kilograms is now:&#39;</span>, weight_kg, <span class="st">&#39;and weight in pounds is still:&#39;</span>, weight_lb)</code></pre>
 <pre class="output"><code>weight in kilograms is now: 100.0 and weight in pounds is still: 126.5</code></pre>
 <div class="figure">
 <img src="fig/python-sticky-note-variables-03.svg" alt="Updating a Variable" /><p class="caption">Updating a Variable</p>
@@ -94,7 +94,7 @@
 <p>Just as we can assign a single value to a variable, we can also assign an array of values to a variable using the same syntax. Let’s re-run <code>numpy.loadtxt</code> and save its result:</p>
 <pre class="sourceCode python"><code class="sourceCode python">data = numpy.loadtxt(fname=<span class="st">&#39;inflammation-01.csv&#39;</span>, delimiter=<span class="st">&#39;,&#39;</span>)</code></pre>
 <p>This statement doesn’t produce any output because assignment doesn’t display anything. If we want to check that our data has been loaded, we can print the variable’s value:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data)</code></pre>
 <pre class="output"><code>[[ 0.  0.  1. ...,  3.  0.  0.]
  [ 0.  1.  2. ...,  1.  0.  1.]
  [ 0.  1.  1. ...,  2.  1.  1.]
@@ -103,16 +103,16 @@
  [ 0.  0.  0. ...,  0.  2.  0.]
  [ 0.  0.  1. ...,  1.  1.  0.]]</code></pre>
 <p>Now that our data is in memory, we can start doing things with it. First, let’s ask what <a href="reference.html#type">type</a> of thing <code>data</code> refers to:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="dt">type</span>(data)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="dt">type</span>(data))</code></pre>
 <pre class="output"><code>&lt;type &#39;numpy.ndarray&#39;&gt;</code></pre>
 <p>The output tells us that <code>data</code> currently refers to an N-dimensional array created by the NumPy library. We can see what its <a href="reference.html#shape">shape</a> is like this:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data.shape</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data.shape)</code></pre>
 <pre class="output"><code>(60, 40)</code></pre>
 <p>This tells us that <code>data</code> has 60 rows and 40 columns. When we created the variable <code>data</code> to store our arthritis data, we didn’t just create the array, we also created information about the array, called <a href="reference.html#member">members</a> or attributes. This extra information describes <code>data</code> in the same way an adjective describes a noun. <code>data.shape</code> is an attribute of <code>data</code> which described the dimensions of <code>data</code>. We use the same dotted notation for the attributes of variables that we use for the functions in libraries because they have the same part-and-whole relationship.</p>
 <p>If we want to get a single number from the array, we must provide an <a href="reference.html#index">index</a> in square brackets, just as we do in math:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;first value in data:&#39;</span>, data[<span class="dv">0</span>, <span class="dv">0</span>]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;first value in data:&#39;</span>, data[<span class="dv">0</span>, <span class="dv">0</span>])</code></pre>
 <pre class="output"><code>first value in data: 0.0</code></pre>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;middle value in data:&#39;</span>, data[<span class="dv">30</span>, <span class="dv">20</span>]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;middle value in data:&#39;</span>, data[<span class="dv">30</span>, <span class="dv">20</span>])</code></pre>
 <pre class="output"><code>middle value in data: 13.0</code></pre>
 <p>The expression <code>data[30, 20]</code> may not surprise you, but <code>data[0, 0]</code> might. Programming languages like Fortran and MATLAB start counting at 1, because that’s what human beings have done for thousands of years. Languages in the C family (including C++, Java, Perl, and Python) count from 0 because that’s simpler for computers to do. As a result, if we have an M×N array in Python, its indices go from 0 to M-1 on the first axis and 0 to N-1 on the second. It takes a bit of getting used to, but one way to remember the rule is that the index is how many steps we have to take from the start to get the item we want.</p>
 <aside class="callout panel panel-info">
@@ -124,14 +124,14 @@
 </div>
 </aside>
 <p>An index like <code>[30, 20]</code> selects a single element of an array, but we can select whole sections as well. For example, we can select the first ten days (columns) of values for the first four (rows) patients like this:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data[<span class="dv">0</span>:<span class="dv">4</span>, <span class="dv">0</span>:<span class="dv">10</span>]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data[<span class="dv">0</span>:<span class="dv">4</span>, <span class="dv">0</span>:<span class="dv">10</span>])</code></pre>
 <pre class="output"><code>[[ 0.  0.  1.  3.  1.  2.  4.  7.  8.  3.]
  [ 0.  1.  2.  1.  2.  1.  3.  2.  2.  6.]
  [ 0.  1.  1.  3.  3.  2.  6.  2.  5.  9.]
  [ 0.  0.  2.  0.  4.  2.  2.  1.  6.  7.]]</code></pre>
 <p>The <a href="reference.html#slice">slice</a> <code>0:4</code> means, “Start at index 0 and go up to, but not including, index 4.” Again, the up-to-but-not-including takes a bit of getting used to, but the rule is that the difference between the upper and lower bounds is the number of values in the slice.</p>
 <p>We don’t have to start slices at 0:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data[<span class="dv">5</span>:<span class="dv">10</span>, <span class="dv">0</span>:<span class="dv">10</span>]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data[<span class="dv">5</span>:<span class="dv">10</span>, <span class="dv">0</span>:<span class="dv">10</span>])</code></pre>
 <pre class="output"><code>[[ 0.  0.  1.  2.  2.  4.  2.  1.  6.  4.]
  [ 0.  0.  2.  2.  4.  2.  2.  5.  5.  8.]
  [ 0.  0.  1.  2.  3.  1.  2.  3.  5.  3.]
@@ -139,8 +139,8 @@
  [ 0.  1.  1.  2.  1.  3.  5.  3.  5.  8.]]</code></pre>
 <p>We also don’t have to include the upper and lower bound on the slice. If we don’t include the lower bound, Python uses 0 by default; if we don’t include the upper, the slice runs to the end of the axis, and if we don’t include either (i.e., if we just use ‘:’ on its own), the slice includes everything:</p>
 <pre class="sourceCode python"><code class="sourceCode python">small = data[:<span class="dv">3</span>, <span class="dv">36</span>:]
-<span class="dt">print</span> <span class="st">&#39;small is:&#39;</span>
-<span class="dt">print</span> small</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;small is:&#39;</span>)
+<span class="dt">print</span>(small)</code></pre>
 <pre class="output"><code>small is:
 [[ 2.  3.  0.  0.]
  [ 1.  1.  0.  1.]
@@ -148,10 +148,10 @@
 <p>Arrays also know how to perform common mathematical operations on their values. The simplest operations with data are arithmetic: add, subtract, multiply, and divide. When you do such operations on arrays, the operation is done on each individual element of the array. Thus:</p>
 <pre class="sourceCode python"><code class="sourceCode python">doubledata = data * <span class="fl">2.0</span></code></pre>
 <p>will create a new array <code>doubledata</code> whose elements have the value of two times the value of the corresponding elements in <code>data</code>:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;original:&#39;</span>
-<span class="dt">print</span> data[:<span class="dv">3</span>, <span class="dv">36</span>:]
-<span class="dt">print</span> <span class="st">&#39;doubledata:&#39;</span>
-<span class="dt">print</span> doubledata[:<span class="dv">3</span>, <span class="dv">36</span>:]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;original:&#39;</span>)
+<span class="dt">print</span>(data[:<span class="dv">3</span>, <span class="dv">36</span>:])
+<span class="dt">print</span>(<span class="st">&#39;doubledata:&#39;</span>)
+<span class="dt">print</span>(doubledata[:<span class="dv">3</span>, <span class="dv">36</span>:])</code></pre>
 <pre class="output"><code>original:
 [[ 2.  3.  0.  0.]
  [ 1.  1.  0.  1.]
@@ -163,36 +163,36 @@ doubledata:
 <p>If, instead of taking an array and doing arithmetic with a single value (as above) you did the arithmetic operation with another array of the same shape, the operation will be done on corresponding elements of the two arrays. Thus:</p>
 <pre class="sourceCode python"><code class="sourceCode python">tripledata = doubledata + data</code></pre>
 <p>will give you an array where <code>tripledata[0,0]</code> will equal <code>doubledata[0,0]</code> plus <code>data[0,0]</code>, and so on for all other elements of the arrays.</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;tripledata:&#39;</span>
-<span class="dt">print</span> tripledata[:<span class="dv">3</span>, <span class="dv">36</span>:]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;tripledata:&#39;</span>)
+<span class="dt">print</span>(tripledata[:<span class="dv">3</span>, <span class="dv">36</span>:])</code></pre>
 <pre class="output"><code>tripledata:
 [[ 6.  9.  0.  0.]
  [ 3.  3.  0.  3.]
  [ 6.  6.  3.  3.]]</code></pre>
 <p>Often, we want to do more than add, subtract, multiply, and divide values of data. Arrays also know how to do more complex operations on their values. If we want to find the average inflammation for all patients on all days, for example, we can just ask the array for its mean value</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data.mean()</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data.mean())</code></pre>
 <pre class="output"><code>6.14875</code></pre>
 <p><code>mean</code> is a <a href="reference.html#method">method</a> of the array, i.e., a function that belongs to it in the same way that the member <code>shape</code> does. If variables are nouns, methods are verbs: they are what the thing in question knows how to do. We need empty parentheses for <code>data.mean()</code>, even when we’re not passing in any parameters, to tell Python to go and do something for us. <code>data.shape</code> doesn’t need <code>()</code> because it is just a description but <code>data.mean()</code> requires the <code>()</code> because it is an action.</p>
 <p>NumPy arrays have lots of useful methods:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;maximum inflammation:&#39;</span>, data.<span class="dt">max</span>()
-<span class="dt">print</span> <span class="st">&#39;minimum inflammation:&#39;</span>, data.<span class="dt">min</span>()
-<span class="dt">print</span> <span class="st">&#39;standard deviation:&#39;</span>, data.std()</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;maximum inflammation:&#39;</span>, data.<span class="dt">max</span>())
+<span class="dt">print</span>(<span class="st">&#39;minimum inflammation:&#39;</span>, data.<span class="dt">min</span>())
+<span class="dt">print</span>(<span class="st">&#39;standard deviation:&#39;</span>, data.std())</code></pre>
 <pre class="output"><code>maximum inflammation: 20.0
 minimum inflammation: 0.0
 standard deviation: 4.61383319712</code></pre>
 <p>When analyzing data, though, we often want to look at partial statistics, such as the maximum value per patient or the average value per day. One way to do this is to create a new temporary array of the data we want, then ask it to do the calculation:</p>
 <pre class="sourceCode python"><code class="sourceCode python">patient_0 = data[<span class="dv">0</span>, :] <span class="co"># 0 on the first axis, everything on the second</span>
-<span class="dt">print</span> <span class="st">&#39;maximum inflammation for patient 0:&#39;</span>, patient_0.<span class="dt">max</span>()</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;maximum inflammation for patient 0:&#39;</span>, patient_0.<span class="dt">max</span>())</code></pre>
 <pre class="output"><code>maximum inflammation for patient 0: 18.0</code></pre>
 <p>We don’t actually need to store the row in a variable of its own. Instead, we can combine the selection and the method call:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;maximum inflammation for patient 2:&#39;</span>, data[<span class="dv">2</span>, :].<span class="dt">max</span>()</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;maximum inflammation for patient 2:&#39;</span>, data[<span class="dv">2</span>, :].<span class="dt">max</span>())</code></pre>
 <pre class="output"><code>maximum inflammation for patient 2: 19.0</code></pre>
 <p>What if we need the maximum inflammation for <em>all</em> patients (as in the next diagram on the left), or the average for each day (as in the diagram on the right)? As the diagram below shows, we want to perform the operation across an axis:</p>
 <div class="figure">
 <img src="fig/python-operations-across-axes.svg" alt="Operations Across Axes" /><p class="caption">Operations Across Axes</p>
 </div>
 <p>To support this, most array methods allow us to specify the axis we want to work on. If we ask for the average across axis 0 (rows in our 2D example), we get:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data.mean(axis=<span class="dv">0</span>)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data.mean(axis=<span class="dv">0</span>))</code></pre>
 <pre class="output"><code>[  0.           0.45         1.11666667   1.75         2.43333333   3.15
    3.8          3.88333333   5.23333333   5.51666667   5.95         5.9
    8.35         7.73333333   8.36666667   9.5          9.58333333
@@ -202,10 +202,10 @@ standard deviation: 4.61383319712</code></pre>
    3.3          3.56666667   2.48333333   1.5          1.13333333
    0.56666667]</code></pre>
 <p>As a quick check, we can ask this array what its shape is:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data.mean(axis=<span class="dv">0</span>).shape</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data.mean(axis=<span class="dv">0</span>).shape)</code></pre>
 <pre class="output"><code>(40,)</code></pre>
 <p>The expression <code>(40,)</code> tells us we have an N×1 vector, so this is the average inflammation per day for all patients. If we average across axis 1 (columns in our 2D example), we get:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> data.mean(axis=<span class="dv">1</span>)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(data.mean(axis=<span class="dv">1</span>))</code></pre>
 <pre class="output"><code>[ 5.45   5.425  6.1    5.9    5.55   6.225  5.975  6.65   6.625  6.525
   6.775  5.8    6.225  5.75   5.225  6.3    6.55   5.7    5.85   6.55
   5.775  5.825  6.175  6.1    5.8    6.425  6.05   6.025  6.175  6.55
@@ -220,21 +220,32 @@ matplotlib.pyplot.show(image)</code></pre>
 <div class="figure">
 <img src="fig/01-numpy_71_0.png" alt="Heatmap of the Data" /><p class="caption">Heatmap of the Data</p>
 </div>
-<p>Blue regions in this heat map are low values, while red shows high values. As we can see, inflammation rises and falls over a 40-day period. Let’s take a look at the average inflammation over time:</p>
+<p>Blue regions in this heat map are low values, while red shows high values. As we can see, inflammation rises and falls over a 40-day period.</p>
+<aside class="callout panel panel-info">
+<div class="panel-heading">
+<h2><span class="glyphicon glyphicon-pushpin"></span>Some IPython magic</h2>
+</div>
+<div class="panel-body">
+<p>If you’re using an IPython / Jupyter notebook, you’ll need to execute the following command in order for your matplotlib images to appear in the notebook when <code>show()</code> is called:</p>
+<pre class="sourceCode python"><code class="sourceCode python">% matplotlib inline</code></pre>
+<p>The <code>%</code> indicates an IPython magic function - a function that is only valid within the notebook environment. Note that you only have to execute this function once per notebook.</p>
+</div>
+</aside>
+<p>Let’s take a look at the average inflammation over time:</p>
 <pre class="sourceCode python"><code class="sourceCode python">ave_inflammation = data.mean(axis=<span class="dv">0</span>)
-ave_plot = pyplot.plot(ave_inflammation)
-pyplot.show(ave_plot)</code></pre>
+ave_plot = matplotlib.pyplot.plot(ave_inflammation)
+matplotlib.pyplot.show(ave_plot)</code></pre>
 <div class="figure">
 <img src="fig/01-numpy_73_0.png" alt="Average Inflammation Over Time" /><p class="caption">Average Inflammation Over Time</p>
 </div>
-<p>Here, we have put the average per day across all patients in the variable <code>ave_inflammation</code>, then asked <code>pyplot</code> to create and display a line graph of those values. The result is roughly a linear rise and fall, which is suspicious: based on other studies, we expect a sharper rise and slower fall. Let’s have a look at two other statistics:</p>
-<pre class="sourceCode python"><code class="sourceCode python">max_plot = pyplot.plot(data.<span class="dt">max</span>(axis=<span class="dv">0</span>))
-pyplot.show(max_plot)</code></pre>
+<p>Here, we have put the average per day across all patients in the variable <code>ave_inflammation</code>, then asked <code>matplotlib.pyplot</code> to create and display a line graph of those values. The result is roughly a linear rise and fall, which is suspicious: based on other studies, we expect a sharper rise and slower fall. Let’s have a look at two other statistics:</p>
+<pre class="sourceCode python"><code class="sourceCode python">max_plot = matplotlib.pyplot.plot(data.<span class="dt">max</span>(axis=<span class="dv">0</span>))
+matplotlib.pyplot.show(max_plot)</code></pre>
 <div class="figure">
 <img src="fig/01-numpy_75_1.png" alt="Maximum Value Along The First Axis" /><p class="caption">Maximum Value Along The First Axis</p>
 </div>
-<pre class="sourceCode python"><code class="sourceCode python">min_plot = pyplot.plot(data.<span class="dt">min</span>(axis=<span class="dv">0</span>))
-pyplot.show(min_plot)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python">min_plot = matplotlib.pyplot.plot(data.<span class="dt">min</span>(axis=<span class="dv">0</span>))
+matplotlib.pyplot.show(min_plot)</code></pre>
 <div class="figure">
 <img src="fig/01-numpy_75_3.png" alt="Minimum Value Along The First Axis" /><p class="caption">Minimum Value Along The First Axis</p>
 </div>
@@ -295,7 +306,7 @@ age = age - <span class="dv">20</span></code></pre>
 <p>What does the following program print out?</p>
 <pre class="sourceCode python"><code class="sourceCode python">first, second = <span class="st">&#39;Grace&#39;</span>, <span class="st">&#39;Hopper&#39;</span>
 third, fourth = second, first
-<span class="dt">print</span> third, fourth</code></pre>
+<span class="dt">print</span>(third, fourth)</code></pre>
 </div>
 </section>
 <section class="challenge panel panel-success">
@@ -305,8 +316,8 @@ third, fourth = second, first
 <div class="panel-body">
 <p>A section of an array is called a <a href="reference.html#slice">slice</a>. We can take slices of character strings as well:</p>
 <pre class="sourceCode python"><code class="sourceCode python">element = <span class="st">&#39;oxygen&#39;</span>
-<span class="dt">print</span> <span class="st">&#39;first three characters:&#39;</span>, element[<span class="dv">0</span>:<span class="dv">3</span>]
-<span class="dt">print</span> <span class="st">&#39;last three characters:&#39;</span>, element[<span class="dv">3</span>:<span class="dv">6</span>]</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;first three characters:&#39;</span>, element[<span class="dv">0</span>:<span class="dv">3</span>])
+<span class="dt">print</span>(<span class="st">&#39;last three characters:&#39;</span>, element[<span class="dv">3</span>:<span class="dv">6</span>])</code></pre>
 <pre class="output"><code>first three characters: oxy
 last three characters: gen</code></pre>
 <p>What is the value of <code>element[:4]</code>? What about <code>element[4:]</code>? Or <code>element[:]</code>?</p>

--- a/01-numpy.md
+++ b/01-numpy.md
@@ -93,7 +93,7 @@ weight_kg = 55
 Once a variable has a value, we can print it to the screen:
 
 ~~~ {.python}
-print weight_kg
+print(weight_kg)
 ~~~
 ~~~ {.output}
 55
@@ -102,7 +102,7 @@ print weight_kg
 and do arithmetic with it:
 
 ~~~ {.python}
-print 'weight in pounds:', 2.2 * weight_kg
+print('weight in pounds:', 2.2 * weight_kg)
 ~~~
 ~~~ {.output}
 weight in pounds: 121.0
@@ -112,7 +112,7 @@ We can also change a variable's value by assigning it a new one:
 
 ~~~ {.python}
 weight_kg = 57.5
-print 'weight in kilograms is now:', weight_kg
+print('weight in kilograms is now:', weight_kg)
 ~~~
 ~~~ {.output}
 weight in kilograms is now: 57.5
@@ -132,7 +132,7 @@ let's store the subject's weight in pounds in a variable:
 
 ~~~ {.python}
 weight_lb = 2.2 * weight_kg
-print 'weight in kilograms:', weight_kg, 'and in pounds:', weight_lb
+print('weight in kilograms:', weight_kg, 'and in pounds:', weight_lb)
 ~~~
 ~~~ {.output}
 weight in kilograms: 57.5 and in pounds: 126.5
@@ -144,7 +144,7 @@ and then change `weight_kg`:
 
 ~~~ {.python}
 weight_kg = 100.0
-print 'weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', weight_lb
+print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', weight_lb)
 ~~~
 ~~~ {.output}
 weight in kilograms is now: 100.0 and weight in pounds is still: 126.5
@@ -168,7 +168,7 @@ If we want to check that our data has been loaded,
 we can print the variable's value:
 
 ~~~ {.python}
-print data
+print(data)
 ~~~
 ~~~ {.output}
 [[ 0.  0.  1. ...,  3.  0.  0.]
@@ -186,7 +186,7 @@ First,
 let's ask what [type](reference.html#type) of thing `data` refers to:
 
 ~~~ {.python}
-print type(data)
+print(type(data))
 ~~~
 ~~~ {.output}
 <type 'numpy.ndarray'>
@@ -196,7 +196,7 @@ The output tells us that `data` currently refers to an N-dimensional array creat
 We can see what its [shape](reference.html#shape) is like this:
 
 ~~~ {.python}
-print data.shape
+print(data.shape)
 ~~~
 ~~~ {.output}
 (60, 40)
@@ -217,14 +217,14 @@ we must provide an [index](reference.html#index) in square brackets,
 just as we do in math:
 
 ~~~ {.python}
-print 'first value in data:', data[0, 0]
+print('first value in data:', data[0, 0])
 ~~~
 ~~~ {.output}
 first value in data: 0.0
 ~~~
 
 ~~~ {.python}
-print 'middle value in data:', data[30, 20]
+print('middle value in data:', data[30, 20])
 ~~~
 ~~~ {.output}
 middle value in data: 13.0
@@ -261,7 +261,7 @@ we can select the first ten days (columns) of values
 for the first four (rows) patients like this:
 
 ~~~ {.python}
-print data[0:4, 0:10]
+print(data[0:4, 0:10])
 ~~~
 ~~~ {.output}
 [[ 0.  0.  1.  3.  1.  2.  4.  7.  8.  3.]
@@ -279,7 +279,7 @@ but the rule is that the difference between the upper and lower bounds is the nu
 We don't have to start slices at 0:
 
 ~~~ {.python}
-print data[5:10, 0:10]
+print(data[5:10, 0:10])
 ~~~
 ~~~ {.output}
 [[ 0.  0.  1.  2.  2.  4.  2.  1.  6.  4.]
@@ -300,8 +300,8 @@ the slice includes everything:
 
 ~~~ {.python}
 small = data[:3, 36:]
-print 'small is:'
-print small
+print('small is:')
+print(small)
 ~~~
 ~~~ {.output}
 small is:
@@ -325,10 +325,10 @@ will create a new array `doubledata`
 whose elements have the value of two times the value of the corresponding elements in `data`:
 
 ~~~ {.python}
-print 'original:'
-print data[:3, 36:]
-print 'doubledata:'
-print doubledata[:3, 36:]
+print('original:')
+print(data[:3, 36:])
+print('doubledata:')
+print(doubledata[:3, 36:])
 ~~~
 ~~~ {.output}
 original:
@@ -355,8 +355,8 @@ will give you an array where `tripledata[0,0]` will equal `doubledata[0,0]` plus
 and so on for all other elements of the arrays.
 
 ~~~ {.python}
-print 'tripledata:'
-print tripledata[:3, 36:]
+print('tripledata:')
+print(tripledata[:3, 36:])
 ~~~
 ~~~ {.output}
 tripledata:
@@ -372,7 +372,7 @@ for example,
 we can just ask the array for its mean value
 
 ~~~ {.python}
-print data.mean()
+print(data.mean())
 ~~~
 ~~~ {.output}
 6.14875
@@ -393,9 +393,9 @@ because it is an action.
 NumPy arrays have lots of useful methods:
 
 ~~~ {.python}
-print 'maximum inflammation:', data.max()
-print 'minimum inflammation:', data.min()
-print 'standard deviation:', data.std()
+print('maximum inflammation:', data.max())
+print('minimum inflammation:', data.min())
+print('standard deviation:', data.std())
 ~~~
 ~~~ {.output}
 maximum inflammation: 20.0
@@ -413,7 +413,7 @@ then ask it to do the calculation:
 
 ~~~ {.python}
 patient_0 = data[0, :] # 0 on the first axis, everything on the second
-print 'maximum inflammation for patient 0:', patient_0.max()
+print('maximum inflammation for patient 0:', patient_0.max())
 ~~~
 ~~~ {.output}
 maximum inflammation for patient 0: 18.0
@@ -423,7 +423,7 @@ We don't actually need to store the row in a variable of its own.
 Instead, we can combine the selection and the method call:
 
 ~~~ {.python}
-print 'maximum inflammation for patient 2:', data[2, :].max()
+print('maximum inflammation for patient 2:', data[2, :].max())
 ~~~
 ~~~ {.output}
 maximum inflammation for patient 2: 19.0
@@ -442,7 +442,7 @@ If we ask for the average across axis 0 (rows in our 2D example),
 we get:
 
 ~~~ {.python}
-print data.mean(axis=0)
+print(data.mean(axis=0))
 ~~~
 ~~~ {.output}
 [  0.           0.45         1.11666667   1.75         2.43333333   3.15
@@ -459,7 +459,7 @@ As a quick check,
 we can ask this array what its shape is:
 
 ~~~ {.python}
-print data.mean(axis=0).shape
+print(data.mean(axis=0).shape)
 ~~~
 ~~~ {.output}
 (40,)
@@ -470,7 +470,7 @@ so this is the average inflammation per day for all patients.
 If we average across axis 1 (columns in our 2D example), we get:
 
 ~~~ {.python}
-print data.mean(axis=1)
+print(data.mean(axis=1))
 ~~~
 ~~~ {.output}
 [ 5.45   5.425  6.1    5.9    5.55   6.225  5.975  6.65   6.625  6.525
@@ -637,7 +637,7 @@ the graphs will actually be squeezed together more closely.)
 > ~~~ {.python}
 > first, second = 'Grace', 'Hopper'
 > third, fourth = second, first
-> print third, fourth
+> print(third, fourth)
 > ~~~
 
 > ## Slicing strings {.challenge}
@@ -647,8 +647,8 @@ the graphs will actually be squeezed together more closely.)
 >
 > ~~~ {.python}
 > element = 'oxygen'
-> print 'first three characters:', element[0:3]
-> print 'last three characters:', element[3:6]
+> print('first three characters:', element[0:3])
+> print('last three characters:', element[3:6])
 > ~~~
 >
 > ~~~ {.output}

--- a/02-loop.html
+++ b/02-loop.html
@@ -43,12 +43,12 @@
 </section>
 <p>In the last lesson, we wrote some code that plots some values of interest from our first inflammation dataset, and reveals some suspicious features in it, such as from <code>inflammation-01.csv</code></p>
 <p><img src="fig/03-loop_2_0.png" alt="Analysis of inflammation-01.csv" /><br /> but we have a dozen data sets right now and more on the way. We want to create plots for all our data sets with a single statement. To do that, we’ll have to teach the computer how to repeat things.</p>
-<p>An example task that we might want to repeat is printing each character in a word on a line of its own. One way to do this would be to use a series of <code>print</code> statements:</p>
+<p>An example task that we might want to repeat is printing each character in a word on a line of its own. One way to do this would be to use a series of <code>print</code> functions:</p>
 <pre class="sourceCode python"><code class="sourceCode python">word = <span class="st">&#39;lead&#39;</span>
-<span class="dt">print</span> word[<span class="dv">0</span>]
-<span class="dt">print</span> word[<span class="dv">1</span>]
-<span class="dt">print</span> word[<span class="dv">2</span>]
-<span class="dt">print</span> word[<span class="dv">3</span>]</code></pre>
+<span class="dt">print</span>(word[<span class="dv">0</span>])
+<span class="dt">print</span>(word[<span class="dv">1</span>])
+<span class="dt">print</span>(word[<span class="dv">2</span>])
+<span class="dt">print</span>(word[<span class="dv">3</span>])</code></pre>
 <pre class="output"><code>l
 e
 a
@@ -59,25 +59,25 @@ d</code></pre>
 <li><p>It’s fragile: if we give it a longer string, it only prints part of the data, and if we give it a shorter one, it produces an error because we’re asking for characters that don’t exist.</p></li>
 </ol>
 <pre class="sourceCode python"><code class="sourceCode python">word = <span class="st">&#39;tin&#39;</span>
-<span class="dt">print</span> word[<span class="dv">0</span>]
-<span class="dt">print</span> word[<span class="dv">1</span>]
-<span class="dt">print</span> word[<span class="dv">2</span>]
-<span class="dt">print</span> word[<span class="dv">3</span>]</code></pre>
+<span class="dt">print</span>(word[<span class="dv">0</span>])
+<span class="dt">print</span>(word[<span class="dv">1</span>])
+<span class="dt">print</span>(word[<span class="dv">2</span>])
+<span class="dt">print</span>(word[<span class="dv">3</span>])</code></pre>
 <pre class="output"><code>t
 i
 n</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
 &lt;ipython-input-3-7974b6cdaf14&gt; in &lt;module&gt;()
-      3 print word[1]
-      4 print word[2]
-----&gt; 5 print word[3]
+      3 print(word[1])
+      4 print(word[2])
+----&gt; 5 print(word[3])
 
 IndexError: string index out of range</code></pre>
 <p>Here’s a better approach:</p>
 <pre class="sourceCode python"><code class="sourceCode python">word = <span class="st">&#39;lead&#39;</span>
 <span class="kw">for</span> char in word:
-    <span class="dt">print</span> char</code></pre>
+    <span class="dt">print</span>(char)</code></pre>
 <pre class="output"><code>l
 e
 a
@@ -85,7 +85,7 @@ d</code></pre>
 <p>This is shorter—certainly shorter than something that prints every character in a hundred-letter string—and more robust as well:</p>
 <pre class="sourceCode python"><code class="sourceCode python">word = <span class="st">&#39;oxygen&#39;</span>
 <span class="kw">for</span> char in word:
-    <span class="dt">print</span> char</code></pre>
+    <span class="dt">print</span>(char)</code></pre>
 <pre class="output"><code>o
 x
 y
@@ -100,20 +100,20 @@ n</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python">length = <span class="dv">0</span>
 <span class="kw">for</span> vowel in <span class="st">&#39;aeiou&#39;</span>:
     length = length + <span class="dv">1</span>
-<span class="dt">print</span> <span class="st">&#39;There are&#39;</span>, length, <span class="st">&#39;vowels&#39;</span></code></pre>
+<span class="dt">print</span>(<span class="st">&#39;There are&#39;</span>, length, <span class="st">&#39;vowels&#39;</span>)</code></pre>
 <pre class="output"><code>There are 5 vowels</code></pre>
-<p>It’s worth tracing the execution of this little program step by step. Since there are five characters in <code>'aeiou'</code>, the statement on line 3 will be executed five times. The first time around, <code>length</code> is zero (the value assigned to it on line 1) and <code>vowel</code> is <code>'a'</code>. The statement adds 1 to the old value of <code>length</code>, producing 1, and updates <code>length</code> to refer to that new value. The next time around, <code>vowel</code> is <code>'e'</code> and <code>length</code> is 1, so <code>length</code> is updated to be 2. After three more updates, <code>length</code> is 5; since there is nothing left in <code>'aeiou'</code> for Python to process, the loop finishes and the <code>print</code> statement on line 4 tells us our final answer.</p>
+<p>It’s worth tracing the execution of this little program step by step. Since there are five characters in <code>'aeiou'</code>, the statement on line 3 will be executed five times. The first time around, <code>length</code> is zero (the value assigned to it on line 1) and <code>vowel</code> is <code>'a'</code>. The statement adds 1 to the old value of <code>length</code>, producing 1, and updates <code>length</code> to refer to that new value. The next time around, <code>vowel</code> is <code>'e'</code> and <code>length</code> is 1, so <code>length</code> is updated to be 2. After three more updates, <code>length</code> is 5; since there is nothing left in <code>'aeiou'</code> for Python to process, the loop finishes and the <code>print</code> function on line 4 tells us our final answer.</p>
 <p>Note that a loop variable is just a variable that’s being used to record progress in a loop. It still exists after the loop is over, and we can re-use variables previously defined as loop variables as well:</p>
 <pre class="sourceCode python"><code class="sourceCode python">letter = <span class="st">&#39;z&#39;</span>
 <span class="kw">for</span> letter in <span class="st">&#39;abc&#39;</span>:
-    <span class="dt">print</span> letter
-<span class="dt">print</span> <span class="st">&#39;after the loop, letter is&#39;</span>, letter</code></pre>
+    <span class="dt">print</span>(letter)
+<span class="dt">print</span>(<span class="st">&#39;after the loop, letter is&#39;</span>, letter)</code></pre>
 <pre class="output"><code>a
 b
 c
 after the loop, letter is c</code></pre>
 <p>Note also that finding the length of a string is such a common operation that Python actually has a built-in function to do it called <code>len</code>:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="dt">len</span>(<span class="st">&#39;aeiou&#39;</span>)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="dt">len</span>(<span class="st">&#39;aeiou&#39;</span>))</code></pre>
 <pre class="output"><code>5</code></pre>
 <p><code>len</code> is much faster than any function we could write ourselves, and much easier to read than a two-line loop; it will also give us the length of many other things that we haven’t met yet, so we should always use it when we can.</p>
 <section class="challenge panel panel-success">
@@ -133,7 +133,7 @@ after the loop, letter is c</code></pre>
 </div>
 <div class="panel-body">
 <p>Exponentiation is built into Python:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="dv">5</span>**<span class="dv">3</span>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="dv">5</span>**<span class="dv">3</span>)
 <span class="dv">125</span></code></pre>
 <p>It also has a function called <code>pow</code> that calculates the same value. Write a loop to calculate the same result.</p>
 </div>

--- a/02-loop.md
+++ b/02-loop.md
@@ -22,14 +22,14 @@ We want to create plots for all our data sets with a single statement.
 To do that, we'll have to teach the computer how to repeat things.
 
 An example task that we might want to repeat is printing each character in a
-word on a line of its own. One way to do this would be to use a series of `print` statements:
+word on a line of its own. One way to do this would be to use a series of `print` functions:
 
 ~~~ {.python}
 word = 'lead'
-print word[0]
-print word[1]
-print word[2]
-print word[3]
+print(word[0])
+print(word[1])
+print(word[2])
+print(word[3])
 
 ~~~
 ~~~ {.output}
@@ -53,10 +53,10 @@ but that's a bad approach for two reasons:
 
 ~~~ {.python}
 word = 'tin'
-print word[0]
-print word[1]
-print word[2]
-print word[3]
+print(word[0])
+print(word[1])
+print(word[2])
+print(word[3])
 
 ~~~
 ~~~ {.output}
@@ -68,9 +68,9 @@ n
 ---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
 <ipython-input-3-7974b6cdaf14> in <module>()
-      3 print word[1]
-      4 print word[2]
-----> 5 print word[3]
+      3 print(word[1])
+      4 print(word[2])
+----> 5 print(word[3])
 
 IndexError: string index out of range
 ~~~
@@ -81,7 +81,7 @@ Here's a better approach:
 ~~~ {.python}
 word = 'lead'
 for char in word:
-    print char
+    print(char)
 
 ~~~
 
@@ -98,7 +98,7 @@ more robust as well:
 ~~~ {.python}
 word = 'oxygen'
 for char in word:
-    print char
+    print(char)
 ~~~
 
 ~~~ {.output}
@@ -130,7 +130,7 @@ Here's another loop that repeatedly updates a variable:
 length = 0
 for vowel in 'aeiou':
     length = length + 1
-print 'There are', length, 'vowels'
+print('There are', length, 'vowels')
 ~~~
 
 ~~~ {.output}
@@ -153,7 +153,7 @@ After three more updates,
 `length` is 5;
 since there is nothing left in `'aeiou'` for Python to process,
 the loop finishes
-and the `print` statement on line 4 tells us our final answer.
+and the `print` function on line 4 tells us our final answer.
 
 Note that a loop variable is just a variable that's being used to record progress in a loop.
 It still exists after the loop is over,
@@ -162,8 +162,8 @@ and we can re-use variables previously defined as loop variables as well:
 ~~~ {.python}
 letter = 'z'
 for letter in 'abc':
-    print letter
-print 'after the loop, letter is', letter
+    print(letter)
+print('after the loop, letter is', letter)
 ~~~
 
 ~~~ {.output}
@@ -177,7 +177,7 @@ Note also that finding the length of a string is such a common operation
 that Python actually has a built-in function to do it called `len`:
 
 ~~~ {.python}
-print len('aeiou')
+print(len('aeiou'))
 ~~~
 
 ~~~ {.output}
@@ -213,7 +213,7 @@ so we should always use it when we can.
 > Exponentiation is built into Python:
 >
 > ~~~ {.python}
-> print 5**3
+> print(5**3)
 > 125
 > ~~~
 >

--- a/03-lists.html
+++ b/03-lists.html
@@ -41,23 +41,23 @@
 </section>
 <p>Just as a <code>for</code> loop is a way to do operations many times, a list is a way to store many values. Unlike NumPy arrays, lists are built into the language (so we don’t have to load a library to use them). We create a list by putting values inside square brackets:</p>
 <pre class="sourceCode python"><code class="sourceCode python">odds = [<span class="dv">1</span>, <span class="dv">3</span>, <span class="dv">5</span>, <span class="dv">7</span>]
-<span class="dt">print</span> <span class="st">&#39;odds are:&#39;</span>, odds</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;odds are:&#39;</span>, odds)</code></pre>
 <pre class="output"><code>odds are: [1, 3, 5, 7]</code></pre>
 <p>We select individual elements from lists by indexing them:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;first and last:&#39;</span>, odds[<span class="dv">0</span>], odds[-<span class="dv">1</span>]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;first and last:&#39;</span>, odds[<span class="dv">0</span>], odds[-<span class="dv">1</span>])</code></pre>
 <pre class="output"><code>first and last: 1 7</code></pre>
 <p>and if we loop over a list, the loop variable is assigned elements one at a time:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">for</span> number in odds:
-    <span class="dt">print</span> number</code></pre>
+    <span class="dt">print</span>(number)</code></pre>
 <pre class="output"><code>1
 3
 5
 7</code></pre>
 <p>There is one important difference between lists and strings: we can change the values in a list, but we cannot change the characters in a string. For example:</p>
 <pre class="sourceCode python"><code class="sourceCode python">names = [<span class="st">&#39;Newton&#39;</span>, <span class="st">&#39;Darwing&#39;</span>, <span class="st">&#39;Turing&#39;</span>] <span class="co"># typo in Darwin&#39;s name</span>
-<span class="dt">print</span> <span class="st">&#39;names is originally:&#39;</span>, names
+<span class="dt">print</span>(<span class="st">&#39;names is originally:&#39;</span>, names)
 names[<span class="dv">1</span>] = <span class="st">&#39;Darwin&#39;</span> <span class="co"># correct the name</span>
-<span class="dt">print</span> <span class="st">&#39;final value of names:&#39;</span>, names</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;final value of names:&#39;</span>, names)</code></pre>
 <pre class="output"><code>names is originally: [&#39;Newton&#39;, &#39;Darwing&#39;, &#39;Turing&#39;]
 final value of names: [&#39;Newton&#39;, &#39;Darwin&#39;, &#39;Turing&#39;]</code></pre>
 <p>works, but:</p>
@@ -82,13 +82,13 @@ TypeError: &#39;str&#39; object does not support item assignment</code></pre>
 </aside>
 <p>There are many ways to change the contents of lists besides assigning new values to individual elements:</p>
 <pre class="sourceCode python"><code class="sourceCode python">odds.append(<span class="dv">11</span>)
-<span class="dt">print</span> <span class="st">&#39;odds after adding a value:&#39;</span>, odds</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;odds after adding a value:&#39;</span>, odds)</code></pre>
 <pre class="output"><code>[1, 3, 5, 7, 11]</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">del</span> odds[<span class="dv">0</span>]
-<span class="dt">print</span> <span class="st">&#39;odds after removing the first element:&#39;</span>, odds</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;odds after removing the first element:&#39;</span>, odds)</code></pre>
 <pre class="output"><code>[3, 5, 7, 11]</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python">odds.reverse()
-<span class="dt">print</span> <span class="st">&#39;odds after reversing:&#39;</span>, odds</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;odds after reversing:&#39;</span>, odds)</code></pre>
 <pre class="output"><code>[11, 7, 5, 3]</code></pre>
         </div>
       </div>

--- a/03-lists.md
+++ b/03-lists.md
@@ -18,7 +18,7 @@ We create a list by putting values inside square brackets:
 
 ~~~ {.python}
 odds = [1, 3, 5, 7]
-print 'odds are:', odds
+print('odds are:', odds)
 ~~~
 
 ~~~ {.output}
@@ -28,7 +28,7 @@ odds are: [1, 3, 5, 7]
 We select individual elements from lists by indexing them:
 
 ~~~ {.python}
-print 'first and last:', odds[0], odds[-1]
+print('first and last:', odds[0], odds[-1])
 ~~~
 
 ~~~ {.output}
@@ -40,7 +40,7 @@ the loop variable is assigned elements one at a time:
 
 ~~~ {.python}
 for number in odds:
-    print number
+    print(number)
 ~~~
 
 ~~~ {.output}
@@ -57,9 +57,9 @@ For example:
 
 ~~~ {.python}
 names = ['Newton', 'Darwing', 'Turing'] # typo in Darwin's name
-print 'names is originally:', names
+print('names is originally:', names)
 names[1] = 'Darwin' # correct the name
-print 'final value of names:', names
+print('final value of names:', names)
 ~~~
 
 ~~~ {.output}
@@ -111,7 +111,7 @@ individual elements:
 
 ~~~ {.python}
 odds.append(11)
-print 'odds after adding a value:', odds
+print('odds after adding a value:', odds)
 ~~~
 ~~~ {.output}
 [1, 3, 5, 7, 11]
@@ -119,7 +119,7 @@ print 'odds after adding a value:', odds
 
 ~~~ {.python}
 del odds[0]
-print 'odds after removing the first element:', odds
+print('odds after removing the first element:', odds)
 ~~~
 ~~~ {.output}
 [3, 5, 7, 11]
@@ -127,7 +127,7 @@ print 'odds after removing the first element:', odds
 
 ~~~ {.python}
 odds.reverse()
-print 'odds after reversing:', odds
+print('odds after reversing:', odds)
 ~~~
 ~~~ {.output}
 [11, 7, 5, 3]

--- a/04-files.html
+++ b/04-files.html
@@ -42,17 +42,20 @@
 <p>We now have almost everything we need to process all our data files. The only thing that’s missing is a library with a rather unpleasant name:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> glob</code></pre>
 <p>The <code>glob</code> library contains a single function, also called <code>glob</code>, that finds files whose names match a pattern. We provide those patterns as strings: the character <code>*</code> matches zero or more characters, while <code>?</code> matches any one character. We can use this to get the names of all the html files:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> glob.glob(<span class="st">&#39;*.html&#39;</span>)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(glob.glob(<span class="st">&#39;*.html&#39;</span>))</code></pre>
 <pre class="output"><code>[&#39;01-numpy.html&#39;, &#39;02-loop.html&#39;, &#39;03-lists.html&#39;, &#39;04-files.html&#39;, &#39;05-cond.html&#39;, &#39;06-func.html&#39;, &#39;07-errors.html&#39;, &#39;08-defensive.html&#39;, &#39;09-debugging.html&#39;, &#39;10-cmdline.html&#39;, &#39;index.html&#39;, &#39;LICENSE.html&#39;, &#39;instructors.html&#39;, &#39;README.html&#39;, &#39;discussion.html&#39;, &#39;reference.html&#39;]</code></pre>
 <p>As these examples show, <code>glob.glob</code>’s result is a list of strings, which means we can loop over it to do something with each filename in turn. In our case, the “something” we want to do is generate a set of plots for each file in our inflammation dataset. Let’s test it by analyzing the first three files in the list:</p>
-<pre class="sourceCode python"><code class="sourceCode python">filenames = glob.glob(<span class="st">&#39;*.csv&#39;</span>)
+<pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> numpy
+<span class="ch">import</span> matplotlib.pyplot
+
+filenames = glob.glob(<span class="st">&#39;*.csv&#39;</span>)
 filenames = filenames[<span class="dv">0</span>:<span class="dv">3</span>]
 <span class="kw">for</span> f in filenames:
-    <span class="dt">print</span> f
+    <span class="dt">print</span>(f)
 
-    data = np.loadtxt(fname=f, delimiter=<span class="st">&#39;,&#39;</span>)
+    data = numpy.loadtxt(fname=f, delimiter=<span class="st">&#39;,&#39;</span>)
 
-    fig = plt.figure(figsize=(<span class="fl">10.0</span>, <span class="fl">3.0</span>))
+    fig = matplotlib.pyplot.figure(figsize=(<span class="fl">10.0</span>, <span class="fl">3.0</span>))
 
     axes1 = fig.add_subplot(<span class="dv">1</span>, <span class="dv">3</span>, <span class="dv">1</span>)
     axes2 = fig.add_subplot(<span class="dv">1</span>, <span class="dv">3</span>, <span class="dv">2</span>)

--- a/04-files.md
+++ b/04-files.md
@@ -24,7 +24,7 @@ while `?` matches any one character.
 We can use this to get the names of all the html files:
 
 ~~~ {.python}
-print glob.glob('*.html')
+print(glob.glob('*.html'))
 ~~~
 
 ~~~ {.output}
@@ -46,7 +46,7 @@ import matplotlib.pyplot
 filenames = glob.glob('*.csv')
 filenames = filenames[0:3]
 for f in filenames:
-    print f
+    print(f)
 
     data = numpy.loadtxt(fname=f, delimiter=',')
 

--- a/05-cond.html
+++ b/05-cond.html
@@ -45,69 +45,69 @@
 <p>We can ask Python to take different actions, depending on a condition, with an if statement:</p>
 <pre class="sourceCode python"><code class="sourceCode python">num = <span class="dv">37</span>
 <span class="kw">if</span> num &gt; <span class="dv">100</span>:
-    <span class="dt">print</span> <span class="st">&#39;greater&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;greater&#39;</span>)
 <span class="kw">else</span>:
-    <span class="dt">print</span> <span class="st">&#39;not greater&#39;</span>
-<span class="dt">print</span> <span class="st">&#39;done&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;not greater&#39;</span>)
+<span class="dt">print</span>(<span class="st">&#39;done&#39;</span>)</code></pre>
 <pre class="output"><code>not greater
 done
 </code></pre>
 <p>The second line of this code uses the keyword <code>if</code> to tell Python that we want to make a choice. If the test that follows the <code>if</code> statement is true, the body of the <code>if</code> (i.e., the lines indented underneath it) are executed. If the test is false, the body of the <code>else</code> is executed instead. Only one or the other is ever executed:</p>
 <p><img src="fig/python-flowchart-conditional.svg" alt="Executing a Conditional" /><br /> Conditional statements don’t have to include an <code>else</code>. If there isn’t one, Python simply does nothing if the test is false:</p>
 <pre class="sourceCode python"><code class="sourceCode python">num = <span class="dv">53</span>
-<span class="dt">print</span> <span class="st">&#39;before conditional...&#39;</span>
+<span class="dt">print</span>(<span class="st">&#39;before conditional...&#39;</span>)
 <span class="kw">if</span> num &gt; <span class="dv">100</span>:
-    <span class="dt">print</span> <span class="st">&#39;53 is greater than 100&#39;</span>
-<span class="dt">print</span> <span class="st">&#39;...after conditional&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;53 is greater than 100&#39;</span>)
+<span class="dt">print</span>(<span class="st">&#39;...after conditional&#39;</span>)</code></pre>
 <pre class="output"><code>before conditional...
 ...after conditional</code></pre>
 <p>We can also chain several tests together using <code>elif</code>, which is short for “else if”. The following Python code uses <code>elif</code> to print the sign of a number.</p>
 <pre class="sourceCode python"><code class="sourceCode python">num = -<span class="dv">3</span>
 
 <span class="kw">if</span> num &gt; <span class="dv">0</span>:
-    <span class="dt">print</span> num, <span class="st">&quot;is positive&quot;</span>
+    <span class="dt">print</span>(num, <span class="st">&quot;is positive&quot;</span>)
 <span class="kw">elif</span> num == <span class="dv">0</span>:
-    <span class="dt">print</span> num, <span class="st">&quot;is zero&quot;</span>
+    <span class="dt">print</span>(num, <span class="st">&quot;is zero&quot;</span>)
 <span class="kw">else</span>:
-    <span class="dt">print</span> num, <span class="st">&quot;is negative&quot;</span></code></pre>
+    <span class="dt">print</span>(num, <span class="st">&quot;is negative&quot;</span>)</code></pre>
 <pre class="output"><code>&quot;-3 is negative&quot;</code></pre>
 <p>One important thing to notice in the code above is that we use a double equals sign <code>==</code> to test for equality rather than a single equals sign because the latter is used to mean assignment.</p>
 <p>We can also combine tests using <code>and</code> and <code>or</code>. <code>and</code> is only true if both parts are true:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> (<span class="dv">1</span> &gt; <span class="dv">0</span>) and (-<span class="dv">1</span> &gt; <span class="dv">0</span>):
-    <span class="dt">print</span> <span class="st">&#39;both parts are true&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;both parts are true&#39;</span>)
 <span class="kw">else</span>:
-    <span class="dt">print</span> <span class="st">&#39;one part is not true&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;one part is not true&#39;</span>)</code></pre>
 <pre class="output"><code>one part is not true</code></pre>
 <p>while <code>or</code> is true if at least one part is true:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> (<span class="dv">1</span> &lt; <span class="dv">0</span>) or (-<span class="dv">1</span> &lt; <span class="dv">0</span>):
-    <span class="dt">print</span> <span class="st">&#39;at least one test is true&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;at least one test is true&#39;</span>)</code></pre>
 <pre class="output"><code>at least one test is true</code></pre>
 <h2 id="checking-our-data">Checking our Data</h2>
 <p>Now that we’ve seen how conditionals work, we can use them to check for the suspicious features we saw in our inflammation data. In the first couple of plots, the maximum inflammation per day seemed to rise like a straight line, one unit per day. We can check for this inside the <code>for</code> loop we wrote with the following conditional:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> data.<span class="dt">min</span>(axis=<span class="dv">0</span>)[<span class="dv">0</span>] == <span class="dv">0</span> and data.<span class="dt">max</span>(axis=<span class="dv">0</span>)[<span class="dv">20</span>] == <span class="dv">20</span>:
-    <span class="dt">print</span> <span class="st">&#39;Suspicious looking maxima!&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;Suspicious looking maxima!&#39;</span>)</code></pre>
 <p>We also saw a different problem in the third dataset; the minima per day were all zero (looks like a healthy person snuck into our study). We can also check for this with an <code>elif</code> condition:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">elif</span> data.<span class="dt">min</span>(axis=<span class="dv">0</span>).<span class="dt">sum</span>() == <span class="dv">0</span>:
-    <span class="dt">print</span> <span class="st">&#39;Minima add up to zero!&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;Minima add up to zero!&#39;</span>)</code></pre>
 <p>And if neither of these conditions are true, we can use <code>else</code> to give the all-clear:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">else</span>:
-    <span class="dt">print</span> <span class="st">&#39;Seems OK!&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;Seems OK!&#39;</span>)</code></pre>
 <p>Let’s test that out:</p>
 <pre class="sourceCode python"><code class="sourceCode python">data = numpy.loadtxt(fname=<span class="st">&#39;inflammation-01.csv&#39;</span>, delimiter=<span class="st">&#39;,&#39;</span>)
 <span class="kw">if</span> data.<span class="dt">max</span>(axis=<span class="dv">0</span>)[<span class="dv">0</span>] == <span class="dv">0</span> and data.<span class="dt">max</span>(axis=<span class="dv">0</span>)[<span class="dv">20</span>] == <span class="dv">20</span>:
-    <span class="dt">print</span> <span class="st">&#39;Suspicious looking maxima!&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;Suspicious looking maxima!&#39;</span>)
 <span class="kw">elif</span> data.<span class="dt">min</span>(axis=<span class="dv">0</span>).<span class="dt">sum</span>() == <span class="dv">0</span>:
-    <span class="dt">print</span> <span class="st">&#39;Minima add up to zero!&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;Minima add up to zero!&#39;</span>)
 <span class="kw">else</span>:
-    <span class="dt">print</span> <span class="st">&#39;Seems OK!&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;Seems OK!&#39;</span>)</code></pre>
 <pre class="output"><code>Suspicious looking maxima!</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python">data = numpy.loadtxt(fname=<span class="st">&#39;inflammation-03.csv&#39;</span>, delimiter=<span class="st">&#39;,&#39;</span>)
 <span class="kw">if</span> data.<span class="dt">max</span>(axis=<span class="dv">0</span>)[<span class="dv">0</span>] == <span class="dv">0</span> and data.<span class="dt">max</span>(axis=<span class="dv">0</span>)[<span class="dv">20</span>] == <span class="dv">20</span>:
-    <span class="dt">print</span> <span class="st">&#39;Suspicious looking maxima!&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;Suspicious looking maxima!&#39;</span>)
 <span class="kw">elif</span> data.<span class="dt">min</span>(axis=<span class="dv">0</span>).<span class="dt">sum</span>() == <span class="dv">0</span>:
-    <span class="dt">print</span> <span class="st">&#39;Minima add up to zero!&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;Minima add up to zero!&#39;</span>)
 <span class="kw">else</span>:
-    <span class="dt">print</span> <span class="st">&#39;Seems OK!&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;Seems OK!&#39;</span>)</code></pre>
 <pre class="output"><code>Minima add up to zero!</code></pre>
 <p>In this way, we have asked Python to do something different depending on the condition of our data. Here we printed messages in all cases, but we could also imagine not using the <code>else</code> catch-all so that messages are only printed when something is wrong, freeing us from having to manually examine every plot for features we’ve seen before.</p>
 <section class="challenge panel panel-success">
@@ -116,13 +116,18 @@ done
 </div>
 <div class="panel-body">
 <p>Which of the following would be printed if you were to run this code? Why did you pick this answer?</p>
-<p>A B C B and C</p>
+<ol style="list-style-type: decimal">
+<li>A</li>
+<li>B</li>
+<li>C</li>
+<li>B and C</li>
+</ol>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> <span class="dv">4</span> &gt; <span class="dv">5</span>:
-    <span class="dt">print</span> <span class="st">&#39;A&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;A&#39;</span>)
 <span class="kw">elif</span> <span class="dv">4</span> == <span class="dv">5</span>:
-    <span class="dt">print</span> <span class="st">&#39;B&#39;</span>
+    <span class="dt">print</span>(<span class="st">&#39;B&#39;</span>)
 <span class="kw">elif</span> <span class="dv">4</span> &lt; <span class="dv">5</span>:
-    <span class="dt">print</span> <span class="st">&#39;C&#39;</span></code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;C&#39;</span>)</code></pre>
 </div>
 </section>
 <section class="challenge panel panel-success">
@@ -131,12 +136,12 @@ done
 </div>
 <div class="panel-body">
 <p><code>True</code> and <code>False</code> are special words in Python called <code>booleans</code> which represent true and false statements. However, they aren’t the only values in Python that are true and false. In fact, <em>any</em> value can be used in an <code>if</code> or <code>elif</code>. After reading and running the code below, explain what the rule is for which values are considered true and which are considered false. (Note that if the body of a conditional is a single statement, we can write it on the same line as the <code>if</code>.)</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> <span class="st">&#39;&#39;</span>: <span class="dt">print</span> <span class="st">&#39;empty string is true&#39;</span>
-<span class="kw">if</span> <span class="st">&#39;word&#39;</span>: <span class="dt">print</span> <span class="st">&#39;word is true&#39;</span>
-<span class="kw">if</span> []: <span class="dt">print</span> <span class="st">&#39;empty list is true&#39;</span>
-<span class="kw">if</span> [<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>]: <span class="dt">print</span> <span class="st">&#39;non-empty list is true&#39;</span>
-<span class="kw">if</span> <span class="dv">0</span>: <span class="dt">print</span> <span class="st">&#39;zero is true&#39;</span>
-<span class="kw">if</span> <span class="dv">1</span>: <span class="dt">print</span> <span class="st">&#39;one is true&#39;</span></code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">if</span> <span class="st">&#39;&#39;</span>: <span class="dt">print</span>(<span class="st">&#39;empty string is true&#39;</span>)
+<span class="kw">if</span> <span class="st">&#39;word&#39;</span>: <span class="dt">print</span>(<span class="st">&#39;word is true&#39;</span>)
+<span class="kw">if</span> []: <span class="dt">print</span>(<span class="st">&#39;empty list is true&#39;</span>)
+<span class="kw">if</span> [<span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">3</span>]: <span class="dt">print</span>(<span class="st">&#39;non-empty list is true&#39;</span>)
+<span class="kw">if</span> <span class="dv">0</span>: <span class="dt">print</span>(<span class="st">&#39;zero is true&#39;</span>)
+<span class="kw">if</span> <span class="dv">1</span>: <span class="dt">print</span>(<span class="st">&#39;one is true&#39;</span>)</code></pre>
 </div>
 </section>
 <section class="challenge panel panel-success">
@@ -156,7 +161,7 @@ done
 <pre class="sourceCode python"><code class="sourceCode python">x = <span class="dv">1</span>  <span class="co"># original value</span>
 x += <span class="dv">1</span> <span class="co"># add one to x, assigning result back to x</span>
 x *= <span class="dv">3</span> <span class="co"># multiply x by 3</span>
-<span class="dt">print</span> x</code></pre>
+<span class="dt">print</span>(x)</code></pre>
 <pre class="output"><code>6</code></pre>
 <p>Write some code that sums the positive and negative numbers in a list separately, using in-place operators. Do you think the result is more or less readable than writing the same without in-place operators?</p>
 </div>

--- a/05-cond.md
+++ b/05-cond.md
@@ -23,10 +23,10 @@ We can ask Python to take different actions, depending on a condition, with an i
 ~~~ {.python}
 num = 37
 if num > 100:
-    print 'greater'
+    print('greater')
 else:
-    print 'not greater'
-print 'done'
+    print('not greater')
+print('done')
 ~~~
 ~~~ {.output}
 not greater
@@ -50,10 +50,10 @@ Python simply does nothing if the test is false:
 
 ~~~ {.python}
 num = 53
-print 'before conditional...'
+print('before conditional...')
 if num > 100:
-    print '53 is greater than 100'
-print '...after conditional'
+    print('53 is greater than 100')
+print('...after conditional')
 ~~~
 ~~~ {.output}
 before conditional...
@@ -68,11 +68,11 @@ The following Python code uses `elif` to print the sign of a number.
 num = -3
 
 if num > 0:
-    print num, "is positive"
+    print(num, "is positive")
 elif num == 0:
-    print num, "is zero"
+    print(num, "is zero")
 else:
-    print num, "is negative"
+    print(num, "is negative")
 ~~~
 ~~~ {.output}
 "-3 is negative"
@@ -87,9 +87,9 @@ We can also combine tests using `and` and `or`.
 
 ~~~ {.python}
 if (1 > 0) and (-1 > 0):
-    print 'both parts are true'
+    print('both parts are true')
 else:
-    print 'one part is not true'
+    print('one part is not true')
 ~~~
 ~~~ {.output}
 one part is not true
@@ -99,7 +99,7 @@ while `or` is true if at least one part is true:
 
 ~~~ {.python}
 if (1 < 0) or (-1 < 0):
-    print 'at least one test is true'
+    print('at least one test is true')
 ~~~
 ~~~ {.output}
 at least one test is true
@@ -115,7 +115,7 @@ We can check for this inside the `for` loop we wrote with the following conditio
 
 ~~~ {.python}
 if data.min(axis=0)[0] == 0 and data.max(axis=0)[20] == 20:
-    print 'Suspicious looking maxima!'
+    print('Suspicious looking maxima!')
 ~~~
 
 We also saw a different problem in the third dataset;
@@ -124,14 +124,14 @@ We can also check for this with an `elif` condition:
 
 ~~~{.python}
 elif data.min(axis=0).sum() == 0:
-    print 'Minima add up to zero!'
+    print('Minima add up to zero!')
 ~~~
 
 And if neither of these conditions are true, we can use `else` to give the all-clear:
 
 ~~~ {.python}
 else:
-    print 'Seems OK!'
+    print('Seems OK!')
 ~~~
 
 Let's test that out:
@@ -139,11 +139,11 @@ Let's test that out:
 ~~~ {.python}
 data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 if data.max(axis=0)[0] == 0 and data.max(axis=0)[20] == 20:
-    print 'Suspicious looking maxima!'
+    print('Suspicious looking maxima!')
 elif data.min(axis=0).sum() == 0:
-    print 'Minima add up to zero!'
+    print('Minima add up to zero!')
 else:
-    print 'Seems OK!'
+    print('Seems OK!')
 ~~~
 
 ~~~ {.output}
@@ -153,11 +153,11 @@ Suspicious looking maxima!
 ~~~ {.python}
 data = numpy.loadtxt(fname='inflammation-03.csv', delimiter=',')
 if data.max(axis=0)[0] == 0 and data.max(axis=0)[20] == 20:
-    print 'Suspicious looking maxima!'
+    print('Suspicious looking maxima!')
 elif data.min(axis=0).sum() == 0:
-    print 'Minima add up to zero!'
+    print('Minima add up to zero!')
 else:
-    print 'Seems OK!'
+    print('Seems OK!')
 ~~~
 
 ~~~ {.output}
@@ -182,11 +182,11 @@ freeing us from having to manually examine every plot for features we've seen be
 >
 > ~~~ {.python}
 > if 4 > 5:
->     print 'A'
+>     print('A')
 > elif 4 == 5:
->     print 'B'
+>     print('B')
 > elif 4 < 5:
->     print 'C'
+>     print('C')
 > ~~~
 
 > ## What is truth? {.challenge}
@@ -199,12 +199,12 @@ and false statements. However, they aren't the only values in Python that are tr
 > (Note that if the body of a conditional is a single statement, we can write it on the same line as the `if`.)
 >
 > ~~~ {.python}
-> if '': print 'empty string is true'
-> if 'word': print 'word is true'
-> if []: print 'empty list is true'
-> if [1, 2, 3]: print 'non-empty list is true'
-> if 0: print 'zero is true'
-> if 1: print 'one is true'
+> if '': print('empty string is true')
+> if 'word': print('word is true')
+> if []: print('empty list is true')
+> if [1, 2, 3]: print('non-empty list is true')
+> if 0: print('zero is true')
+> if 1: print('one is true')
 > ~~~
 
 > ## Close enough {.challenge}
@@ -224,7 +224,7 @@ and false statements. However, they aren't the only values in Python that are tr
 > x = 1  # original value
 > x += 1 # add one to x, assigning result back to x
 > x *= 3 # multiply x by 3
-> print x
+> print(x)
 > ~~~
 > ~~~ {.output}
 > 6

--- a/06-func.html
+++ b/06-func.html
@@ -49,8 +49,8 @@
 <p>The function definition opens with the word <code>def</code>, which is followed by the name of the function and a parenthesized list of parameter names. The <a href="reference.html#function-body">body</a> of the function — the statements that are executed when it runs — is indented below the definition line, typically by four spaces.</p>
 <p>When we call the function, the values we pass to it are assigned to those variables so that we can use them inside the function. Inside the function, we use a <a href="reference.html#return-statement">return statement</a> to send a result back to whoever asked for it.</p>
 <p>Let’s try running our function. Calling our own function is no different from calling any other function:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;freezing point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">32</span>)
-<span class="dt">print</span> <span class="st">&#39;boiling point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">212</span>)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;freezing point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">32</span>))
+<span class="dt">print</span>(<span class="st">&#39;boiling point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">212</span>))</code></pre>
 <pre class="output"><code>freezing point of water: 273.15
 boiling point of water: 273.15</code></pre>
 <p>We’ve successfully called the function that we defined, and we have access to the value that we returned. Unfortunately, the value returned doesn’t look right. What went wrong?</p>
@@ -58,36 +58,36 @@ boiling point of water: 273.15</code></pre>
 <p><em>Debugging</em> is when we fix a piece of code that we know is working incorrectly. In this case, we know that <code>fahr_to_kelvin</code> is giving us the wrong answer, so let’s find out why.</p>
 <p>For big pieces of code, there are tools called <em>debuggers</em> that aid in this process. Since we just have a short function, we’ll debug by choosing some parameter value, breaking our function into small parts, and printing out the value of each part.</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="co"># We&#39;ll use temp = 212, the boiling point of water, which was incorrect</span>
-<span class="dt">print</span> <span class="st">&quot;212 - 32:&quot;</span>, <span class="dv">212</span> - <span class="dv">32</span></code></pre>
+<span class="dt">print</span>(<span class="st">&quot;212 - 32:&quot;</span>, <span class="dv">212</span> - <span class="dv">32</span>)</code></pre>
 <pre class="output"><code>212 - 32: 180</code></pre>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&quot;(212 - 32) * (5/9):&quot;</span>, (<span class="dv">212</span> - <span class="dv">32</span>) * (<span class="dv">5</span>/<span class="dv">9</span>)</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&quot;(212 - 32) * (5/9):&quot;</span>, (<span class="dv">212</span> - <span class="dv">32</span>) * (<span class="dv">5</span>/<span class="dv">9</span>))</code></pre>
 <pre class="output"><code>(212 - 32) * (5/9): 0</code></pre>
 <p>Aha! The problem comes when we multiply by <code>5/9</code>. This is because <code>5/9</code> is actually 0.</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="dv">5</span>/<span class="dv">9</span></code></pre>
 <pre class="output"><code>0</code></pre>
 <p>Computers store numbers in one of two ways: as <a href="reference.html#integer">integers</a> or as <a href="reference.html#floating-point-number">floating-point numbers</a> (or floats). The first are the numbers we usually count with; the second have fractional parts. Addition, subtraction and multiplication work on both as we’d expect, but division works differently. If we divide one integer by another, we get the quotient without the remainder:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;10/3 is:&#39;</span>, <span class="dv">10</span>/<span class="dv">3</span></code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;10/3 is:&#39;</span>, <span class="dv">10</span>/<span class="dv">3</span>)</code></pre>
 <pre class="output"><code>10/3 is: 3</code></pre>
 <p>If either part of the division is a float, on the other hand, the computer creates a floating-point answer:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;10.0/3 is:&#39;</span>, <span class="fl">10.0</span>/<span class="dv">3</span></code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;10.0/3 is:&#39;</span>, <span class="fl">10.0</span>/<span class="dv">3</span>)</code></pre>
 <pre class="output"><code>10.0/3 is: 3.33333333333</code></pre>
 <p>The computer does this for historical reasons: integer operations were much faster on early machines, and this behavior is actually useful in a lot of situations. It’s still confusing, though, so Python 3 produces a floating-point answer when dividing integers if it needs to. We’re still using Python 2.7 in this class, though, so if we want <code>5/9</code> to give us the right answer, we have to write it as <code>5.0/9</code>, <code>5/9.0</code>, or some other variation.</p>
 <p>Another way to create a floating-point answer is to explicitly tell the computer that you desire one. This is achieved by <a href="reference.html#typecast">casting</a> one of the numbers:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;float(10)/3 is:&#39;</span>, <span class="dt">float</span>(<span class="dv">10</span>)/<span class="dv">3</span></code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;float(10)/3 is:&#39;</span>, <span class="dt">float</span>(<span class="dv">10</span>)/<span class="dv">3</span>)</code></pre>
 <pre class="output"><code>float(10)/3 is: 3.33333333333</code></pre>
 <p>The advantage to this method is it can be used with existing variables. Let’s take a look:</p>
 <pre class="sourceCode python"><code class="sourceCode python">a = <span class="dv">10</span>
 b = <span class="dv">3</span>
-<span class="dt">print</span> <span class="st">&#39;a/b is:&#39;</span>, a/b
-<span class="dt">print</span> <span class="st">&#39;float(a)/b is:&#39;</span>, <span class="dt">float</span>(a)/b</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;a/b is:&#39;</span>, a/b)
+<span class="dt">print</span>(<span class="st">&#39;float(a)/b is:&#39;</span>, <span class="dt">float</span>(a)/b)</code></pre>
 <pre class="output"><code>a/b is: 3
 float(a)/b is: 3.33333333333</code></pre>
 <p>Let’s fix our <code>fahr_to_kelvin</code> function with this new knowledge:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> fahr_to_kelvin(temp):
     <span class="kw">return</span> ((temp - <span class="dv">32</span>) * (<span class="fl">5.0</span>/<span class="fl">9.0</span>)) + <span class="fl">273.15</span>
 
-<span class="dt">print</span> <span class="st">&#39;freezing point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">32</span>)
-<span class="dt">print</span> <span class="st">&#39;boiling point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">212</span>)</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;freezing point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">32</span>))
+<span class="dt">print</span>(<span class="st">&#39;boiling point of water:&#39;</span>, fahr_to_kelvin(<span class="dv">212</span>))</code></pre>
 <pre class="output"><code>freezing point of water: 273.15
 boiling point of water: 373.15</code></pre>
 <h2 id="composing-functions">Composing Functions</h2>
@@ -95,7 +95,7 @@ boiling point of water: 373.15</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> kelvin_to_celsius(temp):
     <span class="kw">return</span> temp - <span class="fl">273.15</span>
 
-<span class="dt">print</span> <span class="st">&#39;absolute zero in Celsius:&#39;</span>, kelvin_to_celsius(<span class="fl">0.0</span>)</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;absolute zero in Celsius:&#39;</span>, kelvin_to_celsius(<span class="fl">0.0</span>))</code></pre>
 <pre class="output"><code>absolute zero in Celsius: -273.15</code></pre>
 <p>What about converting Fahrenheit to Celsius? We could write out the formula, but we don’t need to. Instead, we can <a href="reference.html#function-composition">compose</a> the two functions we have already created:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> fahr_to_celsius(temp):
@@ -103,7 +103,7 @@ boiling point of water: 373.15</code></pre>
     result = kelvin_to_celsius(temp_k)
     <span class="kw">return</span> result
 
-<span class="dt">print</span> <span class="st">&#39;freezing point of water in Celsius:&#39;</span>, fahr_to_celsius(<span class="fl">32.0</span>)</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;freezing point of water in Celsius:&#39;</span>, fahr_to_celsius(<span class="fl">32.0</span>))</code></pre>
 <pre class="output"><code>freezing point of water in Celsius: 0.0</code></pre>
 <p>This is our first taste of how larger programs are built: we define basic operations, then combine them in ever-large chunks to get the effect we want. Real-life functions will usually be larger than the ones shown here — typically half a dozen to a few dozen lines — but they shouldn’t ever be much longer than that, or the next person who reads it won’t be able to understand what’s going on.</p>
 <h2 id="tidying-up">Tidying up</h2>
@@ -135,14 +135,14 @@ boiling point of water: 373.15</code></pre>
     data = np.loadtxt(fname=filename, delimiter=<span class="st">&#39;,&#39;</span>)
 
     <span class="kw">if</span> data.<span class="dt">max</span>(axis=<span class="dv">0</span>)[<span class="dv">0</span>] == <span class="dv">0</span> and data.<span class="dt">max</span>(axis=<span class="dv">0</span>)[<span class="dv">20</span>] == <span class="dv">20</span>:
-        <span class="dt">print</span> <span class="st">&#39;Suspicious looking maxima!&#39;</span>
+        <span class="dt">print</span>(<span class="st">&#39;Suspicious looking maxima!&#39;</span>)
     <span class="kw">elif</span> data.<span class="dt">min</span>(axis=<span class="dv">0</span>).<span class="dt">sum</span>() == <span class="dv">0</span>:
-        <span class="dt">print</span> <span class="st">&#39;Minima add up to zero!&#39;</span>
+        <span class="dt">print</span>(<span class="st">&#39;Minima add up to zero!&#39;</span>)
     <span class="kw">else</span>:
-        <span class="dt">print</span> <span class="st">&#39;Seems OK!&#39;</span></code></pre>
+        <span class="dt">print</span>(<span class="st">&#39;Seems OK!&#39;</span>)</code></pre>
 <p>Notice that rather than jumbling this code together in one giant <code>for</code> loop, we can now read and reuse both ideas separately. We can reproduce the previous analysis with a much simpler <code>for</code> loop:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">for</span> f in filenames[:<span class="dv">3</span>]:
-    <span class="dt">print</span> f
+    <span class="dt">print</span>(f)
     analyze(f)
     detectProblems(f)</code></pre>
 <p>By giving our functions human-readable names, we can more easily read and understand what is happening in the <code>for</code> loop. Even better, if at some later date we want to use either of those pieces of code again, we can do so in a single line.</p>
@@ -152,12 +152,12 @@ boiling point of water: 373.15</code></pre>
     <span class="kw">return</span> (data - data.mean()) + desired</code></pre>
 <p>We could test this on our actual data, but since we don’t know what the values ought to be, it will be hard to tell if the result was correct. Instead, let’s use NumPy to create a matrix of 0’s and then center that around 3:</p>
 <pre class="sourceCode python"><code class="sourceCode python">z = numpy.zeros((<span class="dv">2</span>,<span class="dv">2</span>))
-<span class="dt">print</span> center(z, <span class="dv">3</span>)</code></pre>
+<span class="dt">print</span>(center(z, <span class="dv">3</span>))</code></pre>
 <pre class="output"><code>[[ 3.  3.]
  [ 3.  3.]]</code></pre>
 <p>That looks right, so let’s try <code>center</code> on our real data:</p>
 <pre class="sourceCode python"><code class="sourceCode python">data = numpy.loadtxt(fname=<span class="st">&#39;inflammation-01.csv&#39;</span>, delimiter=<span class="st">&#39;,&#39;</span>)
-<span class="dt">print</span> center(data, <span class="dv">0</span>)</code></pre>
+<span class="dt">print</span>(center(data, <span class="dv">0</span>))</code></pre>
 <pre class="output"><code>[[-6.14875 -6.14875 -5.14875 ..., -3.14875 -6.14875 -6.14875]
  [-6.14875 -5.14875 -4.14875 ..., -5.14875 -6.14875 -5.14875]
  [-6.14875 -5.14875 -5.14875 ..., -4.14875 -5.14875 -5.14875]
@@ -166,16 +166,16 @@ boiling point of water: 373.15</code></pre>
  [-6.14875 -6.14875 -6.14875 ..., -6.14875 -4.14875 -6.14875]
  [-6.14875 -6.14875 -5.14875 ..., -5.14875 -5.14875 -6.14875]]</code></pre>
 <p>It’s hard to tell from the default output whether the result is correct, but there are a few simple tests that will reassure us:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;original min, mean, and max are:&#39;</span>, data.<span class="dt">min</span>(), data.mean(), data.<span class="dt">max</span>()
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;original min, mean, and max are:&#39;</span>, data.<span class="dt">min</span>(), data.mean(), data.<span class="dt">max</span>())
 centered = center(data, <span class="dv">0</span>)
-<span class="dt">print</span> <span class="st">&#39;min, mean, and and max of centered data are:&#39;</span>, centered.<span class="dt">min</span>(), centered.mean(), centered.<span class="dt">max</span>()</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;min, mean, and and max of centered data are:&#39;</span>, centered.<span class="dt">min</span>(), centered.mean(), centered.<span class="dt">max</span>())</code></pre>
 <pre class="output"><code>original min, mean, and max are: 0.0 6.14875 20.0
 min, mean, and and max of centered data are: -6.14875 -3.49054118942e-15 13.85125</code></pre>
 <p>That seems almost right: the original mean was about 6.1, so the lower bound from zero is how about -6.1. The mean of the centered data isn’t quite zero — we’ll explore why not in the challenges — but it’s pretty close. We can even go further and check that the standard deviation hasn’t changed:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;std dev before and after:&#39;</span>, data.std(), centered.std()</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;std dev before and after:&#39;</span>, data.std(), centered.std())</code></pre>
 <pre class="output"><code>std dev before and after: 4.61383319712 4.61383319712</code></pre>
 <p>Those values look the same, but we probably wouldn’t notice if they were different in the sixth decimal place. Let’s do this instead:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;difference in standard deviations before and after:&#39;</span>, data.std() - centered.std()</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;difference in standard deviations before and after:&#39;</span>, data.std() - centered.std())</code></pre>
 <pre class="output"><code>difference in standard deviations before and after: -3.5527136788e-15</code></pre>
 <p>Again, the difference is very small. It’s still possible that our function is wrong, but it seems unlikely enough that we should probably get back to doing our analysis. We have one more task first, though: we should write some <a href="reference.html#documentation">documentation</a> for our function to remind ourselves later what it’s for and how to use it.</p>
 <p>The usual way to put documentation in software is to add <a href="reference.html#comment">comments</a> like this:</p>
@@ -238,15 +238,15 @@ TypeError: data type &quot;,&quot; not understood</code></pre>
     <span class="kw">return</span> (data - data.mean()) + desired</code></pre>
 <p>The key change is that the second parameter is now written <code>desired=0.0</code> instead of just <code>desired</code>. If we call the function with two arguments, it works as it did before:</p>
 <pre class="sourceCode python"><code class="sourceCode python">test_data = numpy.zeros((<span class="dv">2</span>, <span class="dv">2</span>))
-<span class="dt">print</span> center(test_data, <span class="dv">3</span>)</code></pre>
+<span class="dt">print</span>(center(test_data, <span class="dv">3</span>))</code></pre>
 <pre class="output"><code>[[ 3.  3.]
  [ 3.  3.]]</code></pre>
 <p>But we can also now call it with just one parameter, in which case <code>desired</code> is automatically assigned the <a href="reference.html#default-value">default value</a> of 0.0:</p>
 <pre class="sourceCode python"><code class="sourceCode python">more_data = <span class="dv">5</span> + numpy.zeros((<span class="dv">2</span>, <span class="dv">2</span>))
-<span class="dt">print</span> <span class="st">&#39;data before centering:&#39;</span>
-<span class="dt">print</span> more_data
-<span class="dt">print</span> <span class="st">&#39;centered data:&#39;</span>
-<span class="dt">print</span> center(more_data)</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;data before centering:&#39;</span>)
+<span class="dt">print</span>(more_data)
+<span class="dt">print</span>(<span class="st">&#39;centered data:&#39;</span>)
+<span class="dt">print</span>(center(more_data))</code></pre>
 <pre class="output"><code>data before centering:
 [[ 5.  5.]
  [ 5.  5.]]
@@ -255,13 +255,13 @@ centered data:
  [ 0.  0.]]</code></pre>
 <p>This is handy: if we usually want a function to work one way, but occasionally need it to do something else, we can allow people to pass a parameter when they need to but provide a default to make the normal case easier. The example below shows how Python matches values to parameters:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> display(a=<span class="dv">1</span>, b=<span class="dv">2</span>, c=<span class="dv">3</span>):
-    <span class="dt">print</span> <span class="st">&#39;a:&#39;</span>, a, <span class="st">&#39;b:&#39;</span>, b, <span class="st">&#39;c:&#39;</span>, c
+    <span class="dt">print</span>(<span class="st">&#39;a:&#39;</span>, a, <span class="st">&#39;b:&#39;</span>, b, <span class="st">&#39;c:&#39;</span>, c)
 
-<span class="dt">print</span> <span class="st">&#39;no parameters:&#39;</span>
+<span class="dt">print</span>(<span class="st">&#39;no parameters:&#39;</span>)
 display()
-<span class="dt">print</span> <span class="st">&#39;one parameter:&#39;</span>
+<span class="dt">print</span>(<span class="st">&#39;one parameter:&#39;</span>)
 display(<span class="dv">55</span>)
-<span class="dt">print</span> <span class="st">&#39;two parameters:&#39;</span>
+<span class="dt">print</span>(<span class="st">&#39;two parameters:&#39;</span>)
 display(<span class="dv">55</span>, <span class="dv">66</span>)</code></pre>
 <pre class="output"><code>no parameters:
 a: 1 b: 2 c: 3
@@ -270,7 +270,7 @@ a: 55 b: 2 c: 3
 two parameters:
 a: 55 b: 66 c: 3</code></pre>
 <p>As this example shows, parameters are matched up from left to right, and any that haven’t been given a value explicitly get their default value. We can override this behavior by naming the value as we pass it in:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;only setting the value of c&#39;</span>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;only setting the value of c&#39;</span>)
 display(c=<span class="dv">77</span>)</code></pre>
 <pre class="output"><code>only setting the value of c
 a: 1 b: 2 c: 77</code></pre>
@@ -373,7 +373,7 @@ loadtxt(fname, dtype=&lt;type &#39;float&#39;&gt;, comments=&#39;#&#39;, delimit
 </div>
 <div class="panel-body">
 <p>“Adding” two strings produces their concatenation: <code>'a' + 'b'</code> is <code>'ab'</code>. Write a function called <code>fence</code> that takes two parameters called <code>original</code> and <code>wrapper</code> and returns a new string that has the wrapper character at the beginning and end of the original. A call to your function should look like this:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> fence(<span class="st">&#39;name&#39;</span>, <span class="st">&#39;*&#39;</span>)
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(fence(<span class="st">&#39;name&#39;</span>, <span class="st">&#39;*&#39;</span>))
 *name*</code></pre>
 </div>
 </section>
@@ -383,7 +383,7 @@ loadtxt(fname, dtype=&lt;type &#39;float&#39;&gt;, comments=&#39;#&#39;, delimit
 </div>
 <div class="panel-body">
 <p>If the variable <code>s</code> refers to a string, then <code>s[0]</code> is the string’s first character and <code>s[-1]</code> is its last. Write a function called <code>outer</code> that returns a string made up of just the first and last characters of its input. A call to your function should look like this:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> outer(<span class="st">&#39;helium&#39;</span>)
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(outer(<span class="st">&#39;helium&#39;</span>))
 hm</code></pre>
 </div>
 </section>
@@ -428,15 +428,7 @@ f2k(<span class="dv">8</span>)
 f2k(<span class="dv">41</span>)
 f2k(<span class="dv">32</span>)
 
-<span class="dt">print</span> k</code></pre>
-</div>
-</section>
-<section class="challenge panel panel-success">
-<div class="panel-heading">
-<h2><span class="glyphicon glyphicon-pencil"></span>Automatic plots</h2>
-</div>
-<div class="panel-body">
-<p>Write a function called <code>analyze</code> that takes a filename as a parameter and displays the three graphs produced in the previous lessons, i.e., <code>analyze('inflammation-01.csv')</code> should produce the graphs already shown, while <code>analyze('inflammation-02.csv')</code> should produce corresponding graphs for the second data set. Be sure to give your function a docstring.</p>
+<span class="dt">print</span>(k)</code></pre>
 </div>
 </section>
         </div>

--- a/06-func.md
+++ b/06-func.md
@@ -52,8 +52,8 @@ Let's try running our function.
 Calling our own function is no different from calling any other function:
 
 ~~~ {.python}
-print 'freezing point of water:', fahr_to_kelvin(32)
-print 'boiling point of water:', fahr_to_kelvin(212)
+print('freezing point of water:', fahr_to_kelvin(32))
+print('boiling point of water:', fahr_to_kelvin(212))
 ~~~
 ~~~ {.output}
 freezing point of water: 273.15
@@ -82,14 +82,14 @@ and printing out the value of each part.
 
 ~~~ {.python}
 # We'll use temp = 212, the boiling point of water, which was incorrect
-print "212 - 32:", 212 - 32
+print("212 - 32:", 212 - 32)
 ~~~
 ~~~ {.output}
 212 - 32: 180
 ~~~
 
 ~~~ {.python}
-print "(212 - 32) * (5/9):", (212 - 32) * (5/9)
+print("(212 - 32) * (5/9):", (212 - 32) * (5/9))
 ~~~
 ~~~ {.output}
 (212 - 32) * (5/9): 0
@@ -116,7 +116,7 @@ If we divide one integer by another,
 we get the quotient without the remainder:
 
 ~~~ {.python}
-print '10/3 is:', 10/3
+print('10/3 is:', 10/3)
 ~~~
 ~~~ {.output}
 10/3 is: 3
@@ -127,7 +127,7 @@ on the other hand,
 the computer creates a floating-point answer:
 
 ~~~ {.python}
-print '10.0/3 is:', 10.0/3
+print('10.0/3 is:', 10.0/3)
 ~~~
 ~~~ {.output}
 10.0/3 is: 3.33333333333
@@ -149,7 +149,7 @@ is to explicitly tell the computer that you desire one.
 This is achieved by [casting](reference.html#typecast) one of the numbers:
 
 ~~~ {.python}
-print 'float(10)/3 is:', float(10)/3
+print('float(10)/3 is:', float(10)/3)
 ~~~
 ~~~ {.output}
 float(10)/3 is: 3.33333333333
@@ -161,8 +161,8 @@ Let's take a look:
 ~~~ {.python}
 a = 10
 b = 3
-print 'a/b is:', a/b
-print 'float(a)/b is:', float(a)/b
+print('a/b is:', a/b)
+print('float(a)/b is:', float(a)/b)
 ~~~
 ~~~ {.output}
 a/b is: 3
@@ -175,8 +175,8 @@ Let's fix our `fahr_to_kelvin` function with this new knowledge:
 def fahr_to_kelvin(temp):
     return ((temp - 32) * (5.0/9.0)) + 273.15
 
-print 'freezing point of water:', fahr_to_kelvin(32)
-print 'boiling point of water:', fahr_to_kelvin(212)
+print('freezing point of water:', fahr_to_kelvin(32))
+print('boiling point of water:', fahr_to_kelvin(212))
 ~~~
 ~~~ {.output}
 freezing point of water: 273.15
@@ -192,7 +192,7 @@ it's easy to turn Kelvin into Celsius:
 def kelvin_to_celsius(temp):
     return temp - 273.15
 
-print 'absolute zero in Celsius:', kelvin_to_celsius(0.0)
+print('absolute zero in Celsius:', kelvin_to_celsius(0.0))
 ~~~
 ~~~ {.output}
 absolute zero in Celsius: -273.15
@@ -210,7 +210,7 @@ def fahr_to_celsius(temp):
     result = kelvin_to_celsius(temp_k)
     return result
 
-print 'freezing point of water in Celsius:', fahr_to_celsius(32.0)
+print('freezing point of water in Celsius:', fahr_to_celsius(32.0))
 ~~~
 ~~~ {.output}
 freezing point of water in Celsius: 0.0
@@ -262,11 +262,11 @@ def detect_problems(filename):
     data = np.loadtxt(fname=filename, delimiter=',')
 
     if data.max(axis=0)[0] == 0 and data.max(axis=0)[20] == 20:
-        print 'Suspicious looking maxima!'
+        print('Suspicious looking maxima!')
     elif data.min(axis=0).sum() == 0:
-        print 'Minima add up to zero!'
+        print('Minima add up to zero!')
     else:
-        print 'Seems OK!'
+        print('Seems OK!')
 ~~~
 
 Notice that rather than jumbling this code together in one giant `for` loop,
@@ -275,7 +275,7 @@ We can reproduce the previous analysis with a much simpler `for` loop:
 
 ~~~ {.python}
 for f in filenames[:3]:
-    print f
+    print(f)
     analyze(f)
     detectProblems(f)
 ~~~
@@ -306,7 +306,7 @@ and then center that around 3:
 
 ~~~ {.python}
 z = numpy.zeros((2,2))
-print center(z, 3)
+print(center(z, 3))
 ~~~
 ~~~ {.output}
 [[ 3.  3.]
@@ -318,7 +318,7 @@ so let's try `center` on our real data:
 
 ~~~ {.python}
 data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
-print center(data, 0)
+print(center(data, 0))
 ~~~
 ~~~ {.output}
 [[-6.14875 -6.14875 -5.14875 ..., -3.14875 -6.14875 -6.14875]
@@ -334,9 +334,9 @@ It's hard to tell from the default output whether the result is correct,
 but there are a few simple tests that will reassure us:
 
 ~~~ {.python}
-print 'original min, mean, and max are:', data.min(), data.mean(), data.max()
+print('original min, mean, and max are:', data.min(), data.mean(), data.max())
 centered = center(data, 0)
-print 'min, mean, and and max of centered data are:', centered.min(), centered.mean(), centered.max()
+print('min, mean, and and max of centered data are:', centered.min(), centered.mean(), centered.max())
 ~~~
 ~~~ {.output}
 original min, mean, and max are: 0.0 6.14875 20.0
@@ -350,7 +350,7 @@ The mean of the centered data isn't quite zero --- we'll explore why not in the 
 We can even go further and check that the standard deviation hasn't changed:
 
 ~~~ {.python}
-print 'std dev before and after:', data.std(), centered.std()
+print('std dev before and after:', data.std(), centered.std())
 ~~~
 ~~~ {.output}
 std dev before and after: 4.61383319712 4.61383319712
@@ -361,7 +361,7 @@ but we probably wouldn't notice if they were different in the sixth decimal plac
 Let's do this instead:
 
 ~~~ {.python}
-print 'difference in standard deviations before and after:', data.std() - centered.std()
+print('difference in standard deviations before and after:', data.std() - centered.std())
 ~~~
 ~~~ {.output}
 difference in standard deviations before and after: -3.5527136788e-15
@@ -487,7 +487,7 @@ it works as it did before:
 
 ~~~ {.python}
 test_data = numpy.zeros((2, 2))
-print center(test_data, 3)
+print(center(test_data, 3))
 ~~~
 ~~~ {.output}
 [[ 3.  3.]
@@ -499,10 +499,10 @@ in which case `desired` is automatically assigned the [default value](reference.
 
 ~~~ {.python}
 more_data = 5 + numpy.zeros((2, 2))
-print 'data before centering:'
-print more_data
-print 'centered data:'
-print center(more_data)
+print('data before centering:')
+print(more_data)
+print('centered data:')
+print(center(more_data))
 ~~~
 ~~~ {.output}
 data before centering:
@@ -522,13 +522,13 @@ The example below shows how Python matches values to parameters:
 
 ~~~ {.python}
 def display(a=1, b=2, c=3):
-    print 'a:', a, 'b:', b, 'c:', c
+    print('a:', a, 'b:', b, 'c:', c)
 
-print 'no parameters:'
+print('no parameters:')
 display()
-print 'one parameter:'
+print('one parameter:')
 display(55)
-print 'two parameters:'
+print('two parameters:')
 display(55, 66)
 ~~~
 ~~~ {.output}
@@ -546,7 +546,7 @@ and any that haven't been given a value explicitly get their default value.
 We can override this behavior by naming the value as we pass it in:
 
 ~~~ {.python}
-print 'only setting the value of c'
+print('only setting the value of c')
 display(c=77)
 ~~~
 ~~~ {.output}
@@ -682,7 +682,7 @@ the second parameter in the list.
 > A call to your function should look like this:
 >
 > ~~~ {.python}
-> print fence('name', '*')
+> print(fence('name', '*'))
 > *name*
 > ~~~
 
@@ -696,7 +696,7 @@ the second parameter in the list.
 > A call to your function should look like this:
 >
 > ~~~ {.python}
-> print outer('helium')
+> print(outer('helium'))
 > hm
 > ~~~
 
@@ -738,6 +738,6 @@ the second parameter in the list.
 > f2k(41)
 > f2k(32)
 >
-> print k
+> print(k)
 > ~~~
 

--- a/07-errors.html
+++ b/07-errors.html
@@ -63,15 +63,15 @@ IndexError                                Traceback (most recent call last)
 /Users/jhamrick/project/swc/novice/python/errors_01.pyc in favorite_ice_cream()
       5         &quot;strawberry&quot;
       6     ]
-----&gt; 7     print ice_creams[3]
+----&gt; 7     print(ice_creams[3])
 
 IndexError: list index out of range</code></pre>
 <p>This particular traceback has two levels. You can determine the number of levels by looking for the number of arrows on the left hand side. In this case:</p>
 <ol style="list-style-type: decimal">
 <li><p>The first shows code from the cell above, with an arrow pointing to Line 2 (which is <code>favorite_ice_cream()</code>).</p></li>
-<li><p>The second shows some code in another function (<code>favorite_ice_cream</code>, located in the file <code>errors_01.py</code>), with an arrow pointing to Line 7 (which is <code>print ice_creams[3]</code>).</p></li>
+<li><p>The second shows some code in another function (<code>favorite_ice_cream</code>, located in the file <code>errors_01.py</code>), with an arrow pointing to Line 7 (which is <code>print(ice_creams[3])</code>).</p></li>
 </ol>
-<p>The last level is the actual place where the error occurred. The other level(s) show what function the program executed to get to the next level down. So, in this case, the program first performed a <a href="reference.html#function-call">function call</a> to the function <code>favorite_ice_cream</code>. Inside this function, the program encountered an error on Line 7, when it tried to run the code <code>print ice_creams[3]</code>.</p>
+<p>The last level is the actual place where the error occurred. The other level(s) show what function the program executed to get to the next level down. So, in this case, the program first performed a <a href="reference.html#function-call">function call</a> to the function <code>favorite_ice_cream</code>. Inside this function, the program encountered an error on Line 7, when it tried to run the code <code>print(ice_creams[3])</code>.</p>
 <aside class="callout panel panel-info">
 <div class="panel-heading">
 <h2><span class="glyphicon glyphicon-pushpin"></span>Long Tracebacks</h2>
@@ -91,7 +91,7 @@ IndexError: list index out of range</code></pre>
 <p>People can typically figure out what is meant by text with no punctuation, but people are much smarter than computers. If Python doesn’t know how to read the program, it will just give up and inform you with an error. For example:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> some_function()
     msg = <span class="st">&quot;hello, world!&quot;</span>
-    <span class="dt">print</span> msg
+    <span class="dt">print</span>(msg)
      <span class="kw">return</span> msg</code></pre>
 <pre class="error"><code>  File &quot;&lt;ipython-input-3-6bb841ea1423&gt;&quot;, line 1
     def some_function()
@@ -101,7 +101,7 @@ SyntaxError: invalid syntax</code></pre>
 <p>Actually, the function above has <em>two</em> issues with syntax. If we fix the problem with the colon, we see that there is <em>also</em> an <code>IndentationError</code>, which means that the lines in the function definition do not all have the same indentation:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> some_function():
     msg = <span class="st">&quot;hello, world!&quot;</span>
-    <span class="dt">print</span> msg
+    <span class="dt">print</span>(msg)
      <span class="kw">return</span> msg</code></pre>
 <pre class="error"><code>  File &quot;&lt;ipython-input-4-ae290e7659cb&gt;&quot;, line 4
     return msg
@@ -116,7 +116,7 @@ IndentationError: unexpected indent</code></pre>
 <p>A quick note on indentation errors: they can sometimes be insidious, especially if you are mixing spaces and tabs. Because they are both <a href="reference.html#whitespace">whitespace</a>, it is difficult to visually tell the difference. The IPython notebook actually gives us a bit of a hint, but not all Python editors will do that. In the following example, the first two lines are using a tab for indentation, while the third line uses four spaces:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> some_function():
     msg = <span class="st">&quot;hello, world!&quot;</span>
-    <span class="dt">print</span> msg
+    <span class="dt">print</span>(msg)
     <span class="kw">return</span> msg</code></pre>
 <pre class="error"><code>  File &quot;&lt;ipython-input-5-653b36fbcd41&gt;&quot;, line 4
     return msg
@@ -127,64 +127,64 @@ IndentationError: unindent does not match any outer indentation level</code></pr
 </aside>
 <h2 id="variable-name-errors">Variable Name Errors</h2>
 <p>Another very common type of error is called a <code>NameError</code>, and occurs when you try to use a variable that does not exist. For example:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> a</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(a)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 &lt;ipython-input-7-9d7b17ad5387&gt; in &lt;module&gt;()
-----&gt; 1 print a
+----&gt; 1 print(a)
 
 NameError: name &#39;a&#39; is not defined</code></pre>
 <p>Variable name errors come with some of the most informative error messages, which are usually of the form “name ‘the_variable_name’ is not defined”.</p>
 <p>Why does this error message occur? That’s harder question to answer, because it depends on what your code is supposed to do. However, there are a few very common reasons why you might have an undefined variable. The first is that you meant to use a <a href="reference.html#string">string</a>, but forgot to put quotes around it:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> hello</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(hello)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 &lt;ipython-input-8-9553ee03b645&gt; in &lt;module&gt;()
-----&gt; 1 print hello
+----&gt; 1 print(hello)
 
 NameError: name &#39;hello&#39; is not defined</code></pre>
 <p>The second is that you just forgot to create the variable before using it. In the following example, <code>count</code> should have been defined (e.g., with <code>count = 0</code>) before the for loop:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">for</span> number in <span class="dt">range</span>(<span class="dv">10</span>):
     count = count + number
-<span class="dt">print</span> <span class="st">&quot;The count is: &quot;</span> + <span class="dt">str</span>(count)</code></pre>
+<span class="dt">print</span>(<span class="st">&quot;The count is: &quot;</span> + <span class="dt">str</span>(count))</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 &lt;ipython-input-9-dd6a12d7ca5c&gt; in &lt;module&gt;()
       1 for number in range(10):
 ----&gt; 2     count = count + number
-      3 print &quot;The count is: &quot; + str(count)
+      3 print(&quot;The count is: &quot; + str(count))
 
 NameError: name &#39;count&#39; is not defined</code></pre>
 <p>Finally, the third possibility is that you made a typo when you were writing your code. Let’s say we fixed the error above by adding the line <code>Count = 0</code> before the for loop. Frustratingly, this actually does not fix the error. Remember that variables are <a href="reference.html#case-sensitive">case-sensitive</a>, so the variable <code>count</code> is different from <code>Count</code>. We still get the same error, because we still have not defined <code>count</code>:</p>
 <pre class="sourceCode python"><code class="sourceCode python">Count = <span class="dv">0</span>
 <span class="kw">for</span> number in <span class="dt">range</span>(<span class="dv">10</span>):
     count = count + number
-<span class="dt">print</span> <span class="st">&quot;The count is: &quot;</span> + <span class="dt">str</span>(count)</code></pre>
+<span class="dt">print</span>(<span class="st">&quot;The count is: &quot;</span> + <span class="dt">str</span>(count))</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 &lt;ipython-input-10-d77d40059aea&gt; in &lt;module&gt;()
       1 Count = 0
       2 for number in range(10):
 ----&gt; 3     count = count + number
-      4 print &quot;The count is: &quot; + str(count)
+      4 print(&quot;The count is: &quot; + str(count))
 
 NameError: name &#39;count&#39; is not defined</code></pre>
 <h2 id="item-errors">Item Errors</h2>
 <p>Next up are errors having to do with containers (like lists and dictionaries) and the items within them. If you try to access an item in a list or a dictionary that does not exist, then you will get an error. This makes sense: if you asked someone what day they would like to get coffee, and they answered “caturday”, you might be a bit annoyed. Python gets similarly annoyed if you try to ask it for an item that doesn’t exist:</p>
 <pre class="sourceCode python"><code class="sourceCode python">letters = [<span class="st">&#39;a&#39;</span>, <span class="st">&#39;b&#39;</span>, <span class="st">&#39;c&#39;</span>]
-<span class="dt">print</span> <span class="st">&quot;Letter #1 is &quot;</span> + letters[<span class="dv">0</span>]
-<span class="dt">print</span> <span class="st">&quot;Letter #2 is &quot;</span> + letters[<span class="dv">1</span>]
-<span class="dt">print</span> <span class="st">&quot;Letter #3 is &quot;</span> + letters[<span class="dv">2</span>]
-<span class="dt">print</span> <span class="st">&quot;Letter #4 is &quot;</span> + letters[<span class="dv">3</span>]</code></pre>
+<span class="dt">print</span>(<span class="st">&quot;Letter #1 is &quot;</span> + letters[<span class="dv">0</span>])
+<span class="dt">print</span>(<span class="st">&quot;Letter #2 is &quot;</span> + letters[<span class="dv">1</span>])
+<span class="dt">print</span>(<span class="st">&quot;Letter #3 is &quot;</span> + letters[<span class="dv">2</span>])
+<span class="dt">print</span>(<span class="st">&quot;Letter #4 is &quot;</span> + letters[<span class="dv">3</span>])</code></pre>
 <pre class="output"><code>Letter #1 is a
 Letter #2 is b
 Letter #3 is c</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
 &lt;ipython-input-11-d817f55b7d6c&gt; in &lt;module&gt;()
-      3 print &quot;Letter #2 is &quot; + letters[1]
-      4 print &quot;Letter #3 is &quot; + letters[2]
-----&gt; 5 print &quot;Letter #4 is &quot; + letters[3]
+      3 print(&quot;Letter #2 is &quot; + letters[1])
+      4 print(&quot;Letter #3 is &quot; + letters[2])
+----&gt; 5 print(&quot;Letter #4 is &quot; + letters[3])
 
 IndexError: list index out of range</code></pre>
 <p>Here, Python is telling us that there is an <code>IndexError</code> in our code, meaning we tried to access a list index that did not exist.</p>
@@ -238,7 +238,7 @@ KeyError                                  Traceback (most recent call last)
 /Users/jhamrick/project/swc/novice/python/errors_02.py in print_message(day)
       9         &quot;sunday&quot;: &quot;Aw, the weekend is almost over.&quot;
      10     }
----&gt; 11     print messages[day]
+---&gt; 11     print(messages[day])
      12
      13
 
@@ -257,9 +257,9 @@ KeyError: &#39;Friday&#39;</code></pre>
 <li>Repeat steps 2 and 3, until you have fixed all the errors.</li>
 </ol>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> another_function
-  <span class="dt">print</span> <span class="st">&quot;Syntax errors are annoying.&quot;</span>
-   <span class="dt">print</span> <span class="st">&quot;But at least python tells us about them!&quot;</span>
-  <span class="dt">print</span> <span class="st">&quot;So they are usually not too hard to fix.&quot;</span></code></pre>
+  <span class="dt">print</span>(<span class="st">&quot;Syntax errors are annoying.&quot;</span>)
+   <span class="dt">print</span>(<span class="st">&quot;But at least python tells us about them!&quot;</span>)
+  <span class="dt">print</span>(<span class="st">&quot;So they are usually not too hard to fix.&quot;</span>)</code></pre>
 </div>
 </section>
 <section class="challenge panel panel-success">
@@ -279,7 +279,7 @@ KeyError: &#39;Friday&#39;</code></pre>
         message = message + a
     <span class="kw">else</span>:
         message = message + <span class="st">&quot;b&quot;</span>
-<span class="dt">print</span> message</code></pre>
+<span class="dt">print</span>(message)</code></pre>
 </div>
 </section>
 <section class="challenge panel panel-success">
@@ -293,7 +293,7 @@ KeyError: &#39;Friday&#39;</code></pre>
 <li>Fix the error.</li>
 </ol>
 <pre class="sourceCode python"><code class="sourceCode python">seasons = [<span class="st">&#39;Spring&#39;</span>, <span class="st">&#39;Summer&#39;</span>, <span class="st">&#39;Fall&#39;</span>, <span class="st">&#39;Winter&#39;</span>]
-<span class="dt">print</span> <span class="st">&#39;My favorite season is &#39;</span>, seasons[<span class="dv">4</span>]</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;My favorite season is &#39;</span>, seasons[<span class="dv">4</span>])</code></pre>
 </div>
 </section>
         </div>

--- a/07-errors.md
+++ b/07-errors.md
@@ -45,7 +45,7 @@ IndexError                                Traceback (most recent call last)
 /Users/jhamrick/project/swc/novice/python/errors_01.pyc in favorite_ice_cream()
       5         "strawberry"
       6     ]
-----> 7     print ice_creams[3]
+----> 7     print(ice_creams[3])
 
 IndexError: list index out of range
 ~~~
@@ -58,13 +58,13 @@ In this case:
     with an arrow pointing to Line 2 (which is `favorite_ice_cream()`).
 
 2.  The second shows some code in another function (`favorite_ice_cream`, located in the file `errors_01.py`),
-    with an arrow pointing to Line 7 (which is `print ice_creams[3]`).
+    with an arrow pointing to Line 7 (which is `print(ice_creams[3])`).
 
 The last level is the actual place where the error occurred.
 The other level(s) show what function the program executed to get to the next level down.
 So, in this case, the program first performed a [function call](reference.html#function-call) to the function `favorite_ice_cream`.
 Inside this function,
-the program encountered an error on Line 7, when it tried to run the code `print ice_creams[3]`.
+the program encountered an error on Line 7, when it tried to run the code `print(ice_creams[3])`.
 
 > ## Long Tracebacks {.callout}
 >
@@ -121,7 +121,7 @@ For example:
 ~~~ {.python}
 def some_function()
     msg = "hello, world!"
-    print msg
+    print(msg)
      return msg
 ~~~
 ~~~ {.error}
@@ -143,7 +143,7 @@ which means that the lines in the function definition do not all have the same i
 ~~~ {.python}
 def some_function():
     msg = "hello, world!"
-    print msg
+    print(msg)
      return msg
 ~~~
 ~~~ {.error}
@@ -173,7 +173,7 @@ it *always* means that there is a problem with how your code is indented.
 > ~~~ {.python}
 > def some_function():
 >     msg = "hello, world!"
->     print msg
+>     print(msg)
 >     return msg
 > ~~~
 > ~~~ {.error}
@@ -195,13 +195,13 @@ and occurs when you try to use a variable that does not exist.
 For example:
 
 ~~~ {.python}
-print a
+print(a)
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 <ipython-input-7-9d7b17ad5387> in <module>()
-----> 1 print a
+----> 1 print(a)
 
 NameError: name 'a' is not defined
 ~~~
@@ -217,13 +217,13 @@ there are a few very common reasons why you might have an undefined variable.
 The first is that you meant to use a [string](reference.html#string), but forgot to put quotes around it:
 
 ~~~ {.python}
-print hello
+print(hello)
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 <ipython-input-8-9553ee03b645> in <module>()
-----> 1 print hello
+----> 1 print(hello)
 
 NameError: name 'hello' is not defined
 ~~~
@@ -235,7 +235,7 @@ In the following example,
 ~~~ {.python}
 for number in range(10):
     count = count + number
-print "The count is: " + str(count)
+print("The count is: " + str(count))
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
@@ -243,7 +243,7 @@ NameError                                 Traceback (most recent call last)
 <ipython-input-9-dd6a12d7ca5c> in <module>()
       1 for number in range(10):
 ----> 2     count = count + number
-      3 print "The count is: " + str(count)
+      3 print("The count is: " + str(count))
 
 NameError: name 'count' is not defined
 ~~~
@@ -258,7 +258,7 @@ so the variable `count` is different from `Count`. We still get the same error, 
 Count = 0
 for number in range(10):
     count = count + number
-print "The count is: " + str(count)
+print("The count is: " + str(count))
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
@@ -267,7 +267,7 @@ NameError                                 Traceback (most recent call last)
       1 Count = 0
       2 for number in range(10):
 ----> 3     count = count + number
-      4 print "The count is: " + str(count)
+      4 print("The count is: " + str(count))
 
 NameError: name 'count' is not defined
 ~~~
@@ -285,10 +285,10 @@ Python gets similarly annoyed if you try to ask it for an item that doesn't exis
 
 ~~~ {.python}
 letters = ['a', 'b', 'c']
-print "Letter #1 is " + letters[0]
-print "Letter #2 is " + letters[1]
-print "Letter #3 is " + letters[2]
-print "Letter #4 is " + letters[3]
+print("Letter #1 is " + letters[0])
+print("Letter #2 is " + letters[1])
+print("Letter #3 is " + letters[2])
+print("Letter #4 is " + letters[3])
 ~~~
 ~~~ {.output}
 Letter #1 is a
@@ -299,9 +299,9 @@ Letter #3 is c
 ---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
 <ipython-input-11-d817f55b7d6c> in <module>()
-      3 print "Letter #2 is " + letters[1]
-      4 print "Letter #3 is " + letters[2]
-----> 5 print "Letter #4 is " + letters[3]
+      3 print("Letter #2 is " + letters[1])
+      4 print("Letter #3 is " + letters[2])
+----> 5 print("Letter #4 is " + letters[3])
 
 IndexError: list index out of range
 ~~~
@@ -393,7 +393,7 @@ IOError: File not open for reading
 > /Users/jhamrick/project/swc/novice/python/errors_02.py in print_message(day)
 >       9         "sunday": "Aw, the weekend is almost over."
 >      10     }
-> ---> 11     print messages[day]
+> ---> 11     print(messages[day])
 >      12
 >      13
 >
@@ -409,9 +409,9 @@ IOError: File not open for reading
 >
 > ~~~ {.python}
 > def another_function
->   print "Syntax errors are annoying."
->    print "But at least python tells us about them!"
->   print "So they are usually not too hard to fix."
+>   print("Syntax errors are annoying.")
+>    print("But at least python tells us about them!")
+>   print("So they are usually not too hard to fix.")
 > ~~~
 
 > ## Identifying Variable Name Errors {.challenge}
@@ -428,7 +428,7 @@ IOError: File not open for reading
 >         message = message + a
 >     else:
 >         message = message + "b"
-> print message
+> print(message)
 > ~~~
 
 > ## Identifying Item Errors {.challenge}
@@ -439,5 +439,5 @@ IOError: File not open for reading
 >
 > ~~~ {.python}
 > seasons = ['Spring', 'Summer', 'Fall', 'Winter']
-> print 'My favorite season is ', seasons[4]
+> print('My favorite season is ', seasons[4])
 > ~~~

--- a/08-defensive.html
+++ b/08-defensive.html
@@ -57,7 +57,7 @@ total = <span class="fl">0.0</span>
 <span class="kw">for</span> n in numbers:
     <span class="kw">assert</span> n &gt; <span class="fl">0.0</span>, <span class="st">&#39;Data should only contain positive values&#39;</span>
     total += n
-<span class="dt">print</span> <span class="st">&#39;total is:&#39;</span>, total</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;total is:&#39;</span>, total)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 &lt;ipython-input-19-33d87ea29ae4&gt; in &lt;module&gt;()
@@ -65,7 +65,7 @@ AssertionError                            Traceback (most recent call last)
       3 for n in numbers:
 ----&gt; 4     assert n &gt; 0.0, &#39;Data should only contain positive values&#39;
       5     total += n
-      6 print &#39;total is:&#39;, total
+      6 print(&#39;total is:&#39;, total)
 
 AssertionError: Data should only contain positive values</code></pre>
 <p>Programs like the Firefox browser are full of assertions: 10-20% of the code they contain are there to check that the other 80-90% are working correctly. Broadly speaking, assertions fall into three categories:</p>
@@ -96,11 +96,11 @@ AssertionError: Data should only contain positive values</code></pre>
 
     <span class="kw">return</span> (<span class="dv">0</span>, <span class="dv">0</span>, upper_x, upper_y)</code></pre>
 <p>The preconditions on lines 2, 4, and 5 catch invalid inputs:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">1.0</span>, <span class="fl">2.0</span>) ) <span class="co"># missing the fourth coordinate</span></code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">1.0</span>, <span class="fl">2.0</span>) )) <span class="co"># missing the fourth coordinate</span></code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 &lt;ipython-input-21-3a97b1dcab70&gt; in &lt;module&gt;()
-----&gt; 1 print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
+----&gt; 1 print(normalize_rectangle( (0.0, 1.0, 2.0) )) # missing the fourth coordinate
 
 &lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
       1 def normalize_rectangle(rect):
@@ -110,11 +110,11 @@ AssertionError                            Traceback (most recent call last)
       5     assert x0 &lt; x1, &#39;Invalid X coordinates&#39;
 
 AssertionError: Rectangles must contain 4 coordinates</code></pre>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> normalize_rectangle( (<span class="fl">4.0</span>, <span class="fl">2.0</span>, <span class="fl">1.0</span>, <span class="fl">5.0</span>) ) <span class="co"># X axis inverted</span></code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(normalize_rectangle( (<span class="fl">4.0</span>, <span class="fl">2.0</span>, <span class="fl">1.0</span>, <span class="fl">5.0</span>) )) <span class="co"># X axis inverted</span></code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 &lt;ipython-input-22-f05ae7878a45&gt; in &lt;module&gt;()
-----&gt; 1 print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
+----&gt; 1 print(normalize_rectangle( (4.0, 2.0, 1.0, 5.0) )) # X axis inverted
 
 &lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
       3     assert len(rect) == 4, &#39;Rectangles must contain 4 coordinates&#39;
@@ -125,14 +125,14 @@ AssertionError                            Traceback (most recent call last)
 
 AssertionError: Invalid X coordinates</code></pre>
 <p>The post-conditions help us catch bugs by telling us when our calculations cannot have been correct. For example, if we normalize a rectangle that is taller than it is wide everything seems OK:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">0.0</span>, <span class="fl">1.0</span>, <span class="fl">5.0</span>) )</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">0.0</span>, <span class="fl">1.0</span>, <span class="fl">5.0</span>) ))</code></pre>
 <pre class="output"><code>(0, 0, 0.2, 1.0)</code></pre>
 <p>but if we normalize one that’s wider than it is tall, the assertion is triggered:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">0.0</span>, <span class="fl">5.0</span>, <span class="fl">1.0</span>) )</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(normalize_rectangle( (<span class="fl">0.0</span>, <span class="fl">0.0</span>, <span class="fl">5.0</span>, <span class="fl">1.0</span>) ))</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 &lt;ipython-input-24-5f0ef7954aeb&gt; in &lt;module&gt;()
-----&gt; 1 print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
+----&gt; 1 print(normalize_rectangle( (0.0, 0.0, 5.0, 1.0) ))
 
 &lt;ipython-input-20-408dc39f3915&gt; in normalize_rectangle(rect)
      16

--- a/08-defensive.md
+++ b/08-defensive.md
@@ -62,7 +62,7 @@ total = 0.0
 for n in numbers:
     assert n > 0.0, 'Data should only contain positive values'
     total += n
-print 'total is:', total
+print('total is:', total)
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
@@ -72,7 +72,7 @@ AssertionError                            Traceback (most recent call last)
       3 for n in numbers:
 ----> 4     assert n > 0.0, 'Data should only contain positive values'
       5     total += n
-      6 print 'total is:', total
+      6 print('total is:', total)
 
 AssertionError: Data should only contain positive values
 ~~~
@@ -124,13 +124,13 @@ def normalize_rectangle(rect):
 The preconditions on lines 2, 4, and 5 catch invalid inputs:
 
 ~~~ {.python}
-print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
+print(normalize_rectangle( (0.0, 1.0, 2.0) )) # missing the fourth coordinate
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 <ipython-input-21-3a97b1dcab70> in <module>()
-----> 1 print normalize_rectangle( (0.0, 1.0, 2.0) ) # missing the fourth coordinate
+----> 1 print(normalize_rectangle( (0.0, 1.0, 2.0) )) # missing the fourth coordinate
 
 <ipython-input-20-408dc39f3915> in normalize_rectangle(rect)
       1 def normalize_rectangle(rect):
@@ -143,13 +143,13 @@ AssertionError: Rectangles must contain 4 coordinates
 ~~~
 
 ~~~ {.python}
-print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
+print(normalize_rectangle( (4.0, 2.0, 1.0, 5.0) )) # X axis inverted
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 <ipython-input-22-f05ae7878a45> in <module>()
-----> 1 print normalize_rectangle( (4.0, 2.0, 1.0, 5.0) ) # X axis inverted
+----> 1 print(normalize_rectangle( (4.0, 2.0, 1.0, 5.0) )) # X axis inverted
 
 <ipython-input-20-408dc39f3915> in normalize_rectangle(rect)
       3     assert len(rect) == 4, 'Rectangles must contain 4 coordinates'
@@ -166,7 +166,7 @@ For example,
 if we normalize a rectangle that is taller than it is wide everything seems OK:
 
 ~~~ {.python}
-print normalize_rectangle( (0.0, 0.0, 1.0, 5.0) )
+print(normalize_rectangle( (0.0, 0.0, 1.0, 5.0) ))
 ~~~
 ~~~ {.output}
 (0, 0, 0.2, 1.0)
@@ -176,13 +176,13 @@ but if we normalize one that's wider than it is tall,
 the assertion is triggered:
 
 ~~~ {.python}
-print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
+print(normalize_rectangle( (0.0, 0.0, 5.0, 1.0) ))
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 <ipython-input-24-5f0ef7954aeb> in <module>()
-----> 1 print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
+----> 1 print(normalize_rectangle( (0.0, 0.0, 5.0, 1.0) ))
 
 <ipython-input-20-408dc39f3915> in normalize_rectangle(rect)
      16

--- a/10-cmdline.html
+++ b/10-cmdline.html
@@ -72,14 +72,14 @@
 <h2 id="command-line-arguments">Command-Line Arguments</h2>
 <p>Using the text editor of your choice, save the following in a text file called <code>sys-version.py</code>:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
-<span class="dt">print</span> <span class="st">&#39;version is&#39;</span>, sys.version</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;version is&#39;</span>, sys.version)</code></pre>
 <p>The first line imports a library called <code>sys</code>, which is short for “system”. It defines values such as <code>sys.version</code>, which describes which version of Python we are running. We can run this script from the command line like this:</p>
 <pre class="input"><code>$ python sys-version.py</code></pre>
 <pre class="output"><code>version is 2.7.5 |Anaconda 1.8.0 (x86_64)| (default, Oct 24 2013, 07:02:20)
 [GCC 4.0.1 (Apple Inc. build 5493)]</code></pre>
 <p>Create another file called <code>argv-list.py</code> and save the following text to it.</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> sys
-<span class="dt">print</span> <span class="st">&#39;sys.argv is&#39;</span>, sys.argv</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;sys.argv is&#39;</span>, sys.argv)</code></pre>
 <p>The strange name <code>argv</code> stands for “argument values”. Whenever Python runs a program, it takes all of the values given on the command line and puts them in the list <code>sys.argv</code> so that the program can determine what they were. If we run this program with no arguments:</p>
 <pre class="input"><code>$ python argv-list.py</code></pre>
 <pre class="output"><code>sys.argv is [&#39;argv-list.py&#39;]</code></pre>
@@ -97,7 +97,7 @@
     filename = sys.argv[<span class="dv">1</span>]
     data = numpy.loadtxt(filename, delimiter=<span class="st">&#39;,&#39;</span>)
     <span class="kw">for</span> m in data.mean(axis=<span class="dv">1</span>):
-        <span class="dt">print</span> m</code></pre>
+        <span class="dt">print</span>(m)</code></pre>
 <p>This function gets the name of the script from <code>sys.argv[0]</code>, because that’s where it’s always put, and the name of the file to process from <code>sys.argv[1]</code>. Here’s a simple test:</p>
 <pre class="input"><code>$ python readings-01.py inflammation-01.csv</code></pre>
 <p>There is no output because we have defined a function, but haven’t actually called it. Let’s add a call to <code>main</code>:</p>
@@ -110,7 +110,7 @@
     filename = sys.argv[<span class="dv">1</span>]
     data = numpy.loadtxt(filename, delimiter=<span class="st">&#39;,&#39;</span>)
     <span class="kw">for</span> m in data.mean(axis=<span class="dv">1</span>):
-        <span class="dt">print</span> m
+        <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>and run that:</p>
@@ -205,7 +205,7 @@ main()</code></pre>
     <span class="kw">for</span> filename in sys.argv[<span class="dv">1</span>:]:
         data = numpy.loadtxt(filename, delimiter=<span class="st">&#39;,&#39;</span>)
         <span class="kw">for</span> m in data.mean(axis=<span class="dv">1</span>):
-            <span class="dt">print</span> m
+            <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>and here it is in action:</p>
@@ -244,7 +244,7 @@ main()</code></pre>
             values = data.<span class="dt">max</span>(axis=<span class="dv">1</span>)
 
         <span class="kw">for</span> m in values:
-            <span class="dt">print</span> m
+            <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>This works:</p>
@@ -281,7 +281,7 @@ main()</code></pre>
         values = data.<span class="dt">max</span>(axis=<span class="dv">1</span>)
 
     <span class="kw">for</span> m in values:
-        <span class="dt">print</span> m
+        <span class="dt">print</span>(m)
 
 main()</code></pre>
 <p>This is four lines longer than its predecessor, but broken into more digestible chunks of 8 and 12 lines.</p>
@@ -295,7 +295,7 @@ count = <span class="dv">0</span>
 <span class="kw">for</span> line in sys.stdin:
     count += <span class="dv">1</span>
 
-<span class="dt">print</span> count, <span class="st">&#39;lines in standard input&#39;</span></code></pre>
+<span class="dt">print</span>(count, <span class="st">&#39;lines in standard input&#39;</span>)</code></pre>
 <p>This little program reads lines from a special “file” called <code>sys.stdin</code>, which is automatically connected to the program’s standard input. We don’t have to open it — Python and the operating system take care of that when the program starts up — but we can do almost anything with it that we could do to a regular file. Let’s try running it as if it were a regular command-line program:</p>
 <pre class="input"><code>$ python count-stdin.py &lt; small-01.csv</code></pre>
 <pre class="output"><code>2 lines in standard input</code></pre>

--- a/10-cmdline.md
+++ b/10-cmdline.md
@@ -68,7 +68,7 @@ save the following in a text file called `sys-version.py`:
 
 ~~~ {.python}
 import sys
-print 'version is', sys.version
+print('version is', sys.version)
 ~~~
 
 The first line imports a library called `sys`,
@@ -90,7 +90,7 @@ Create another file called `argv-list.py` and save the following text to it.
 
 ~~~ {.python}
 import sys
-print 'sys.argv is', sys.argv
+print('sys.argv is', sys.argv)
 ~~~
 
 The strange name `argv` stands for "argument values".
@@ -141,7 +141,7 @@ def main():
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)
 ~~~
 
 This function gets the name of the script from `sys.argv[0]`,
@@ -170,7 +170,7 @@ def main():
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)
 
 main()
 ~~~
@@ -323,7 +323,7 @@ def main():
     for filename in sys.argv[1:]:
         data = numpy.loadtxt(filename, delimiter=',')
         for m in data.mean(axis=1):
-            print m
+            print(m)
 
 main()
 ~~~
@@ -384,7 +384,7 @@ def main():
             values = data.max(axis=1)
 
         for m in values:
-            print m
+            print(m)
 
 main()
 ~~~
@@ -442,7 +442,7 @@ def process(filename, action):
         values = data.max(axis=1)
 
     for m in values:
-        print m
+        print(m)
 
 main()
 ~~~
@@ -474,7 +474,7 @@ count = 0
 for line in sys.stdin:
     count += 1
 
-print count, 'lines in standard input'
+print(count, 'lines in standard input')
 ~~~
 
 This little program reads lines from a special "file" called `sys.stdin`,

--- a/code/argv-list.py
+++ b/code/argv-list.py
@@ -1,2 +1,2 @@
 import sys
-print 'sys.argv is', sys.argv
+print('sys.argv is', sys.argv)

--- a/code/count-stdin.py
+++ b/code/count-stdin.py
@@ -4,4 +4,4 @@ count = 0
 for line in sys.stdin:
     count += 1
 
-print count, 'lines in standard input'
+print(count, 'lines in standard input')

--- a/code/errors-01.py
+++ b/code/errors-01.py
@@ -4,4 +4,4 @@ def favorite_ice_cream():
         "vanilla",
         "strawberry"
     ]
-    print ice_creams[3]
+    print(ice_creams[3])

--- a/code/errors-02.py
+++ b/code/errors-02.py
@@ -8,7 +8,7 @@ def print_message(day):
         "saturday": "Hooray for the weekend!",
         "sunday": "Aw, the weekend is almost over."
     }
-    print messages[day]
+    print(messages[day])
 
 
 def print_friday_message():

--- a/code/gen-inflammation.py
+++ b/code/gen-inflammation.py
@@ -16,4 +16,4 @@ for p in range(n_patients):
     for d in range(n_days):
         upper = max(n_range - abs(d - middle), 0)
         vals.append(random.randint(upper/4, upper))
-    print ','.join([str(v) for v in vals])
+    print(','.join([str(v) for v in vals]))

--- a/code/readings-01.py
+++ b/code/readings-01.py
@@ -6,4 +6,4 @@ def main():
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)

--- a/code/readings-02.py
+++ b/code/readings-02.py
@@ -6,6 +6,6 @@ def main():
     filename = sys.argv[1]
     data = numpy.loadtxt(filename, delimiter=',')
     for m in data.mean(axis=1):
-        print m
+        print(m)
 
 main()

--- a/code/readings-03.py
+++ b/code/readings-03.py
@@ -6,6 +6,6 @@ def main():
     for filename in sys.argv[1:]:
         data = numpy.loadtxt(filename, delimiter=',')
         for m in data.mean(axis=1):
-            print m
+            print(m)
 
 main()

--- a/code/readings-04.py
+++ b/code/readings-04.py
@@ -17,6 +17,6 @@ def main():
             values = data.max(axis=1)
 
         for m in values:
-            print m
+            print(m)
 
 main()

--- a/code/readings-05.py
+++ b/code/readings-05.py
@@ -21,6 +21,6 @@ def process(filename, action):
         values = data.max(axis=1)
 
     for m in values:
-        print m
+        print(m)
 
 main()

--- a/code/readings-06.py
+++ b/code/readings-06.py
@@ -24,6 +24,6 @@ def process(filename, action):
         values = data.max(axis=1)
 
     for m in values:
-        print m
+        print(m)
 
 main()

--- a/code/sys-version.py
+++ b/code/sys-version.py
@@ -1,2 +1,2 @@
 import sys
-print 'version is', sys.version
+print('version is', sys.version)

--- a/discussion.html
+++ b/discussion.html
@@ -54,11 +54,11 @@ final = fahr_to_celsius(original)</code></pre>
 <p><img src="fig/python-call-stack-05.svg" alt="Call Stack During Call to Second Nested Function" /><br /> Once again, Python throws away that stack frame when <code>kelvin_to_celsius</code> is done and creates the variable <code>result</code> in the stack frame for <code>fahr_to_celsius</code>:</p>
 <p><img src="fig/python-call-stack-06.svg" alt="Call Stack After Second Nested Function Returns" /><br /> Finally, when <code>fahr_to_celsius</code> is done, Python throws away <em>its</em> stack frame and puts its result in a new variable called <code>final</code> that lives in the stack frame we started with:</p>
 <p><img src="fig/python-call-stack-07.svg" alt="Call Stack After All Functions Have Finished" /><br /> This final stack frame is always there; it holds the variables we defined outside the functions in our code. What it <em>doesn’t</em> hold is the variables that were in the various stack frames. If we try to get the value of <code>temp</code> after our functions have finished running, Python tells us that there’s no such thing:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;final value of temp after all function calls:&#39;</span>, temp</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;final value of temp after all function calls:&#39;</span>, temp)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 &lt;ipython-input-12-ffd9b4dbd5f1&gt; in &lt;module&gt;()
-----&gt; 1 print &#39;final value of temp after all function calls:&#39;, temp
+----&gt; 1 print(&#39;final value of temp after all function calls:&#39;, temp)
 
 NameError: name &#39;temp&#39; is not defined</code></pre>
 <pre class="output"><code>final value of temp after all function calls:</code></pre>
@@ -70,11 +70,11 @@ diff = a.<span class="dt">max</span>() - a.<span class="dt">min</span>()
 <span class="kw">return</span> diff
 
 data = numpy.loadtxt(fname=<span class="st">&#39;inflammation-01.csv&#39;</span>, delimiter=<span class="st">&#39;,&#39;</span>)
-<span class="dt">print</span> <span class="st">&#39;span of data&#39;</span>, span(data)</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;span of data&#39;</span>, span(data))</code></pre>
 <pre class="output"><code>span of data 20.0</code></pre>
 <p>Notice that <code>span</code> assigns a value to a variable called <code>diff</code>. We might very well use a variable with the same name to hold data:</p>
 <pre class="sourceCode python"><code class="sourceCode python">diff = numpy.loadtxt(fname=<span class="st">&#39;inflammation-01.csv&#39;</span>, delimiter=<span class="st">&#39;,&#39;</span>)
-<span class="dt">print</span> <span class="st">&#39;span of data:&#39;</span>, span(diff)</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;span of data:&#39;</span>, span(diff))</code></pre>
 <pre class="output"><code>span of data: 20.0</code></pre>
 <p>We don’t expect <code>diff</code> to have the value 20.0 after this function call, so the name <code>diff</code> cannot refer to the same thing inside <code>span</code> as it does in the main body of our program. And yes, we could probably choose a different name than <code>diff</code> in our main program in this case, but we don’t want to have to read every line of NumPy to see what variable names its functions use before calling any of those functions, just in case they change the values of our variables.</p>
 <p>The big idea here is <a href="reference.html#encapsulation">encapsulation</a>, and it’s the key to writing correct, comprehensible programs. A function’s job is to turn several operations into one so that we can think about a single function call instead of a dozen or a hundred statements each time we want to do something. That only works if functions don’t interfere with each other; if they do, we have to pay attention to the details once again, which quickly overloads our short-term memory.</p>
@@ -84,7 +84,7 @@ data = numpy.loadtxt(fname=<span class="st">&#39;inflammation-01.csv&#39;</span>
 </div>
 <div class="panel-body">
 <p>We previously wrote functions called <code>fence</code> and <code>outer</code>. Draw a diagram showing how the call stack changes when we run the following:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> outer(fence(<span class="st">&#39;carbon&#39;</span>, <span class="st">&#39;+&#39;</span>))</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(outer(fence(<span class="st">&#39;carbon&#39;</span>, <span class="st">&#39;+&#39;</span>)))</code></pre>
 </div>
 </section>
 <h2 id="image-grids">Image Grids</h2>
@@ -98,9 +98,9 @@ grid.show()</code></pre>
 <img src="img/grid-01.png" />
 </div>
 <p>Just like a NumPy array, an <code>ImageGrid</code> has some properties that hold information about it:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;grid width:&#39;</span>, grid.width
-<span class="dt">print</span> <span class="st">&#39;grid height:&#39;</span>, grid.height
-<span class="dt">print</span> <span class="st">&#39;grid lines on:&#39;</span>, grid.lines_on</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;grid width:&#39;</span>, grid.width)
+<span class="dt">print</span>(<span class="st">&#39;grid height:&#39;</span>, grid.height)
+<span class="dt">print</span>(<span class="st">&#39;grid lines on:&#39;</span>, grid.lines_on)</code></pre>
 <pre class="output"><code>grid width: 5
 grid height: 3
 grid lines on: True</code></pre>
@@ -110,22 +110,22 @@ grid lines on: True</code></pre>
 </div>
 <p>An RGB color is an example of a multi-part value: like a Cartesian coordinate, it is one thing with several parts. We can represent such a value in Python using a <a href="reference.html#tuple">tuple</a>, which we write using parentheses instead of the square brackets used for a list:</p>
 <pre class="sourceCode python"><code class="sourceCode python">position = (<span class="fl">12.3</span>, <span class="fl">45.6</span>)
-<span class="dt">print</span> <span class="st">&#39;position is:&#39;</span>, position
+<span class="dt">print</span>(<span class="st">&#39;position is:&#39;</span>, position)
 color = (<span class="dv">10</span>, <span class="dv">20</span>, <span class="dv">30</span>)
-<span class="dt">print</span> <span class="st">&#39;color is:&#39;</span>, color</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;color is:&#39;</span>, color)</code></pre>
 <pre class="output"><code>position is: (12.3, 45.6)
 color is: (10, 20, 30)</code></pre>
 <p>We can select elements from tuples using indexing, just as we do with lists and arrays:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;first element of color is:&#39;</span>, color[<span class="dv">0</span>]</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;first element of color is:&#39;</span>, color[<span class="dv">0</span>])</code></pre>
 <pre class="output"><code>first element of color is: 10</code></pre>
 <p>Unlike lists and arrays, though, tuples cannot be changed after they are created — in technical terms, they are <a href="reference.html#immutable">immutable</a>:</p>
 <pre class="sourceCode python"><code class="sourceCode python">color[<span class="dv">0</span>] = <span class="dv">40</span>
-<span class="dt">print</span> <span class="st">&#39;first element of color after change:&#39;</span>, color[<span class="dv">0</span>]</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;first element of color after change:&#39;</span>, color[<span class="dv">0</span>])</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 TypeError                                 Traceback (most recent call last)
 &lt;ipython-input-11-9c3dd30a4e52&gt; in &lt;module&gt;()
 ----&gt; 1 color[0] = 40
-2 print &#39;first element of color after change:&#39;, color[0]
+2 print(&#39;first element of color after change:&#39;, color[0])
 
 TypeError: &#39;tuple&#39; object does not support item assignment</code></pre>
 <p>If a tuple represents an RGB color, its red, green, and blue components can take on values between 0 and 255. The upper bound may seem odd, but it’s the largest number that can be represented in an 8-bit byte (i.e., 2<sup>8</sup>-1). This makes it easy for computers to manipulate colors, while providing fine enough gradations to fool most human eyes, most of the time.</p>

--- a/discussion.md
+++ b/discussion.md
@@ -88,13 +88,13 @@ If we try to get the value of `temp` after our functions have finished running,
 Python tells us that there's no such thing:
 
 ~~~ {.python}
-print 'final value of temp after all function calls:', temp
+print('final value of temp after all function calls:', temp)
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 <ipython-input-12-ffd9b4dbd5f1> in <module>()
-----> 1 print 'final value of temp after all function calls:', temp
+----> 1 print('final value of temp after all function calls:', temp)
 
 NameError: name 'temp' is not defined
 ~~~
@@ -115,7 +115,7 @@ diff = a.max() - a.min()
 return diff
 
 data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
-print 'span of data', span(data)
+print('span of data', span(data))
 ~~~
 ~~~ {.output}
 span of data 20.0
@@ -126,7 +126,7 @@ We might very well use a variable with the same name to hold data:
 
 ~~~ {.python}
 diff = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
-print 'span of data:', span(diff)
+print('span of data:', span(diff))
 ~~~
 ~~~ {.output}
 span of data: 20.0
@@ -157,7 +157,7 @@ which quickly overloads our short-term memory.
 > Draw a diagram showing how the call stack changes when we run the following:
 >
 > ~~~ {.python}
-> print outer(fence('carbon', '+'))
+> print(outer(fence('carbon', '+')))
 > ~~~
 
 ## Image Grids
@@ -190,9 +190,9 @@ Just like a NumPy array,
 an `ImageGrid` has some properties that hold information about it:
 
 ~~~ {.python}
-print 'grid width:', grid.width
-print 'grid height:', grid.height
-print 'grid lines on:', grid.lines_on
+print('grid width:', grid.width)
+print('grid height:', grid.height)
+print('grid lines on:', grid.lines_on)
 ~~~
 ~~~ {.output}
 grid width: 5
@@ -219,9 +219,9 @@ which we write using parentheses instead of the square brackets used for a list:
 
 ~~~ {.python}
 position = (12.3, 45.6)
-print 'position is:', position
+print('position is:', position)
 color = (10, 20, 30)
-print 'color is:', color
+print('color is:', color)
 ~~~
 
 ~~~ {.output}
@@ -233,7 +233,7 @@ We can select elements from tuples using indexing,
 just as we do with lists and arrays:
 
 ~~~ {.python}
-print 'first element of color is:', color[0]
+print('first element of color is:', color[0])
 ~~~
 
 ~~~ {.output}
@@ -247,14 +247,14 @@ they are [immutable](reference.html#immutable):
 
 ~~~ {.python}
 color[0] = 40
-print 'first element of color after change:', color[0]
+print('first element of color after change:', color[0])
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 TypeError                                 Traceback (most recent call last)
 <ipython-input-11-9c3dd30a4e52> in <module>()
 ----> 1 color[0] = 40
-2 print 'first element of color after change:', color[0]
+2 print('first element of color after change:', color[0])
 
 TypeError: 'tuple' object does not support item assignment
 ~~~

--- a/reference.html
+++ b/reference.html
@@ -34,7 +34,7 @@
 <li>Use the <code>numpy</code> library to work with arrays in Python.</li>
 <li>Use <code>variable = value</code> to assign a value to a variable in order to record it in memory.</li>
 <li>Variables are created on demand whenever a value is assigned to them.</li>
-<li>Use <code>print something</code> to display the value of <code>something</code>.</li>
+<li>Use <code>print(something)</code> to display the value of <code>something</code>.</li>
 <li>The expression <code>array.shape</code> gives the shape of an array.</li>
 <li>Use <code>array[x, y]</code> to select a single element from an array.</li>
 <li>Array indices start at 0, not 1.</li>
@@ -126,181 +126,181 @@
 <h2 id="glossary">Glossary</h2>
 <dl>
 <dt><span id="additive-color-model">additive color model</span></dt>
-<dd>A way to represent colors as the sum of contributions from primary colors such as <a href="#rgb">red, green, and blue</a>.
+<dd><p>A way to represent colors as the sum of contributions from primary colors such as <a href="#rgb">red, green, and blue</a>.</p>
 </dd>
 <dt><span id="argument">argument</span></dt>
-<dd>A value given to a function or program when it runs. The term is often used interchangeably (and inconsistently) with <a href="#parameter">parameter</a>.
+<dd><p>A value given to a function or program when it runs. The term is often used interchangeably (and inconsistently) with <a href="#parameter">parameter</a>.</p>
 </dd>
 <dt><span id="assertion">assertion</span></dt>
-<dd>An expression which is supposed to be true at a particular point in a program. Programmers typically put assertions in their code to check for errors; if the assertion fails (i.e., if the expression evaluates as false), the program halts and produces an error message. See also: <a href="#invariant">invariant</a>, <a href="#precondition">precondition</a>, <a href="#postcondition">postcondition</a>.
+<dd><p>An expression which is supposed to be true at a particular point in a program. Programmers typically put assertions in their code to check for errors; if the assertion fails (i.e., if the expression evaluates as false), the program halts and produces an error message. See also: <a href="#invariant">invariant</a>, <a href="#precondition">precondition</a>, <a href="#postcondition">postcondition</a>.</p>
 </dd>
 <dt><span id="assign">assign</span></dt>
-<dd>To give a value a name by associating a variable with it.
+<dd><p>To give a value a name by associating a variable with it.</p>
 </dd>
 <dt><span id="body">body</span></dt>
-<dd>(of a function): the statements that are executed when a function runs.
+<dd><p>(of a function): the statements that are executed when a function runs.</p>
 </dd>
 <dt><span id="call-stack">call stack</span></dt>
-<dd>A data structure inside a running program that keeps track of active function calls.
+<dd><p>A data structure inside a running program that keeps track of active function calls.</p>
 </dd>
 <dt><span id="case-insensitive">case-insensitive</span></dt>
-<dd>Treating text as if upper and lower case characters of the same letter were the same. See also: <a href="#case-sensitive">case-sensitive</a>.
+<dd><p>Treating text as if upper and lower case characters of the same letter were the same. See also: <a href="#case-sensitive">case-sensitive</a>.</p>
 </dd>
 <dt><span id="case-sensitive">case-sensitive</span></dt>
-<dd>Treating text as if upper and lower case characters of the same letter are different. See also: <a href="#case-insensitive">case-insensitive</a>.
+<dd><p>Treating text as if upper and lower case characters of the same letter are different. See also: <a href="#case-insensitive">case-insensitive</a>.</p>
 </dd>
 <dt><span id="comment">comment</span></dt>
-<dd>A remark in a program that is intended to help human readers understand what is going on, but is ignored by the computer. Comments in Python, R, and the Unix shell start with a <code>#</code> character and run to the end of the line; comments in SQL start with <code>--</code>, and other languages have other conventions.
+<dd><p>A remark in a program that is intended to help human readers understand what is going on, but is ignored by the computer. Comments in Python, R, and the Unix shell start with a <code>#</code> character and run to the end of the line; comments in SQL start with <code>--</code>, and other languages have other conventions.</p>
 </dd>
 <dt><span id="compose">compose</span></dt>
-<dd>To apply one function to the result of another, such as <code>f(g(x))</code>.
+<dd><p>To apply one function to the result of another, such as <code>f(g(x))</code>.</p>
 </dd>
 <dt><span id="conditional-statement">conditional statement</span></dt>
-<dd>A statement in a program that might or might not be executed depending on whether a test is true or false.
+<dd><p>A statement in a program that might or might not be executed depending on whether a test is true or false.</p>
 </dd>
 <dt><span id="comma-separated-values">comma-separated values</span></dt>
-<dd>(CSV) A common textual representation for tables in which the values in each row are separated by commas.
+<dd><p>(CSV) A common textual representation for tables in which the values in each row are separated by commas.</p>
 </dd>
 <dt><span id="default-value">default value</span></dt>
-<dd>A value to use for a <a href="#parameter">parameter</a> if nothing is specified explicitly.
+<dd><p>A value to use for a <a href="#parameter">parameter</a> if nothing is specified explicitly.</p>
 </dd>
 <dt><span id="defensive-programming">defensive programming</span></dt>
-<dd>The practice of writing programs that check their own operation to catch errors as early as possible.
+<dd><p>The practice of writing programs that check their own operation to catch errors as early as possible.</p>
 </dd>
 <dt><span id="delimiter">delimiter</span></dt>
-<dd>A character or characters used to separate individual values, such as the commas between columns in a <a href="#comma-separated-values">CSV</a> file.
+<dd><p>A character or characters used to separate individual values, such as the commas between columns in a <a href="#comma-separated-values">CSV</a> file.</p>
 </dd>
 <dt><span id="docstring">docstring</span></dt>
-<dd>Short for “documentation string”, this refers to textual documentation embedded in Python programs. Unlike comments, docstrings are preserved in the running program and can be examined in interactive sessions.
+<dd><p>Short for “documentation string”, this refers to textual documentation embedded in Python programs. Unlike comments, docstrings are preserved in the running program and can be examined in interactive sessions.</p>
 </dd>
 <dt><span id="documentation">documentation</span></dt>
-<dd>Human-language text written to explain what software does, how it works, or how to use it.
+<dd><p>Human-language text written to explain what software does, how it works, or how to use it.</p>
 </dd>
 <dt><span id="dotted-notation">dotted notation</span></dt>
-<dd>A two-part notation used in many programming languages in which <code>thing.component</code> refers to the <code>component</code> belonging to <code>thing</code>.
+<dd><p>A two-part notation used in many programming languages in which <code>thing.component</code> refers to the <code>component</code> belonging to <code>thing</code>.</p>
 </dd>
 <dt><span id="empty-string">empty string</span></dt>
-<dd>A character string containing no characters, often thought of as the “zero” of text.
+<dd><p>A character string containing no characters, often thought of as the “zero” of text.</p>
 </dd>
 <dt><span id="encapsulation">encapsulation</span></dt>
-<dd>The practice of hiding something’s implementation details so that the rest of a program can worry about <em>what</em> it does rather than <em>how</em> it does it.
+<dd><p>The practice of hiding something’s implementation details so that the rest of a program can worry about <em>what</em> it does rather than <em>how</em> it does it.</p>
 </dd>
 <dt><span id="floating-point-number">floating-point number</span></dt>
-<dd>A number containing a fractional part and an exponent. See also: <a href="#integer">integer</a>.
+<dd><p>A number containing a fractional part and an exponent. See also: <a href="#integer">integer</a>.</p>
 </dd>
 <dt><span id="for-loop">for loop</span></dt>
-<dd>A loop that is executed once for each value in some kind of set, list, or range. See also: <a href="#while-loop">while loop</a>.
+<dd><p>A loop that is executed once for each value in some kind of set, list, or range. See also: <a href="#while-loop">while loop</a>.</p>
 </dd>
 <dt><span id="function-call">function call</span></dt>
-<dd>A use of a function in another piece of software.
+<dd><p>A use of a function in another piece of software.</p>
 </dd>
 <dt><span id="immutable">immutable</span></dt>
-<dd>Unchangeable. The value of immutable data cannot be altered after it has been created. See also: <a href="#mutable">mutable</a>.
+<dd><p>Unchangeable. The value of immutable data cannot be altered after it has been created. See also: <a href="#mutable">mutable</a>.</p>
 </dd>
 <dt><span id="import">import</span></dt>
-<dd>To load a <a href="#library">library</a> into a program.
+<dd><p>To load a <a href="#library">library</a> into a program.</p>
 </dd>
 <dt><span id="in-place-operators">in-place operators</span></dt>
-<dd>An operator such as <code>+=</code> that provides a shorthand notation for the common case in which the variable being assigned to is also an operand on the right hand side of the assignment. For example, the statement <code>x += 3</code> means the same thing as <code>x = x + 3</code>.
+<dd><p>An operator such as <code>+=</code> that provides a shorthand notation for the common case in which the variable being assigned to is also an operand on the right hand side of the assignment. For example, the statement <code>x += 3</code> means the same thing as <code>x = x + 3</code>.</p>
 </dd>
 <dt><span id="index">index</span></dt>
-<dd>A subscript that specifies the location of a single value in a collection, such as a single pixel in an image.
+<dd><p>A subscript that specifies the location of a single value in a collection, such as a single pixel in an image.</p>
 </dd>
 <dt><span id="inner-loop">inner loop</span></dt>
-<dd>A loop that is inside another loop. See also: <a href="#outer-loop">outer loop</a>.
+<dd><p>A loop that is inside another loop. See also: <a href="#outer-loop">outer loop</a>.</p>
 </dd>
 <dt><span id="integer">integer</span></dt>
-<dd>A whole number, such as -12343. See also: <a href="#floating-point-number">floating-point number</a>.
+<dd><p>A whole number, such as -12343. See also: <a href="#floating-point-number">floating-point number</a>.</p>
 </dd>
 <dt><span id="invariant">invariant</span></dt>
-<dd>An expression whose value doesn’t change during the execution of a program, typically used in an <a href="#assertion">assertion</a>. See also: <a href="#precondition">precondition</a>, <a href="#postcondition">postcondition</a>.
+<dd><p>An expression whose value doesn’t change during the execution of a program, typically used in an <a href="#assertion">assertion</a>. See also: <a href="#precondition">precondition</a>, <a href="#postcondition">postcondition</a>.</p>
 </dd>
 <dt><span id="library">library</span></dt>
-<dd>A family of code units (functions, classes, variables) that implement a set of related tasks.
+<dd><p>A family of code units (functions, classes, variables) that implement a set of related tasks.</p>
 </dd>
 <dt><span id="loop-variable">loop variable</span></dt>
-<dd>The variable that keeps track of the progress of the loop.
+<dd><p>The variable that keeps track of the progress of the loop.</p>
 </dd>
 <dt><span id="member">member</span></dt>
-<dd>A variable contained within an <a href="#object">object</a>.
+<dd><p>A variable contained within an <a href="#object">object</a>.</p>
 </dd>
 <dt><span id="method">method</span></dt>
-<dd>A function which is tied to a particular <a href="#object">object</a>. Each of an object’s methods typically implements one of the things it can do, or one of the questions it can answer.
+<dd><p>A function which is tied to a particular <a href="#object">object</a>. Each of an object’s methods typically implements one of the things it can do, or one of the questions it can answer.</p>
 </dd>
 <dt><span id="object">object</span></dt>
-<dd>A collection of conceptually related variables (<a href="#member">members</a>) and functions using those variables (<a href="#method">methods</a>).
+<dd><p>A collection of conceptually related variables (<a href="#member">members</a>) and functions using those variables (<a href="#method">methods</a>).</p>
 </dd>
 <dt><span id="outer-loop">outer loop</span></dt>
-<dd>A loop that contains another loop. See also: <a href="#inner-loop">inner loop</a>.
+<dd><p>A loop that contains another loop. See also: <a href="#inner-loop">inner loop</a>.</p>
 </dd>
 <dt><span id="parameter">parameter</span></dt>
-<dd>A variable named in the function’s declaration that is used to hold a value passed into the call. The term is often used interchangeably (and inconsistently) with <a href="#argument">argument</a>.
+<dd><p>A variable named in the function’s declaration that is used to hold a value passed into the call. The term is often used interchangeably (and inconsistently) with <a href="#argument">argument</a>.</p>
 </dd>
 <dt><span id="pipe">pipe</span></dt>
-<dd>A connection from the output of one program to the input of another. When two or more programs are connected in this way, they are called a “pipeline”.
+<dd><p>A connection from the output of one program to the input of another. When two or more programs are connected in this way, they are called a “pipeline”.</p>
 </dd>
 <dt><span id="postcondition">postcondition</span></dt>
-<dd>A condition that a function (or other block of code) guarantees is true once it has finished running. Postconditions are often represented using <a href="#assertion">assertions</a>.
+<dd><p>A condition that a function (or other block of code) guarantees is true once it has finished running. Postconditions are often represented using <a href="#assertion">assertions</a>.</p>
 </dd>
 <dt><span id="precondition">precondition</span></dt>
-<dd>A condition that must be true in order for a function (or other block of code) to run correctly.
+<dd><p>A condition that must be true in order for a function (or other block of code) to run correctly.</p>
 </dd>
 <dt><span id="regression">regression</span></dt>
-<dd>To re-introduce a bug that was once fixed.
+<dd><p>To re-introduce a bug that was once fixed.</p>
 </dd>
 <dt><span id="return-statement">return statement</span></dt>
-<dd>A statement that causes a function to stop executing and return a value to its caller immediately.
+<dd><p>A statement that causes a function to stop executing and return a value to its caller immediately.</p>
 </dd>
 <dt><span id="rgb">RGB</span></dt>
-<dd>An <a href="#additive-color-model">additive model</a> that represents colors as combinations of red, green, and blue. Each color’s value is typically in the range 0..255 (i.e., a one-byte integer).
+<dd><p>An <a href="#additive-color-model">additive model</a> that represents colors as combinations of red, green, and blue. Each color’s value is typically in the range 0..255 (i.e., a one-byte integer).</p>
 </dd>
 <dt><span id="sequence">sequence</span></dt>
-<dd>A collection of information that is presented in a specific order. For example, in Python, a <a href="#string">string</a> is a sequence of characters, while a list is a sequence of any variable.
+<dd><p>A collection of information that is presented in a specific order. For example, in Python, a <a href="#string">string</a> is a sequence of characters, while a list is a sequence of any variable.</p>
 </dd>
 <dt><span id="shape">shape</span></dt>
-<dd>An array’s dimensions, represented as a vector. For example, a 5×3 array’s shape is <code>(5,3)</code>.
+<dd><p>An array’s dimensions, represented as a vector. For example, a 5×3 array’s shape is <code>(5,3)</code>.</p>
 </dd>
 <dt><span id="silent-failure">silent failure</span></dt>
-<dd>Failing without producing any warning messages. Silent failures are hard to detect and debug.
+<dd><p>Failing without producing any warning messages. Silent failures are hard to detect and debug.</p>
 </dd>
 <dt><span id="slice">slice</span></dt>
-<dd>A regular subsequence of a larger sequence, such as the first five elements or every second element.
+<dd><p>A regular subsequence of a larger sequence, such as the first five elements or every second element.</p>
 </dd>
 <dt><span id="stack-frame">stack frame</span></dt>
-<dd>A data structure that provides storage for a function’s local variables. Each time a function is called, a new stack frame is created and put on the top of the <a href="#call-stack">call stack</a>. When the function returns, the stack frame is discarded.
+<dd><p>A data structure that provides storage for a function’s local variables. Each time a function is called, a new stack frame is created and put on the top of the <a href="#call-stack">call stack</a>. When the function returns, the stack frame is discarded.</p>
 </dd>
 <dt><span id="standard-input">standard input</span></dt>
-<dd>A process’s default input stream. In interactive command-line applications, it is typically connected to the keyboard; in a <a href="#pipe">pipe</a>, it receives data from the <a href="#standard-output">standard output</a> of the preceding process.
+<dd><p>A process’s default input stream. In interactive command-line applications, it is typically connected to the keyboard; in a <a href="#pipe">pipe</a>, it receives data from the <a href="#standard-output">standard output</a> of the preceding process.</p>
 </dd>
 <dt><span id="standard-output">standard output</span></dt>
-<dd>A process’s default output stream. In interactive command-line applications, data sent to standard output is displayed on the screen; in a <a href="#pipe">pipe</a>, it is passed to the <a href="#standard-input">standard input</a> of the next process.
+<dd><p>A process’s default output stream. In interactive command-line applications, data sent to standard output is displayed on the screen; in a <a href="#pipe">pipe</a>, it is passed to the <a href="#standard-input">standard input</a> of the next process.</p>
 </dd>
 <dt><span id="string">string</span></dt>
-<dd>Short for “character string”, a <a href="#sequence">sequence</a> of zero or more characters.
+<dd><p>Short for “character string”, a <a href="#sequence">sequence</a> of zero or more characters.</p>
 </dd>
 <dt><span id="syntax-error">syntax error</span></dt>
-<dd>A programming error that occurs when statements are in an order or contain characters not expected by the programming language.
+<dd><p>A programming error that occurs when statements are in an order or contain characters not expected by the programming language.</p>
 </dd>
 <dt><span id="test-oracle">test oracle</span></dt>
-<dd>A program, device, data set, or human being against which the results of a test can be compared.
+<dd><p>A program, device, data set, or human being against which the results of a test can be compared.</p>
 </dd>
 <dt><span id="test-driven-development">test-driven development</span></dt>
-<dd>The practice of writing unit tests <em>before</em> writing the code they test.
+<dd><p>The practice of writing unit tests <em>before</em> writing the code they test.</p>
 </dd>
 <dt><span id="traceback">traceback</span></dt>
-<dd>The sequence of function calls that led to an error.
+<dd><p>The sequence of function calls that led to an error.</p>
 </dd>
 <dt><span id="tuple">tuple</span></dt>
-<dd>An <a href="#immutable">immutable</a> <a href="#sequence">sequence</a> of values.
+<dd><p>An <a href="#immutable">immutable</a> <a href="#sequence">sequence</a> of values.</p>
 </dd>
 <dt><span id="type">type</span></dt>
-<dd>The classification of something in a program (for example, the contents of a variable) as a kind of number (e.g. <a href="#float">floating-point</a>, <a href="#integer">integer</a>), <a href="#string">string</a>, or something else.
+<dd><p>The classification of something in a program (for example, the contents of a variable) as a kind of number (e.g. <a href="#float">floating-point</a>, <a href="#integer">integer</a>), <a href="#string">string</a>, or something else.</p>
 </dd>
 <dt><span id="type-of-error">type of error</span></dt>
-<dd>Indicates the nature of an error in a program. For example, in Python, an <code>IOError</code> to problems with file input/output. See also: <a href="#syntax-error">syntax error</a>.
+<dd><p>Indicates the nature of an error in a program. For example, in Python, an <code>IOError</code> to problems with file input/output. See also: <a href="#syntax-error">syntax error</a>.</p>
 </dd>
 <dt><span id="while-loop">while loop</span></dt>
-<dd>A loop that keeps executing as long as some condition is true. See also: <a href="#for-loop">for loop</a>.
+<dd><p>A loop that keeps executing as long as some condition is true. See also: <a href="#for-loop">for loop</a>.</p>
 </dd>
 </dl>
         </div>

--- a/reference.md
+++ b/reference.md
@@ -9,7 +9,7 @@ subtitle: Reference
 *   Use the `numpy` library to work with arrays in Python.
 *   Use `variable = value` to assign a value to a variable in order to record it in memory.
 *   Variables are created on demand whenever a value is assigned to them.
-*   Use `print something` to display the value of `something`.
+*   Use `print(something)` to display the value of `something`.
 *   The expression `array.shape` gives the shape of an array.
 *   Use `array[x, y]` to select a single element from an array.
 *   Array indices start at 0, not 1.


### PR DESCRIPTION
The first big difference between Python 2 and 3 is that [print is now a function](https://docs.python.org/3.0/whatsnew/3.0.html#print-is-a-function). This is a really easy change to make (emacs's M-x replace-regexp is my new friend), but one has to make it nearly *everywhere*, so this is a big diff.

I *think* that I found all of the occurrences, but feedback is welcome.