### PR TITLE
Clarify expression of error types

### DIFF
--- a/07-errors.md
+++ b/07-errors.md
@@ -336,7 +336,7 @@ this will fail.
 The correct path would be `writing/myfile.txt`.
 It is also possible (like with `NameError`) that you just made a typo.
 
-Another issue could be that you used the "read" flag instead of the "write" flag.
+A related issue can occur if you use the "read" flag instead of the "write" flag.
 Python will not give you an error if you try to open a file for writing when the file does not exist.
 However,
 if you meant to open a file for reading,


### PR DESCRIPTION
Without this change, it could be interpreted to mean that using the "read" flag instead of the "write" flag can cause a `FileNotFoundError`, whereas it's a different type of error entirely.