### PR TITLE
Insert empty line to restore bullet point list formatting.

### DIFF
--- a/instructors.md
+++ b/instructors.md
@@ -50,6 +50,7 @@ Explain that we use Python because:
 We do *not* include instructions on running the IPython Notebook in the tutorial
 because we want to focus on the language rather than the tools.
 Instructors should, however, walk learners through some basic operations:
+
 *   Launch from the command line with `ipython notebook`.
 *   Create a new notebook.
 *   Enter code or data in a cell and execute it.


### PR DESCRIPTION
I'm not fully sure, but it appears that you have to have an empty line preceding and following an enumeration to have it properly convert in Jekyll. (This is slightly different from Github's Markdown rendering.)