### PR TITLE
Better explanation for base-0 indexing

### DIFF
--- a/01-numpy.md
+++ b/01-numpy.md
@@ -235,7 +235,7 @@ but `data[0, 0]` might.
 Programming languages like Fortran and MATLAB start counting at 1,
 because that's what human beings have done for thousands of years.
 Languages in the C family (including C++, Java, Perl, and Python) count from 0
-because that's simpler for computers to do.
+because that's more convenient when indices are computed rather than constant.
 As a result,
 if we have an M&times;N array in Python,
 its indices go from 0 to M-1 on the first axis


### PR DESCRIPTION
The argument "that’s simpler for computers to do" is not credible.
Compilers and interpreters can easily handle an offset of one.
The choice of index base is made with human convenience in mind.