### PR TITLE
Fixed broken link

### DIFF
--- a/05-cond.md
+++ b/05-cond.md
@@ -222,7 +222,7 @@ and false statements. However, they aren't the only values in Python that are tr
 
 > ## In-place operators {.challenge}
 >
-> Python (and most other languages in the C family) provides [in-place operators](reference.html#in-place-operator)
+> Python (and most other languages in the C family) provides [in-place operators](reference.html#in-place-operators)
 > that work like this:
 >
 > ~~~ {.python}


### PR DESCRIPTION
There was a typo in the link to the "in-place-operators" anchor tag.

Link now points to the anchor tag correctly and therefore will take users to the right term in the glossary.