### PR TITLE
changed 'lettuce' to 'zucchini' in 03-lists.md

### DIFF
--- a/03-lists.md
+++ b/03-lists.md
@@ -133,7 +133,7 @@ does not.
 > ~~~
 >
 > ~~~ {.output}
-> [['pepper', 'lettuce', 'onion']]
+> [['pepper', 'zucchini', 'onion']]
 > ~~~
 >
 > ~~~ {.python}
@@ -141,7 +141,7 @@ does not.
 > ~~~
 >
 > ~~~ {.output}
-> ['pepper', 'lettuce', 'onion']
+> ['pepper', 'zucchini', 'onion']
 > ~~~
 >
 > ~~~ {.python}

--- a/04-files.md
+++ b/04-files.md
@@ -21,7 +21,7 @@ that finds files whose names match a pattern.
 We provide those patterns as strings:
 the character `*` matches zero or more characters,
 while `?` matches any one character.
-We can use this to get the names of all the HTML files in the current directory:
+We can use this to get the names of all the csv files in the current directory:
 
 ~~~ {.python}
 print(glob.glob('data/inflammation*.csv'))


### PR DESCRIPTION
In the nested lists example (in 03-lists.md), the nested list created is 

```
x = [['pepper', 'zucchini', 'onion'],
     ['cabbage', 'lettuce', 'garlic'],
     ['apple', 'pear', 'banana']]
```
but in the outputs the second item of the first list is indicated as 'lettuce', e.g. print([x[0]])

was 

```
[['pepper', 'lettuce', 'onion']]
```

fixed that to `['pepper', 'zucchini', 'onion']` on line 136 and 144