### PR TITLE
Remove mentions to ipythonblocks and tuples

### DIFF
--- a/05-cond.md
+++ b/05-cond.md
@@ -6,7 +6,6 @@ minutes: 30
 ---
 > ## Learning Objectives {.objectives}
 >
-> *   Explain the similarities and differences between tuples and lists.
 > *   Write conditional statements including `if`, `elif`, and `else` branches.
 > *   Correctly evaluate expressions containing `and` and `or`.
 

--- a/reference.md
+++ b/reference.md
@@ -40,8 +40,6 @@ subtitle: Reference
 
 ## [Making Choices](05-cond.html)
 
-*   Use the `ImageGrid` class from the `ipythonblocks` library to create simple "images" made of colored blocks.
-*   Specify colors use (red, green, blue) triples, each component of which is an integer in the range 0..255.
 *   Use `if condition` to start a conditional statement, `elif condition` to provide additional tests, and `else` to provide a default.
 *   The bodies of the branches of conditional statements must be indented.
 *   Use `==` to test for equality.


### PR DESCRIPTION
Previous versions used ipythonblocks and tuples, mostly when teaching conditionals. I'm removing mentions to them in the code, as we are not using ipythonblocks anymore and tuples only mentioned in one challenge.

This fixes #262, but leaves untouched the entry for tuples in the glossary. 