### PR TITLE
Remove reference to size of indent

### DIFF
--- a/06-func.md
+++ b/06-func.md
@@ -39,8 +39,7 @@ The function definition opens with the word `def`,
 which is followed by the name of the function
 and a parenthesized list of parameter names.
 The [body](reference.html#function-body) of the function --- the
-statements that are executed when it runs --- is indented below the definition line,
-typically by four spaces.
+statements that are executed when it runs --- is indented below the definition line.
 
 When we call the function,
 the values we pass to it are assigned to those variables


### PR DESCRIPTION
I think referring to the size of indents at this point could cause confusion. Given that it's not the first time we refer to indents, a reader might think that there is something about functions in particular that means that means they should be indented by four spaces. Also, this is already better dealt with in lesson 7.