### PR TITLE
Fix formatting for python division example

### DIFF
--- a/06-func.md
+++ b/06-func.md
@@ -113,6 +113,7 @@ and we have access to the value that we returned.
 >
 > And if you want an integer result from division in Python 3,
 > use a double-slash:
+>
 > ~~~ {.python}
 > 4//2
 > ~~~


### PR DESCRIPTION
Add missing `>` which lead to improper formatting.

Before:
![image](https://cloud.githubusercontent.com/assets/79268/12102787/f7a3a856-b302-11e5-9581-eb48eec6c5e8.png)

After:
![image](https://cloud.githubusercontent.com/assets/79268/12102827/4a9b3934-b303-11e5-8943-7f205488331e.png)

