### PR TITLE
Update switcheroo example

### DIFF
--- a/_episodes/06-func.md
+++ b/_episodes/06-func.md
@@ -960,10 +960,10 @@ readable code!
 >
 > Which of the following would be printed if you were to run this code? Why did you pick this answer?
 >
-> a. 7 3
-> b. 3 7
-> c. 3 3
-> d. 7 7
+> 1. `7 3`
+> 2. `3 7`
+> 3. `3 3`
+> 4. `7 7`
 >
 > ~~~
 > a = 3
@@ -979,6 +979,13 @@ readable code!
 > print(a, b)
 > ~~~
 > {: .python}
+> > ## Solution
+> > `3, 7` is correct. Initially `a` has a value of 3 and `b` has a value of 7.
+> > When the swap function is called, it creates local variables (also called
+> > `a` and `b` in this case) and trades their values. The function does not
+> > return any values and does not alter `a` or `b` outside of its local copy.
+> > Therefore the original values of `a` and `b` remain unchanged.
+> {: .solution}
 {: .challenge}
 
 > ## Readable Code


### PR DESCRIPTION
The switcheroo example in the functions episode had all of the possible answers on one line and designated with a, b, c, d, unlike the other examples of 1, 2, 3, 4. This was also confusing as the variables in the example are a and b. I updated the formatting of the question and possible answers. I also added the solution with an explanation of why that is the correct answer. (SWC instructor training qualification) 