### PR TITLE
Add blank line to fix code block formatting

### DIFF
--- a/03-lists.md
+++ b/03-lists.md
@@ -223,6 +223,7 @@ This is different from how variables worked in lesson 1, and more similar to how
 > ["h", "e", "l", "l", "o"]
 > ~~~
 > Hint: You can create an empty list like this:
+>
 > ~~~ {.python}
 > my_list = []
 > ~~~


### PR DESCRIPTION
The generated HTML doesn't display 226--229 as a code block. It looks like pandoc requires a blank line before code blocks, but Github's builtin markdown renderer doesn't... Standards!