### PR TITLE
Adding call stack section

### DIFF
--- a/06-func.md
+++ b/06-func.md
@@ -9,6 +9,7 @@ minutes: 30
 > *   Define a function that takes parameters.
 > *   Return a value from a function.
 > *   Test and debug a function.
+> *   Explain what a call stack is, and trace changes to the call stack as functions are called.
 > *   Set default values for function parameters.
 > *   Explain why we should divide programs into small, single-purpose functions.
 
@@ -166,10 +167,115 @@ Real-life functions will usually be larger than the ones shown here --- typicall
 they shouldn't ever be much longer than that,
 or the next person who reads it won't be able to understand what's going on.
 
+### The Call Stack
+
+Let's take a closer look at what happens when we call `fahr_to_celsius(32)`. To make things clearer, we'll start by putting the initial value 32 in a variable and store the final result in one as well:
+
+
+~~~{.python}
+original = 32
+final = fahr_to_celsius(original)
+~~~
+
+
+The diagram below shows what memory looks like after the first line has been executed:
+
+<img src="fig/python-call-stack-01.svg" alt="Call Stack (Initial State)" />
+
+When we call `fahr_to_celsius`, Python *doesn't* create the variable `temp` right away.
+Instead, it creates something called a [stack frame](reference.html#stack-frame) to keep track of the variables defined by `fahr_to_kelvin`.
+Initially, this stack frame only holds the value of `temp`:
+
+<img src="fig/python-call-stack-02.svg" alt="Call Stack Immediately After First Function Call" />
+
+When we call `fahr_to_kelvin` inside `fahr_to_celsius`, Python creates another stack frame to hold `fahr_to_kelvin`'s variables:
+
+<img src="fig/python-call-stack-03.svg" alt="Call Stack During First Nested Function Call" />
+
+It does this because there are now two variables in play called `temp`: the argument to `fahr_to_celsius`, and the argument to `fahr_to_kelvin`.
+Having two variables with the same name in the same part of the program would be ambiguous, so Python (and every other modern programming language) creates a new stack frame for each function call to keep that function's variables separate from those defined by other functions.
+
+When the call to `fahr_to_kelvin` returns a value, Python throws away `fahr_to_kelvin`'s stack frame and creates a new variable in the stack frame for `fahr_to_celsius` to hold the temperature in Kelvin:
+
+<img src="fig/python-call-stack-04.svg" alt="Call Stack After Return From First Nested Function Call" />
+
+It then calls `kelvin_to_celsius`, which means it creates a stack frame to hold that function's variables:
+
+<img src="fig/python-call-stack-05.svg" alt="Call Stack During Call to Second Nested Function" />
+
+Once again, Python throws away that stack frame when `kelvin_to_celsius` is done
+and creates the variable `result` in the stack frame for `fahr_to_celsius`:
+
+<img src="fig/python-call-stack-06.svg" alt="Call Stack After Second Nested Function Returns" />
+
+Finally, when `fahr_to_celsius` is done, Python throws away *its* stack frame and puts its result in a new variable called `final` that lives in the stack frame we started with:
+
+<img src="fig/python-call-stack-07.svg" alt="Call Stack After All Functions Have Finished" />
+
+This final stack frame is always there;
+it holds the variables we defined outside the functions in our code.
+What it *doesn't* hold is the variables that were in the various stack frames.
+If we try to get the value of `temp` after our functions have finished running, Python tells us that there's no such thing:
+
+
+~~~{.python}
+print(temp)
+~~~
+~~~{.error}
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+NameError: name 'temp' is not defined
+~~~
+
+> ## Tip {.callout}
+>
+> The explanation of the stack frame above was very general and the basic
+> concept will help you understand most languages you try to program with.
+
+
+Why go to all this trouble? Well, here's a function called `span` that calculates the difference between the minimum and maximum values in an array:
+
+
+~~~{.python}
+import numpy as np
+
+def span(a):
+    diff = np.max(a) - np.min(a)
+    return diff
+
+dat = np.loadtxt(fname='data/inflammation-01.csv', delimiter=',')
+
+# span of inflammation data
+span(dat)
+~~~
+~~~{.output}
+20
+~~~
+
+Notice `span` assigns a value to variable called `diff`. We might very well use a variable with the same name (`diff`) to hold the inflammation data:
+
+
+~~~{.python}
+diff = np.loadtxt(fname='diff/inflammation-01.csv', delimiter=',')
+
+# span of inflammation data
+span(data)
+~~~
+~~~{.output}
+20
+~~~
+
+We don't expect the variable `diff` to have the value 20 after this function call, so the name `diff` cannot refer to the same variable defined inside `span` as it does in as it does in the main body of our program (which Python refers to as the global environment).
+And yes, we could probably choose a different name than `diff` for our variable in this case, but we don't want to have to read every line of code of the Python functions we call to see what variable names they use, just in case they change the values of our variables.
+
+The big idea here is [encapsulation](reference.html#encapsulation), and it's the key to writing correct, comprehensible programs.
+A function's job is to turn several operations into one so that we can think about a single function call instead of a dozen or a hundred statements each time we want to do something.
+That only works if functions don't interfere with each other; if they do, we have to pay attention to the details once again, which quickly overloads our short-term memory.
+
 ## Tidying up
 
 Now that we know how to wrap bits of code up in functions,
-we can make our inflammation analyasis easier to read and easier to reuse.
+we can make our inflammation analysis easier to read and easier to reuse.
 First, let's make an `analyze` function that generates our plots:
 
 ~~~ {.python}


### PR DESCRIPTION
In the `Programming with R` lesson, the [`Creating functions` topic](https://swcarpentry.github.io/r-novice-inflammation/02-func-R.html) contains a section about call stack. The python lesson also has a `Creating functions` topic, which does not contain this section. It would be consistent to teach about call stacks in both languages. This pull request adds such section to the Python lesson.

