### PR TITLE
Update numpy.md, files.md

### DIFF
--- a/01-numpy.md
+++ b/01-numpy.md
@@ -511,6 +511,7 @@ and use two of its functions to create and display a heat map of our data:
 
 ~~~ {.python}
 import matplotlib.pyplot
+% matplotlib inline
 image  = matplotlib.pyplot.imshow(data)
 matplotlib.pyplot.show(image)
 ~~~

--- a/04-files.md
+++ b/04-files.md
@@ -24,7 +24,7 @@ while `?` matches any one character.
 We can use this to get the names of all the HTML files in the current directory:
 
 ~~~ {.python}
-print(glob.glob('data/inflammation*.csv'))
+print(sorted(glob.glob('data/inflammation*.csv')))
 ~~~
 
 ~~~ {.output}


### PR DESCRIPTION
Modification to numpy.md
I instructed a python workshop and only introduced the magic command `% matplotlib inline` _after_ getting participants to run the section to show the heat map. I learned that on some computers (Macs, and a few Windows), the ipython notebook hangs if the magic command is not specified - a handful of participants were forced to shut down the notebook and restart. It would be helpful to include the magic command earlier when plotting the graphs to prevent notebooks from potentially hanging.

Modification to files.md
My machine runs on Linux Mint 17.2 (I am new to Linux). The `print(glob.glob('inflammation*.csv'))` command executed but produced a list of inflammation filenames that were out of numeric order. I checked with participants but it seems this behaviour only occurred on my machine. Everyone in that workshop was either running Windows or Mac so the problem may be OS dependent. It was easily fixed with by adding the `sorted()` option. This change could be considered for inclusion but it is not a major problem.

Thanks