### PR TITLE
alternative lesson 8 using doctests under development

### DIFF
--- a/08_alt_def.ipynb
+++ b/08_alt_def.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Intro to tests\n",
+    "\n",
+    "This is an introduction to writing tests for functions, which check that the output of the function is what you expected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The doctest module\n",
+    "\n",
+    "\"The doctest module searches for pieces of text that look like interactive Python sessions,\n",
+    "and then executes those sessions to verify that they work exactly as shown.\" -- python.org"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### My first doctest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exception reporting mode: Plain\n",
+      "Doctest mode is: ON\n"
+     ]
+    }
+   ],
+   "source": [
+    "%doctest_mode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Comments, multiline comments, docstrings, and strings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# This is a single line comment\n",
+    "\n",
+    "\"\"\"This is a \n",
+    "multiline comment\n",
+    "\"\"\"\n",
+    "\n",
+    "def a_function(an_argument):\n",
+    "    \"\"\"\n",
+    "    This multiline is\n",
+    "    a docstring.\n",
+    "    \"\"\"\n",
+    "    \n",
+    "'This is a string'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### This function does exactly what we tell it to.\n",
+    "\n",
+    "The result using the * (multiplication) operator depends on the data type of the operands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def multiply(a, b):\n",
+    "    \"\"\"\n",
+    "    This function multiplies two things.\n",
+    "    \"\"\"\n",
+    "    return a * b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try the following by uncommenting each line. Can you identify the data type of the operands?\n",
+    "\n",
+    "#print(multiply(2, 2))\n",
+    "#print(multiply('hello', 2))\n",
+    "#print(multiply([2],2))\n",
+    "#print(multiply('2', 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example of doctests that describe the expected (default) behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def multiply(a, b):\n",
+    "    \"\"\"\n",
+    "    This function multiplies two things.\n",
+    "    \n",
+    "    >>> multiply(2, 2)\n",
+    "    4\n",
+    "    >>> multiply('hello',2)\n",
+    "    'hellohello'\n",
+    "    >>> multiply([2],2)\n",
+    "    [2, 2]\n",
+    "    >>> multiply('2',2)\n",
+    "    '22'\n",
+    "    \"\"\"\n",
+    "    return a*b\n",
+    "\n",
+    "#print(multiply(2, 2))\n",
+    "#print(multiply('hello', 2))\n",
+    "#print(multiply([2],2))\n",
+    "#print(multiply('2', 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Thorough tests also ensure the output is helpful and reasonable even if the input is invalid; this might mean the function returns an error for invalid input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def multiply(a, b):\n",
+    "    \"\"\"This function multiplies two numbers.\"\"\"\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def multiply(a, b):\n",
+    "    \"\"\"\n",
+    "    This function multiplies two numbers.\n",
+    "    \n",
+    "    >>> multiply(2, 2)\n",
+    "    4\n",
+    "    >>> multiply('hello',2)\n",
+    "    'hellohello'\n",
+    "    >>> multiply([2],2)\n",
+    "    [2, 2]\n",
+    "    >>> multiply('2',2)\n",
+    "    '222'\n",
+    "    \"\"\"\n",
+    "    pass\n",
+    "\n",
+    "def __main__():\n",
+    "    test()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Goal\n",
+    "\n",
+    "In this lesson we will build a function stub with doctests.\n",
+    "We will build code in the function that ensure the doctests pass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Example with cumulative sums"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# function stub with a description in the docstring\n",
+    "def cumulative_sum(alist):\n",
+    "    \"\"\"\n",
+    "    Computes the cumulative sum of a list \n",
+    "    of positive numbers.\n",
+    "    \"\"\"\n",
+    "    #--- your code goes here---\"\n",
+    "    pass # do nothing\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# before writing the code, document its expected behaviour \n",
+    "# in the docstring\n",
+    "def cumulative_sum(alist):\n",
+    "    \"\"\"\n",
+    "    Computes the cumulative sum of a list \n",
+    "    of positive numbers.\n",
+    "    \n",
+    "    >>> alist = [0,1,2,3,4]\n",
+    "    >>> alist\n",
+    "    [0, 1, 2, 3, 4]\n",
+    "    >>> pos_cumulative_sum(alist)\n",
+    "    10\n",
+    "    >>> invalid_list = [-1, -2, -3, 2, 0]\n",
+    "    >>> pos_cumulative_sum(invalid_list) [ELLIPSIS]\n",
+    "    ValueError...\n",
+    "    \"\"\"\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\"doctest.ELLIPSIS:\n",
+    "When specified, an ellipsis marker (...) in the expected output can match any substring in the actual output. This includes substrings that span line boundaries, and empty substrings, so it’s best to keep usage of this simple. Complicated uses can lead to the same kinds of “oops, it matched too much!” surprises that .* is prone to in regular expressions.\" \n",
+    "-- docs.python.org"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Different approaches:\n",
+    "\n",
+    "def cumulative_sum(alist):\n",
+    "    \"\"\"\n",
+    "    Computes the cumulative sum of a list \n",
+    "    of positive numbers.\n",
+    "    \n",
+    "    >>> alist = [0,1,2,3,4]\n",
+    "    >>> alist\n",
+    "    [0, 1, 2, 3, 4]\n",
+    "    >>> pos_cumulative_sum(alist)\n",
+    "    10\n",
+    "    >>> invalid_list = [-1, -2, -3, 2, 0]\n",
+    "    >>> pos_cumulative_sum(invalid_list) [ELLIPSIS]\n",
+    "    ValueError...\n",
+    "    \"\"\"\n",
+    "    # deal with errors\n",
+    "    \n",
+    "    # then assume the result is clean\n",
+    "    pass\n",
+    "    \n",
+    "def cumulative_sum(alist):\n",
+    "    \"\"\"\n",
+    "    Computes the cumulative sum of a list \n",
+    "    of positive numbers.\n",
+    "    \n",
+    "    >>> alist = [0,1,2,3,4]\n",
+    "    >>> alist\n",
+    "    [0, 1, 2, 3, 4]\n",
+    "    >>> pos_cumulative_sum(alist)\n",
+    "    10\n",
+    "    >>> invalid_list = [-1, -2, -3, 2, 0]\n",
+    "    >>> pos_cumulative_sum(invalid_list) [ELLIPSIS]\n",
+    "    ValueError...\n",
+    "    \"\"\"\n",
+    "    # deal with valid input\n",
+    "    \n",
+    "    # assume everything else is rubbish\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Alternative/new lesson on test driven development under development using doctests instead of assertions. Building tests into docstrings is a gentler intro to testing that combines what learners already know about docstrings from the module on error checking and using 'help'. Not yet functional since some of the doctest modules changed under migration from ipython notebook to jupyter and I haven't worked out how to access the new doctest functions in jupyter.