### PR TITLE
Replace "ipython notebook" (deprecated) with "jupyter notebook"

### DIFF
--- a/07-errors.html
+++ b/07-errors.html
@@ -113,7 +113,7 @@ IndentationError: unexpected indent</code></pre>
 <h2 id="tabs-and-spaces"><span class="glyphicon glyphicon-pushpin"></span>Tabs and Spaces</h2>
 </div>
 <div class="panel-body">
-<p>A quick note on indentation errors: they can sometimes be insidious, especially if you are mixing spaces and tabs. Because they are both <a href="reference.html#whitespace">whitespace</a>, it is difficult to visually tell the difference. The IPython notebook actually gives us a bit of a hint, but not all Python editors will do that. In the following example, the first two lines are using a tab for indentation, while the third line uses four spaces:</p>
+<p>A quick note on indentation errors: they can sometimes be insidious, especially if you are mixing spaces and tabs. Because they are both <a href="reference.html#whitespace">whitespace</a>, it is difficult to visually tell the difference. The Jupyter notebook actually gives us a bit of a hint, but not all Python editors will do that. In the following example, the first two lines are using a tab for indentation, while the third line uses four spaces:</p>
 <div class="sourceCode"><pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> some_function():
     msg <span class="op">=</span> <span class="st">&quot;hello, world!&quot;</span>
     <span class="bu">print</span>(msg)

--- a/07-errors.md
+++ b/07-errors.md
@@ -164,7 +164,7 @@ it *always* means that there is a problem with how your code is indented.
 > especially if you are mixing spaces and tabs.
 > Because they are both [whitespace](reference.html#whitespace),
 > it is difficult to visually tell the difference.
-> The IPython notebook actually gives us a bit of a hint,
+> The Jupyter notebook actually gives us a bit of a hint,
 > but not all Python editors will do that.
 > In the following example,
 > the first two lines are using a tab for indentation,

--- a/10-cmdline.html
+++ b/10-cmdline.html
@@ -40,7 +40,7 @@
 </ul>
 </div>
 </section>
-<p>The IPython Notebook and other interactive tools are great for prototyping code and exploring data, but sooner or later we will want to use our program in a pipeline or run it in a shell script to process thousands of data files. In order to do that, we need to make our programs work like other Unix command-line tools. For example, we may want a program that reads a dataset and prints the average inflammation per patient.</p>
+<p>The Jupyter Notebook and other interactive tools are great for prototyping code and exploring data, but sooner or later we will want to use our program in a pipeline or run it in a shell script to process thousands of data files. In order to do that, we need to make our programs work like other Unix command-line tools. For example, we may want a program that reads a dataset and prints the average inflammation per patient.</p>
 <aside class="callout panel panel-info">
 <div class="panel-heading">
 <h2 id="switching-to-shell-commands"><span class="glyphicon glyphicon-pushpin"></span>Switching to Shell Commands</h2>

--- a/10-cmdline.md
+++ b/10-cmdline.md
@@ -10,7 +10,7 @@ minutes: 30
 > *   Handle flags and files separately in a command-line program.
 > *   Read data from standard input in a program so that it can be used in a pipeline.
 
-The IPython Notebook and other interactive tools are great for prototyping code and exploring data,
+The Jupyter Notebook and other interactive tools are great for prototyping code and exploring data,
 but sooner or later we will want to use our program in a pipeline
 or run it in a shell script to process thousands of data files.
 In order to do that,

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
 <div class="panel-body">
 <p>If you will be using the IPython or Jupyter notebook for the lesson, you should have already <a href="http://swcarpentry.github.io/workshop-template/#setup">installed Anaconda</a> which includes the notebook.</p>
 <p>To start the notebook, open a terminal or git bash and type the command:</p>
-<pre class="input"><code>$ ipython notebook</code></pre>
+<pre class="input"><code>$ jupyter notebook</code></pre>
 <p>To start the Python intrepreter without the notebook, open a terminal or git bash and type the command:</p>
 <pre class="input"><code>$ python</code></pre>
 </div>

--- a/index.md
+++ b/index.md
@@ -74,7 +74,7 @@ To do all that, we'll have to learn a little bit about programming.
 > To start the notebook, open a terminal or git bash and type the command:
 >
 > ~~~ {.input}
-> $ ipython notebook
+> $ jupyter notebook
 > ~~~
 >
 > To start the Python intrepreter without the notebook, open a terminal or git bash and type the command:

--- a/instructors.html
+++ b/instructors.html
@@ -41,9 +41,9 @@
 <li>It has a large scientific user community.</li>
 <li>It’s easier for novices to learn than most of the mature alternatives. (Software Carpentry originally used Perl; when we switched, we found that we could cover as much material in two days in Python as we’d covered in three days in Perl, and that retention was higher.)</li>
 </ul>
-<p>We do <em>not</em> include instructions on running the IPython Notebook in the tutorial because we want to focus on the language rather than the tools. Instructors should, however, walk learners through some basic operations:</p>
+<p>We do <em>not</em> include instructions on running the Jupyter Notebook in the tutorial because we want to focus on the language rather than the tools. Instructors should, however, walk learners through some basic operations:</p>
 <ul>
-<li>Launch from the command line with <code>ipython notebook</code>.</li>
+<li>Launch from the command line with <code>jupyter notebook</code>.</li>
 <li>Create a new notebook.</li>
 <li>Enter code or data in a cell and execute it.</li>
 <li>Explain the difference between <code>In[#]</code> and <code>Out[#]</code>.</li>

--- a/instructors.md
+++ b/instructors.md
@@ -47,11 +47,11 @@ Explain that we use Python because:
     as we'd covered in three days in Perl,
     and that retention was higher.)
 
-We do *not* include instructions on running the IPython Notebook in the tutorial
+We do *not* include instructions on running the Jupyter Notebook in the tutorial
 because we want to focus on the language rather than the tools.
 Instructors should, however, walk learners through some basic operations:
 
-*   Launch from the command line with `ipython notebook`.
+*   Launch from the command line with `jupyter notebook`.
 *   Create a new notebook.
 *   Enter code or data in a cell and execute it.
 *   Explain the difference between `In[#]` and `Out[#]`.


### PR DESCRIPTION
The version of `ipython` installed with Anaconda (ipython 4.1.2 at time of writing) prints a deprecation message (see below) when `ipython notebook` is run.  Updating our materials to use `jupyter notebook` instead, the command to use going forward.

```
$ ipython notebook
[TerminalIPythonApp] WARNING | Subcommand `ipython notebook` is deprecated and will be removed in future versions.
[TerminalIPythonApp] WARNING | You likely want to use `jupyter notebook`... continue in 5 sec. Press Ctrl-C to quit now.
```