### PR TITLE
link PNGs instead of SVGs (closes #270 and #271)

### DIFF
--- a/01-numpy.md
+++ b/01-numpy.md
@@ -455,7 +455,7 @@ next diagram on the left), or the average for each day (as in the
 diagram on the right)? As the diagram below shows, we want to perform the
 operation across an axis:
 
-![Operations Across Axes](fig/python-operations-across-axes.svg)
+![Operations Across Axes](fig/python-operations-across-axes.png)
 
 To support this,
 most array methods allow us to specify the axis we want to work on.

--- a/05-cond.md
+++ b/05-cond.md
@@ -41,7 +41,7 @@ If the test is false,
 the body of the `else` is executed instead.
 Only one or the other is ever executed:
 
-![Executing a Conditional](fig/python-flowchart-conditional.svg)\
+![Executing a Conditional](fig/python-flowchart-conditional.png)\
 
 Conditional statements don't have to include an `else`.
 If there isn't one,


### PR DESCRIPTION
It replaces links to SVG files with links with respective PNGs. This solves the problem with differences of rendering of SVGs on different platforms and browsers (mainly related to fonts - see #270 and #271).