### PR TITLE
Notebooks with blanks

### DIFF
--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -413,7 +413,7 @@ print("With known last position:", sond)
 sond = months[8:len(months)]
 print("Using len() to get last entry:", sond)
 sond = months[8:]
-("Omitting ending index:", sond)
+print("Omitting ending index:", sond)
 ~~~
 {: .python}
 

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -220,15 +220,16 @@ If we make a list and (attempt to) copy it then modify in place, we can cause al
 ~~~
 odds = [1, 3, 5, 7]
 primes = odds
-primes += [2]
+primes[0] = 2
+odds += [9]
 print('primes:', primes)
 print('odds:', odds)
 ~~~
 {: .python}
 
 ~~~
-primes: [1, 3, 5, 7, 2]
-odds: [1, 3, 5, 7, 2]
+primes: [2, 3, 5, 7, 9]
+odds: [2, 3, 5, 7, 9]
 ~~~
 {: .output}
 
@@ -238,15 +239,16 @@ If all we want to do is copy a (simple) list, we can use the `list` function, so
 ~~~
 odds = [1, 3, 5, 7]
 primes = list(odds)
-primes += [2]
+primes[0] = 2
+odds += [9]
 print('primes:', primes)
 print('odds:', odds)
 ~~~
 {: .python}
 
 ~~~
-primes: [1, 3, 5, 7, 2]
-odds: [1, 3, 5, 7]
+primes: [2, 3, 5, 7]
+odds: [1, 3, 5, 7, 9]
 ~~~
 {: .output}
 

--- a/notebooks/00-setup.ipynb
+++ b/notebooks/00-setup.ipynb
@@ -13,13 +13,14 @@
     "```\n",
     "1. Go to folder: **python-novice-inflammation-gh-pages/notebooks**\n",
     "```\n",
-    "cd python-novice-inflammation-gh-pages/notebooks\n",
+    "cd python-novice-inflammation-gh-pages\n",
     "```\n",
     "1. Start the Jupyter Notebook\n",
     "```\n",
     "jupyter notebook\n",
     "```\n",
-    "1. Select file `01-numpy.ipynb`"
+    "1. Click on folder `notebooks`\n",
+    "1. Click on file `01-numpy.ipynb`"
    ]
   },
   {

--- a/notebooks/00-setup.ipynb
+++ b/notebooks/00-setup.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Lesson Setup\n",
+    "1. Download and extract the material: https://github.com/swcarpentry/python-novice-inflammation/archive/gh-pages.zip\n",
+    "```\n",
+    "wget https://github.com/swcarpentry/python-novice-inflammation/archive/gh-pages.zip\n",
+    "unzip gh-pages.zip\n",
+    "```\n",
+    "1. Go to folder: **python-novice-inflammation-gh-pages/notebooks**\n",
+    "```\n",
+    "cd python-novice-inflammation-gh-pages/notebooks\n",
+    "```\n",
+    "1. Start the Jupyter Notebook\n",
+    "```\n",
+    "jupyter notebook\n",
+    "```\n",
+    "1. Select file `01-numpy.ipynb`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/00-setup.ipynb
+++ b/notebooks/00-setup.ipynb
@@ -11,7 +11,7 @@
     "wget https://github.com/swcarpentry/python-novice-inflammation/archive/gh-pages.zip\n",
     "unzip gh-pages.zip\n",
     "```\n",
-    "1. Go to folder: **python-novice-inflammation-gh-pages/notebooks**\n",
+    "1. Go to folder: **python-novice-inflammation-gh-pages**\n",
     "```\n",
     "cd python-novice-inflammation-gh-pages\n",
     "```\n",
@@ -19,8 +19,8 @@
     "```\n",
     "jupyter notebook\n",
     "```\n",
-    "1. Click on folder `notebooks`\n",
-    "1. Click on file `01-numpy.ipynb`"
+    "1. Once your web browser is showing the Jupyter portal, click on folder \"`notebooks`\",\n",
+    "   then click on file \"`01-numpy.ipynb`\""
    ]
   },
   {

--- a/notebooks/01-numpy.ipynb
+++ b/notebooks/01-numpy.ipynb
@@ -446,7 +446,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Functions"
+    "## Functions and Tuples"
    ]
   },
   {
@@ -481,7 +481,6 @@
    },
    "outputs": [],
    "source": [
-    "# Using Tuples\n",
     "### numpy.###(data) numpy.###(data) numpy.###(data)\n",
     "\n",
     "print('maximum inflammation:', maxval)\n",
@@ -499,6 +498,34 @@
    "source": [
     "# Mystery Functions in IPython\n",
     "numpy.###"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Tuples and Exchanges\n",
+    "Use tuples to simplify the following three lines of code:\n",
+    "```Python\n",
+    "temp = left\n",
+    "left = right\n",
+    "right = temp\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "left = 'L'\n",
+    "right = 'R'\n",
+    "\n",
+    "###\n",
+    "print(left, right)"
    ]
   },
   {

--- a/notebooks/01-numpy.ipynb
+++ b/notebooks/01-numpy.ipynb
@@ -586,7 +586,7 @@
    },
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot"
+    "import ###"
    ]
   },
   {
@@ -598,7 +598,7 @@
    "outputs": [],
    "source": [
     "# Some IPython Magic\n",
-    "% matplotlib inline"
+    "###"
    ]
   },
   {
@@ -609,8 +609,8 @@
    },
    "outputs": [],
    "source": [
-    "image  = matplotlib.pyplot.imshow(data)\n",
-    "matplotlib.pyplot.show()"
+    "###\n",
+    "###"
    ]
   },
   {
@@ -621,9 +621,9 @@
    },
    "outputs": [],
    "source": [
-    "ave_inflammation = numpy.mean(data, axis=0)\n",
-    "ave_plot = matplotlib.pyplot.plot(ave_inflammation)\n",
-    "matplotlib.pyplot.show()"
+    "ave_inflammation = numpy.###(data, ###)\n",
+    "ave_plot = matplotlib.pyplot.###(###)\n",
+    "matplotlib.pyplot.###()"
    ]
   },
   {
@@ -634,8 +634,8 @@
    },
    "outputs": [],
    "source": [
-    "max_plot = matplotlib.pyplot.plot(numpy.max(data, axis=0))\n",
-    "matplotlib.pyplot.show()"
+    "max_plot = matplotlib.pyplot.plot(numpy.###(data, axis=###))\n",
+    "matplotlib.pyplot.###()"
    ]
   },
   {
@@ -646,8 +646,8 @@
    },
    "outputs": [],
    "source": [
-    "min_plot = matplotlib.pyplot.plot(numpy.min(data, axis=0))\n",
-    "matplotlib.pyplot.show()"
+    "min_plot = matplotlib.pyplot.plot(numpy.###(data, axis=###))\n",
+    "matplotlib.pyplot.###()"
    ]
   },
   {
@@ -666,8 +666,8 @@
    },
    "outputs": [],
    "source": [
-    "std_plot = matplotlib.pyplot.plot(numpy.std(data, axis=0))\n",
-    "matplotlib.pyplot.show()"
+    "std_plot = ###\n",
+    "###"
    ]
   },
   {
@@ -685,24 +685,24 @@
    },
    "outputs": [],
    "source": [
-    "fig = matplotlib.pyplot.figure(figsize=(3 * 3.5, 3.0))\n",
+    "fig = matplotlib.pyplot.###(###=(3 * 3.5, 3.0))\n",
     "\n",
-    "axes1 = fig.add_subplot(1, 3, 1)\n",
-    "axes2 = fig.add_subplot(1, 3, 2)\n",
-    "axes3 = fig.add_subplot(1, 3, 3)\n",
+    "axes1 = fig.###(###, ###, ###)\n",
+    "axes2 = fig.add_subplot(###, ###, ###)\n",
+    "axes3 = fig.add_subplot(###, ###, ###)\n",
     "\n",
-    "axes1.set_ylabel('average')\n",
-    "axes1.plot(numpy.mean(data, axis=0))\n",
+    "axes1.###('average')\n",
+    "axes1.###(numpy.###(data, axis=###))\n",
     "\n",
     "axes2.set_ylabel('max')\n",
-    "axes2.plot(numpy.max(data, axis=0))\n",
+    "axes2.plot(numpy.###(data, axis=###))\n",
     "\n",
     "axes3.set_ylabel('min')\n",
-    "axes3.plot(numpy.min(data, axis=0))\n",
+    "axes3.plot(numpy.###(data, axis=###))\n",
     "\n",
-    "fig.tight_layout()\n",
+    "fig.###()\n",
     "\n",
-    "matplotlib.pyplot.show()"
+    "matplotlib.pyplot.###()"
    ]
   },
   {
@@ -722,12 +722,12 @@
    "outputs": [],
    "source": [
     "# change figsize (swap width and height)\n",
-    "fig = matplotlib.pyplot.figure(figsize=(3.5, 3 * 3.0))\n",
+    "fig = matplotlib.pyplot.###(###=(###, ###))\n",
     "\n",
     "# change add_subplot (swap first two parameters)\n",
-    "axes1 = fig.add_subplot(3, 1, 1)\n",
-    "axes2 = fig.add_subplot(3, 1, 2)\n",
-    "axes3 = fig.add_subplot(3, 1, 3)\n",
+    "axes1 = fig.###(###, ###, 1)\n",
+    "axes2 = fig.add_subplot(###, ###, 2)\n",
+    "axes3 = fig.add_subplot(###, ###, 3)\n",
     "\n",
     "axes1.set_ylabel('average')\n",
     "axes1.plot(numpy.mean(data, axis=0))\n",
@@ -738,9 +738,9 @@
     "axes3.set_ylabel('min')\n",
     "axes3.plot(numpy.min(data, axis=0))\n",
     "\n",
-    "fig.tight_layout()\n",
+    "fig.###()\n",
     "\n",
-    "matplotlib.pyplot.show()"
+    "matplotlib.pyplot.###()"
    ]
   },
   {
@@ -759,8 +759,8 @@
    "outputs": [],
    "source": [
     "# Scientists Dislike Typing\n",
-    "import numpy as np\n",
-    "np.pi"
+    "import numpy ### ###\n",
+    "###.pi"
    ]
   },
   {

--- a/notebooks/01-numpy.ipynb
+++ b/notebooks/01-numpy.ipynb
@@ -1,0 +1,796 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Analyzing Patient Data\n",
+    "Questions\n",
+    "* How can I process tabular data files in Python?\n",
+    "\n",
+    "Objectives\n",
+    "* Explain what a library is, and what libraries are used for.\n",
+    "* Import a Python library and use the things it contains.\n",
+    "* Read tabular data from a file into a program.\n",
+    "* Assign values to variables.\n",
+    "* Select individual values and subsections from data.\n",
+    "* Perform operations on arrays of data.\n",
+    "* Display simple graphs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "weight_kg = 55"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(weight_kg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('weight in pounds:', 2.2 * weight_kg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "weight_kg = 57.5\n",
+    "print('weight in kilograms is now:', weight_kg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Variable as a sticky note](../fig/python-sticky-note-variables-01.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "weight_lb = 2.2 * weight_kg\n",
+    "print('weight in kilograms:', weight_kg, 'and in pounds:', weight_lb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Two variables](../fig/python-sticky-note-variables-02.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "weight_kg = 100.0\n",
+    "print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', weight_lb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Independant variables](../fig/python-sticky-note-variables-03.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%whos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "Draw diagrams showing what variables refer to what values after each statement in the following program:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mass = 47.5        # mass-> 47.5, age-> undefined\n",
+    "age = 122          # mass-> 47.5, age-> 122\n",
+    "mass = mass * 2.0  # mass-> 95.0, age-> 122\n",
+    "age = age - 20     # mass-> 95.0, age-> 102\n",
+    "print(mass, age)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Arrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(type(data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data.dtype)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('first value in data:', data[0, 0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('middle value in data:', data[30, 20])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data[0:4, 0:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data[5:10, 0:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "small = data[:3, 36:]\n",
+    "print('small is:')\n",
+    "print(small)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "doubledata = data * 2.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('original:')\n",
+    "print(data[:3, 36:])\n",
+    "print('doubledata:')\n",
+    "print(doubledata[:3, 36:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tripledata = doubledata + data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('tripledata:')\n",
+    "print(tripledata[:3, 36:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercises - Slicing Strings and Arrays\n",
+    "What would be the output?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "element = 'oxygen'\n",
+    "print(element[0:3])    # oxy\n",
+    "print(element[3:6])    # gen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(element[:4])     # oxyg\n",
+    "print(element[4:])     # en\n",
+    "print(element[:])      # oxygen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(element[-1])     # n\n",
+    "print(element[-2])     # e\n",
+    "print(element[1:-1])   # xyge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(element[3:3])    # Empty string\n",
+    "print(data[3:3, 4:4])  # []\n",
+    "print(data[3:3, :])    # []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Not All Functions Have Input\n",
+    "import time\n",
+    "print(time.ctime())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "maxval, minval, stdval = numpy.max(data), numpy.min(data), numpy.std(data)\n",
+    "\n",
+    "print('maximum inflammation:', maxval)\n",
+    "print('minimum inflammation:', minval)\n",
+    "print('standard deviation:', stdval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Mystery Functions in IPython\n",
+    "numpy.cumprod?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Arrays Axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "patient_0 = data[0, :] # 0 on the first axis, everything on the second\n",
+    "print('maximum inflammation for patient 0:', patient_0.max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('maximum inflammation for patient 2:', numpy.max(data[2, :]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Axis 0, 1](../fig/python-operations-across-axes.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data, axis=0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data, axis=0).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data, axis=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating Plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Some IPython Magic\n",
+    "% matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "image  = matplotlib.pyplot.imshow(data)\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ave_inflammation = numpy.mean(data, axis=0)\n",
+    "ave_plot = matplotlib.pyplot.plot(ave_inflammation)\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "max_plot = matplotlib.pyplot.plot(numpy.max(data, axis=0))\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "min_plot = matplotlib.pyplot.plot(numpy.min(data, axis=0))\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Make Your Own Plot\n",
+    "Create a plot showing the standard deviation (numpy.std) of the inflammation data for each day across all patients"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "std_plot = matplotlib.pyplot.plot(numpy.std(data, axis=0))\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subplots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = matplotlib.pyplot.figure(figsize=(3 * 3.5, 3.0))\n",
+    "\n",
+    "axes1 = fig.add_subplot(1, 3, 1)\n",
+    "axes2 = fig.add_subplot(1, 3, 2)\n",
+    "axes3 = fig.add_subplot(1, 3, 3)\n",
+    "\n",
+    "axes1.set_ylabel('average')\n",
+    "axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "axes2.set_ylabel('max')\n",
+    "axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "axes3.set_ylabel('min')\n",
+    "axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Moving Plots Around\n",
+    "Modify the program to display the three plots on top of one another instead of side by side"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# change figsize (swap width and height)\n",
+    "fig = matplotlib.pyplot.figure(figsize=(3.5, 3 * 3.0))\n",
+    "\n",
+    "# change add_subplot (swap first two parameters)\n",
+    "axes1 = fig.add_subplot(3, 1, 1)\n",
+    "axes2 = fig.add_subplot(3, 1, 2)\n",
+    "axes3 = fig.add_subplot(3, 1, 3)\n",
+    "\n",
+    "axes1.set_ylabel('average')\n",
+    "axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "axes2.set_ylabel('max')\n",
+    "axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "axes3.set_ylabel('min')\n",
+    "axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extra Material"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Scientists Dislike Typing\n",
+    "import numpy as np\n",
+    "np.pi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/01-numpy.ipynb
+++ b/notebooks/01-numpy.ipynb
@@ -139,7 +139,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Variable as a sticky note](../fig/python-sticky-note-variables-01.png---)"
+    "![Figure - Variable as a sticky note](../fig/python-sticky-note-variables-01.png---)"
    ]
   },
   {
@@ -158,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Two variables](../fig/python-sticky-note-variables-02.png---)"
+    "![Figure - Two variables](../fig/python-sticky-note-variables-02.png---)"
    ]
   },
   {
@@ -177,7 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Independant variables](../fig/python-sticky-note-variables-03.png---)"
+    "![Figure - Independant variables](../fig/python-sticky-note-variables-03.png---)"
    ]
   },
   {
@@ -535,7 +535,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Axis 0, 1](../fig/python-operations-across-axes.png---)"
+    "![Figure - Axis 0, 1](../fig/python-operations-across-axes.png---)"
    ]
   },
   {

--- a/notebooks/01-numpy.ipynb
+++ b/notebooks/01-numpy.ipynb
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "###.###(fname='---/---/inflammation-01.---', delimiter='---')"
+    "###.###(###='---/---/inflammation-01.---', ###='---')"
    ]
   },
   {
@@ -120,26 +120,7 @@
    },
    "outputs": [],
    "source": [
-    "###('weight in pounds:', ###)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "weight_kg = ###\n",
-    "print('weight in kilograms is now:', weight_kg)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "![Variable as a sticky note](../fig/python-sticky-note-variables-01.png)"
+    "###('---', ###)"
    ]
   },
   {
@@ -151,14 +132,14 @@
    "outputs": [],
    "source": [
     "### = ###\n",
-    "print('weight in kilograms:', weight_kg, 'and in pounds:', ###)"
+    "print('weight in kilograms ---:', weight_kg)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Two variables](../fig/python-sticky-note-variables-02.png)"
+    "![Variable as a sticky note](../fig/python-sticky-note-variables-01.png---)"
    ]
   },
   {
@@ -169,15 +150,15 @@
    },
    "outputs": [],
    "source": [
-    "weight_kg = ###\n",
-    "print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', ###)"
+    "### = ###\n",
+    "print('weight in kilograms:', weight_kg, 'and weight in pounds:', ###)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Independant variables](../fig/python-sticky-note-variables-03.png)"
+    "![Two variables](../fig/python-sticky-note-variables-02.png---)"
    ]
   },
   {
@@ -188,7 +169,27 @@
    },
    "outputs": [],
    "source": [
-    "%###"
+    "### = ###\n",
+    "print('weight in kilograms is now:', weight_kg, 'and weight in pounds ---:', weight_lb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Independant variables](../fig/python-sticky-note-variables-03.png---)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Who's Who in Memory\n",
+    "###"
    ]
   },
   {
@@ -229,7 +230,7 @@
    },
    "outputs": [],
    "source": [
-    "### = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+    "numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
    ]
   },
   {
@@ -328,7 +329,7 @@
    },
    "outputs": [],
    "source": [
-    "small = data[###]\n",
+    "small = ###\n",
     "print('small is:')\n",
     "print(small)"
    ]
@@ -456,7 +457,7 @@
    },
    "outputs": [],
    "source": [
-    "print(numpy.mean(data))"
+    "print(numpy.###)"
    ]
   },
   {
@@ -468,8 +469,8 @@
    "outputs": [],
    "source": [
     "# Not All Functions Have Input\n",
-    "import time\n",
-    "print(time.ctime())"
+    "import ###\n",
+    "print(###)"
    ]
   },
   {
@@ -480,7 +481,8 @@
    },
    "outputs": [],
    "source": [
-    "maxval, minval, stdval = numpy.max(data), numpy.min(data), numpy.std(data)\n",
+    "# Using Tuples\n",
+    "### numpy.###(data) numpy.###(data) numpy.###(data)\n",
     "\n",
     "print('maximum inflammation:', maxval)\n",
     "print('minimum inflammation:', minval)\n",
@@ -496,7 +498,7 @@
    "outputs": [],
    "source": [
     "# Mystery Functions in IPython\n",
-    "numpy.cumprod?"
+    "numpy.###"
    ]
   },
   {
@@ -514,8 +516,8 @@
    },
    "outputs": [],
    "source": [
-    "patient_0 = data[0, :] # 0 on the first axis, everything on the second\n",
-    "print('maximum inflammation for patient 0:', patient_0.max())"
+    "### # 0 on the first axis, everything on the second\n",
+    "print('maximum inflammation for patient 0:', patient_0.###())"
    ]
   },
   {
@@ -526,14 +528,14 @@
    },
    "outputs": [],
    "source": [
-    "print('maximum inflammation for patient 2:', numpy.max(data[2, :]))"
+    "print('maximum inflammation for patient 2:', numpy.###(data[###]))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Axis 0, 1](../fig/python-operations-across-axes.png)"
+    "![Axis 0, 1](../fig/python-operations-across-axes.png---)"
    ]
   },
   {
@@ -544,7 +546,7 @@
    },
    "outputs": [],
    "source": [
-    "print(numpy.mean(data, axis=0))"
+    "print(numpy.###(data, ###))"
    ]
   },
   {
@@ -555,7 +557,7 @@
    },
    "outputs": [],
    "source": [
-    "print(numpy.mean(data, axis=0).shape)"
+    "print(numpy.mean(data, ###).###)"
    ]
   },
   {
@@ -566,7 +568,7 @@
    },
    "outputs": [],
    "source": [
-    "print(numpy.mean(data, axis=1))"
+    "print(numpy.mean(data, ###))"
    ]
   },
   {

--- a/notebooks/01-numpy.ipynb
+++ b/notebooks/01-numpy.ipynb
@@ -51,7 +51,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/01-numpy.ipynb
+++ b/notebooks/01-numpy.ipynb
@@ -65,11 +65,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
-    "import numpy"
+    "### ###"
    ]
   },
   {
@@ -80,7 +80,7 @@
    },
    "outputs": [],
    "source": [
-    "numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+    "###.###(fname='---/---/inflammation-01.---', delimiter='---')"
    ]
   },
   {
@@ -98,7 +98,7 @@
    },
    "outputs": [],
    "source": [
-    "weight_kg = 55"
+    "### = ###"
    ]
   },
   {
@@ -109,7 +109,7 @@
    },
    "outputs": [],
    "source": [
-    "print(weight_kg)"
+    "###(###)"
    ]
   },
   {
@@ -120,7 +120,7 @@
    },
    "outputs": [],
    "source": [
-    "print('weight in pounds:', 2.2 * weight_kg)"
+    "###('weight in pounds:', ###)"
    ]
   },
   {
@@ -131,7 +131,7 @@
    },
    "outputs": [],
    "source": [
-    "weight_kg = 57.5\n",
+    "weight_kg = ###\n",
     "print('weight in kilograms is now:', weight_kg)"
    ]
   },
@@ -150,8 +150,8 @@
    },
    "outputs": [],
    "source": [
-    "weight_lb = 2.2 * weight_kg\n",
-    "print('weight in kilograms:', weight_kg, 'and in pounds:', weight_lb)"
+    "### = ###\n",
+    "print('weight in kilograms:', weight_kg, 'and in pounds:', ###)"
    ]
   },
   {
@@ -169,8 +169,8 @@
    },
    "outputs": [],
    "source": [
-    "weight_kg = 100.0\n",
-    "print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', weight_lb)"
+    "weight_kg = ###\n",
+    "print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', ###)"
    ]
   },
   {
@@ -188,7 +188,7 @@
    },
    "outputs": [],
    "source": [
-    "%whos"
+    "%###"
    ]
   },
   {
@@ -207,11 +207,11 @@
    },
    "outputs": [],
    "source": [
-    "mass = 47.5        # mass-> 47.5, age-> undefined\n",
-    "age = 122          # mass-> 47.5, age-> 122\n",
-    "mass = mass * 2.0  # mass-> 95.0, age-> 122\n",
-    "age = age - 20     # mass-> 95.0, age-> 102\n",
-    "print(mass, age)"
+    "mass = 47.5        # mass-> ###, age-> ###\n",
+    "age = 122          # mass-> ###, age-> ###\n",
+    "mass = mass * 2.0  # mass-> ###, age-> ###\n",
+    "age = age - 20     # mass-> ###, age-> ###\n",
+    "#print(###)"
    ]
   },
   {
@@ -229,7 +229,7 @@
    },
    "outputs": [],
    "source": [
-    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+    "### = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
    ]
   },
   {
@@ -240,7 +240,7 @@
    },
    "outputs": [],
    "source": [
-    "print(data)"
+    "###"
    ]
   },
   {
@@ -251,7 +251,7 @@
    },
    "outputs": [],
    "source": [
-    "print(type(data))"
+    "print(###(###))"
    ]
   },
   {
@@ -262,7 +262,7 @@
    },
    "outputs": [],
    "source": [
-    "print(data.dtype)"
+    "print(###.###)"
    ]
   },
   {
@@ -273,7 +273,7 @@
    },
    "outputs": [],
    "source": [
-    "print(data.shape)"
+    "print(###.###)"
    ]
   },
   {
@@ -284,7 +284,7 @@
    },
    "outputs": [],
    "source": [
-    "print('first value in data:', data[0, 0])"
+    "print('first value in data:', ###)"
    ]
   },
   {
@@ -295,7 +295,7 @@
    },
    "outputs": [],
    "source": [
-    "print('middle value in data:', data[30, 20])"
+    "print('middle value in data:', ###)"
    ]
   },
   {
@@ -306,7 +306,7 @@
    },
    "outputs": [],
    "source": [
-    "print(data[0:4, 0:10])"
+    "print(###)"
    ]
   },
   {
@@ -317,7 +317,7 @@
    },
    "outputs": [],
    "source": [
-    "print(data[5:10, 0:10])"
+    "print(###)"
    ]
   },
   {
@@ -328,7 +328,7 @@
    },
    "outputs": [],
    "source": [
-    "small = data[:3, 36:]\n",
+    "small = data[###]\n",
     "print('small is:')\n",
     "print(small)"
    ]
@@ -341,7 +341,7 @@
    },
    "outputs": [],
    "source": [
-    "doubledata = data * 2.0"
+    "doubledata = ###"
    ]
   },
   {
@@ -353,9 +353,9 @@
    "outputs": [],
    "source": [
     "print('original:')\n",
-    "print(data[:3, 36:])\n",
+    "print(data[###])\n",
     "print('doubledata:')\n",
-    "print(doubledata[:3, 36:])"
+    "print(doubledata[###])"
    ]
   },
   {
@@ -366,7 +366,7 @@
    },
    "outputs": [],
    "source": [
-    "tripledata = doubledata + data"
+    "tripledata = ###"
    ]
   },
   {
@@ -378,7 +378,7 @@
    "outputs": [],
    "source": [
     "print('tripledata:')\n",
-    "print(tripledata[:3, 36:])"
+    "print(tripledata[###])"
    ]
   },
   {
@@ -398,8 +398,8 @@
    "outputs": [],
    "source": [
     "element = 'oxygen'\n",
-    "print(element[0:3])    # oxy\n",
-    "print(element[3:6])    # gen"
+    "#print(element[0:3])    # \n",
+    "#print(element[3:6])    # "
    ]
   },
   {
@@ -410,9 +410,9 @@
    },
    "outputs": [],
    "source": [
-    "print(element[:4])     # oxyg\n",
-    "print(element[4:])     # en\n",
-    "print(element[:])      # oxygen"
+    "#print(element[:4])     # \n",
+    "#print(element[4:])     # \n",
+    "#print(element[:])      # "
    ]
   },
   {
@@ -423,9 +423,9 @@
    },
    "outputs": [],
    "source": [
-    "print(element[-1])     # n\n",
-    "print(element[-2])     # e\n",
-    "print(element[1:-1])   # xyge"
+    "#print(element[-1])     # \n",
+    "#print(element[-2])     # \n",
+    "#print(element[1:-1])   # "
    ]
   },
   {
@@ -436,9 +436,9 @@
    },
    "outputs": [],
    "source": [
-    "print(element[3:3])    # Empty string\n",
-    "print(data[3:3, 4:4])  # []\n",
-    "print(data[3:3, :])    # []"
+    "#print(element[3:3])    # \n",
+    "#print(data[3:3, 4:4])  # \n",
+    "#print(data[3:3, :])    # "
    ]
   },
   {

--- a/notebooks/02-loop.ipynb
+++ b/notebooks/02-loop.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Repeating Actions with Loops\n",
+    "Questions\n",
+    "* How can I do the same operations on many different values?\n",
+    "\n",
+    "Objectives\n",
+    "* Explain what a for loop does.\n",
+    "* Correctly write for loops to repeat simple calculations.\n",
+    "* Trace changes to a loop variable as the loop runs.\n",
+    "* Trace changes to other variables as they are updated by a for loop."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Repeated Actions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "### = ###"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(###)\n",
+    "print(###)\n",
+    "print(###)\n",
+    "print(###)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "word = ###"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(word[###])\n",
+    "print(word[###])\n",
+    "print(word[###])\n",
+    "print(word[###])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Loops"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "word = ###\n",
+    "###"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "word = ###\n",
+    "for char in word:\n",
+    "    print(char)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loops Syntax\n",
+    "```\n",
+    "for variable in collection:\n",
+    "    do things with variable\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Figure - What happens when accessing each letter](../fig/loops_image.png---)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Using `range()`\n",
+    "```Python\n",
+    "for i in range(3):         # 0, 1, 2\n",
+    "for i in range(2, 5):      # 2, 3, 4\n",
+    "for i in range(3, 10, 3):  # 3, 6, 9\n",
+    "```\n",
+    "But how can we get 1, 2, 3?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for ### in ###:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modifying Variables in a Loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "###\n",
+    "for vowel in 'aeiou':\n",
+    "    ###\n",
+    "print('There are', ###, 'vowels')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "letter = ###\n",
+    "for letter in ###:\n",
+    "    print(letter)\n",
+    "print('after the loop, letter is', ###)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(###('aeiou'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Computing Powers With Loops\n",
+    "```Python\n",
+    "print(5 ** 3)  # 125 = 5 * 5 * 5\n",
+    "```\n",
+    "Write a loop that calculates the same result as `5 ** 3` using multiplication (and without exponentiation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "result = ###\n",
+    "###\n",
+    "    ###\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Reverse a String\n",
+    "Write a loop that takes a string, and produces a new string with the characters in reverse order, so `'Newton'` becomes `'notweN'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "newstring = ''\n",
+    "oldstring = 'Newton'\n",
+    "length_old = len(oldstring)\n",
+    "\n",
+    "for char_index in ###:\n",
+    "   newstring = newstring + ###\n",
+    "\n",
+    "print(newstring)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/02-loop.ipynb
+++ b/notebooks/02-loop.ipynb
@@ -46,7 +46,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/02-loop.ipynb
+++ b/notebooks/02-loop.ipynb
@@ -270,7 +270,7 @@
    "source": [
     "newstring = ''\n",
     "oldstring = 'Newton'\n",
-    "length_old = len(oldstring)\n",
+    "length_old = ###(oldstring)\n",
     "\n",
     "for char_index in ###:\n",
     "   newstring = newstring + ###\n",

--- a/notebooks/03-lists.ipynb
+++ b/notebooks/03-lists.ipynb
@@ -62,7 +62,7 @@
    },
    "outputs": [],
    "source": [
-    "odds = [1, 3, 5, 7]\n",
+    "###\n",
     "print('odds are:', odds)"
    ]
   },
@@ -74,7 +74,7 @@
    },
    "outputs": [],
    "source": [
-    "print('first and last:', odds[0], odds[-1])"
+    "print('first and last:', ###, ###)"
    ]
   },
   {
@@ -85,7 +85,7 @@
    },
    "outputs": [],
    "source": [
-    "for number in odds:\n",
+    "for ###\n",
     "    print(number)"
    ]
   },
@@ -104,10 +104,10 @@
    },
    "outputs": [],
    "source": [
-    "names = ['Newton', 'Darwing', 'Turing'] # typo in Darwin's name\n",
-    "print('names is originally:', names)\n",
+    "names = 'Newton', 'Darwin---', 'Turing' # typo in Darwin's name\n",
+    "print('names is originally:', ###)\n",
     "\n",
-    "names[1] = 'Darwin' # correct the name\n",
+    "names### = ### # correct the name\n",
     "print('final value of names:', names)"
    ]
   },
@@ -120,8 +120,8 @@
    "outputs": [],
    "source": [
     "# Strings are immutable\n",
-    "name = 'Darwin'\n",
-    "name[0] = 'd'"
+    "name = ###\n",
+    "name### = ###"
    ]
   },
   {
@@ -139,16 +139,16 @@
    },
    "outputs": [],
    "source": [
-    "x = [['pepper',  'zucchini', 'onion' ],\n",
-    "     ['cabbage', 'lettuce',  'garlic'],\n",
-    "     ['apple',   'pear',     'banana']]"
+    "x =   'pepper',  'zucchini', 'onion'  ,\n",
+    "      'cabbage', 'lettuce',  'garlic' ,\n",
+    "      'apple',   'pear',     'banana'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Indexing lists in rstats. Inspired by the Residence Inn](../fig/indexing_lists_python.png)\n",
+    "![Indexing lists in rstats. Inspired by the Residence Inn](../fig/indexing_lists_python.png---)\n",
     "Thanks to Hadley Wickham for the image above.\n",
     "Source: https://twitter.com/hadleywickham/status/643381054758363136"
    ]
@@ -161,7 +161,7 @@
    },
    "outputs": [],
    "source": [
-    "print([x[0]])"
+    "print(###)"
    ]
   },
   {
@@ -172,7 +172,7 @@
    },
    "outputs": [],
    "source": [
-    "print(x[0])"
+    "print(###)"
    ]
   },
   {
@@ -183,7 +183,7 @@
    },
    "outputs": [],
    "source": [
-    "print(x[0][0])"
+    "print(###)"
    ]
   },
   {
@@ -201,7 +201,7 @@
    },
    "outputs": [],
    "source": [
-    "odds.append(11)\n",
+    "###\n",
     "print('odds after adding a value:', odds)"
    ]
   },
@@ -213,7 +213,7 @@
    },
    "outputs": [],
    "source": [
-    "del odds[0]\n",
+    "###\n",
     "print('odds after removing the first element:', odds)"
    ]
   },
@@ -225,7 +225,7 @@
    },
    "outputs": [],
    "source": [
-    "odds.reverse()\n",
+    "###\n",
     "print('odds after reversing:', odds)"
    ]
   },
@@ -238,9 +238,9 @@
    "outputs": [],
    "source": [
     "odds = [1, 3, 5, 7]\n",
-    "primes = odds\n",
-    "primes[0] = 2\n",
-    "odds += [9]\n",
+    "### = ###\n",
+    "primes### = ###\n",
+    "odds ### ###\n",
     "\n",
     "print('primes:', primes)\n",
     "print('odds:', odds)"
@@ -255,7 +255,7 @@
    "outputs": [],
    "source": [
     "odds = [1, 3, 5, 7]\n",
-    "primes = list(odds)\n",
+    "primes = ###\n",
     "primes[0] = 2\n",
     "odds += [9]\n",
     "\n",
@@ -286,9 +286,9 @@
    },
    "outputs": [],
    "source": [
-    "my_list = []\n",
-    "for char in \"hello\":\n",
-    "    my_list.append(char)\n",
+    "my_list = ###\n",
+    "for ###\n",
+    "    my_list###\n",
     "print(my_list)"
    ]
   },

--- a/notebooks/03-lists.ipynb
+++ b/notebooks/03-lists.ipynb
@@ -44,7 +44,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/03-lists.ipynb
+++ b/notebooks/03-lists.ipynb
@@ -303,23 +303,16 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
     "binomial_name = \"Drosophila melanogaster\"\n",
-    "group = binomial_name[0:10]\n",
+    "group = binomial_name###\n",
     "print(\"group:\", group)\n",
     "\n",
-    "species = binomial_name[11:24]\n",
-    "print(\"species:\", species)\n",
-    "\n",
-    "chromosomes = [\"X\", \"Y\", \"2\", \"3\", \"4\"]\n",
-    "autosomes = chromosomes[2:5]\n",
-    "print(\"autosomes:\", autosomes)\n",
-    "\n",
-    "last = chromosomes[-1]\n",
-    "print(\"last:\", last)"
+    "species = binomial_name###\n",
+    "print(\"species:\", species)"
    ]
   },
   {
@@ -330,10 +323,36 @@
    },
    "outputs": [],
    "source": [
+    "chromosomes = [\"X\", \"Y\", \"2\", \"3\", \"4\"]\n",
+    "autosomes = chromosomes###\n",
+    "print(\"autosomes:\", autosomes)\n",
+    "\n",
+    "last = chromosomes###\n",
+    "print(\"last:\", last)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "date = \"Monday 4 January 2016\"\n",
-    "day = date[0:6]\n",
-    "print(\"Using 0 to begin range:\", day)\n",
-    "day = date[:6]\n",
+    "day = date###\n",
+    "print(\"Using 0 to begin range:\", ###)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "day = date###\n",
     "print(\"Omitting beginning index:\", day)"
    ]
   },
@@ -346,11 +365,11 @@
    "outputs": [],
    "source": [
     "months = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"]\n",
-    "sond = months[8:12]\n",
+    "sond = months[8:###]\n",
     "print(\"With known last position:     \", sond)\n",
-    "sond = months[8:len(months)]\n",
+    "sond = months[8:###]\n",
     "print(\"Using len() to get last entry:\", sond)\n",
-    "sond = months[8:]\n",
+    "sond = months[8:###]\n",
     "print(\"Omitting ending index:        \", sond)"
    ]
   },
@@ -373,8 +392,8 @@
     "string_for_slicing = \"Observation date: 02-Feb-2013\"\n",
     "list_for_slicing = [[\"fluorine\", \"F\"], [\"chlorine\", \"Cl\"], [\"bromine\", \"Br\"], [\"iodine\", \"I\"], [\"astatine\", \"At\"]]\n",
     "\n",
-    "print(string_for_slicing[-4:])\n",
-    "print(list_for_slicing[-4:])"
+    "print(string_for_slicing###)\n",
+    "print(list_for_slicing###)"
    ]
   },
   {
@@ -400,7 +419,7 @@
    "outputs": [],
    "source": [
     "beatles = \"In an octopus's garden in the shade\"\n",
-    "print(beatles[::2])"
+    "print(beatles###)"
    ]
   },
   {
@@ -423,7 +442,7 @@
     "\n",
     "#my_solution = [4, 8, 12, 16, 20]\n",
     "#my_solution = [2, 2, 4, 4, 6, 6, 8, 8, 10, 10]\n",
-    "my_solution = [2, 4, 6, 8, 10, 2, 4, 6, 8, 10]\n",
+    "#my_solution = [2, 4, 6, 8, 10, 2, 4, 6, 8, 10]\n",
     "#my_solution = [[2, 4, 6, 8, 10],[2, 4, 6, 8, 10]]\n",
     "\n",
     "print(\"Python soln:\", repeats)\n",

--- a/notebooks/04-files.ipynb
+++ b/notebooks/04-files.ipynb
@@ -44,7 +44,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/04-files.ipynb
+++ b/notebooks/04-files.ipynb
@@ -62,7 +62,7 @@
    },
    "outputs": [],
    "source": [
-    "import glob"
+    "###"
    ]
   },
   {
@@ -73,7 +73,7 @@
    },
    "outputs": [],
    "source": [
-    "print(glob.glob('../data/inflammation*.csv'))"
+    "print(###('../data/inflammation---.csv'))"
    ]
   },
   {
@@ -104,31 +104,31 @@
    },
    "outputs": [],
    "source": [
-    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
-    "filenames = filenames[0:3]\n",
+    "###\n",
+    "### # Select only the first 3 files\n",
     "\n",
-    "for f in filenames:\n",
-    "    print(f)\n",
+    "###\n",
+    "    ###\n",
     "\n",
-    "    data = numpy.loadtxt(fname=f, delimiter=',')\n",
+    "data = numpy.loadtxt(fname='---/---/inflammation---.csv', delimiter=',')\n",
     "\n",
-    "    fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
+    "fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
     "\n",
-    "    axes1 = fig.add_subplot(1, 3, 1)\n",
-    "    axes2 = fig.add_subplot(1, 3, 2)\n",
-    "    axes3 = fig.add_subplot(1, 3, 3)\n",
+    "axes1 = fig.add_subplot(1, 3, 1)\n",
+    "axes2 = fig.add_subplot(1, 3, 2)\n",
+    "axes3 = fig.add_subplot(1, 3, 3)\n",
     "\n",
-    "    axes1.set_ylabel('average')\n",
-    "    axes1.plot(numpy.mean(data, axis=0))\n",
+    "axes1.set_ylabel('average')\n",
+    "axes1.plot(numpy.mean(data, axis=0))\n",
     "\n",
-    "    axes2.set_ylabel('max')\n",
-    "    axes2.plot(numpy.max(data, axis=0))\n",
+    "axes2.set_ylabel('max')\n",
+    "axes2.plot(numpy.max(data, axis=0))\n",
     "\n",
-    "    axes3.set_ylabel('min')\n",
-    "    axes3.plot(numpy.min(data, axis=0))\n",
+    "axes3.set_ylabel('min')\n",
+    "axes3.plot(numpy.min(data, axis=0))\n",
     "\n",
-    "    fig.tight_layout()\n",
-    "    matplotlib.pyplot.show()"
+    "fig.tight_layout()\n",
+    "matplotlib.pyplot.show()"
    ]
   },
   {
@@ -149,13 +149,13 @@
    },
    "outputs": [],
    "source": [
-    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "filenames = ###\n",
     "\n",
-    "data0 = numpy.loadtxt(fname=filenames[0], delimiter=',')\n",
-    "data1 = numpy.loadtxt(fname=filenames[1], delimiter=',')\n",
+    "data0 = numpy.loadtxt(fname=filenames###, delimiter=',')\n",
+    "data1 = numpy.loadtxt(fname=filenames###, delimiter=',')\n",
     "\n",
-    "matplotlib.pyplot.ylabel('Difference in average')\n",
-    "matplotlib.pyplot.plot(data0.mean(axis=0) - data1.mean(axis=0))\n",
+    "matplotlib.pyplot.###label('Difference in average')\n",
+    "matplotlib.pyplot.plot(###)\n",
     "\n",
     "matplotlib.pyplot.show()"
    ]

--- a/notebooks/04-files.ipynb
+++ b/notebooks/04-files.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Analyzing Data from Multiple Files\n",
+    "Questions\n",
+    "* How can I do the same operations on many different files?\n",
+    "\n",
+    "Objectives\n",
+    "* Use a library function to get a list of filenames that match a simple wildcard pattern.\n",
+    "* Use a for loop to process multiple files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using `glob`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import glob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(glob.glob('../data/inflammation*.csv'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading Files in Sorted Order"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "import matplotlib.pyplot\n",
+    "% matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "filenames = filenames[0:3]\n",
+    "\n",
+    "for f in filenames:\n",
+    "    print(f)\n",
+    "\n",
+    "    data = numpy.loadtxt(fname=f, delimiter=',')\n",
+    "\n",
+    "    fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
+    "\n",
+    "    axes1 = fig.add_subplot(1, 3, 1)\n",
+    "    axes2 = fig.add_subplot(1, 3, 2)\n",
+    "    axes3 = fig.add_subplot(1, 3, 3)\n",
+    "\n",
+    "    axes1.set_ylabel('average')\n",
+    "    axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "    axes2.set_ylabel('max')\n",
+    "    axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "    axes3.set_ylabel('min')\n",
+    "    axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "    fig.tight_layout()\n",
+    "    matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Exercise - Plotting Differences\n",
+    "Plot the difference between the average of the first dataset and the average of the second dataset, i.e., the difference between the leftmost plot of the first two figures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "\n",
+    "data0 = numpy.loadtxt(fname=filenames[0], delimiter=',')\n",
+    "data1 = numpy.loadtxt(fname=filenames[1], delimiter=',')\n",
+    "\n",
+    "matplotlib.pyplot.ylabel('Difference in average')\n",
+    "matplotlib.pyplot.plot(data0.mean(axis=0) - data1.mean(axis=0))\n",
+    "\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/05-cond.ipynb
+++ b/notebooks/05-cond.ipynb
@@ -1,0 +1,412 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Making Choices\n",
+    "Questions\n",
+    "* How can my programs do different things based on data values?\n",
+    "\n",
+    "Objectives\n",
+    "* Write conditional statements including `if`, `elif`, and `else` branches.\n",
+    "* Correctly evaluate expressions containing `and` and `or`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conditionals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "num = 37\n",
+    "if num > 100:\n",
+    "    print('greater')\n",
+    "else:\n",
+    "    print('not greater')\n",
+    "print('done')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![If num greater than 100](../fig/python-flowchart-conditional.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "num = 53\n",
+    "print('before conditional...')\n",
+    "if num > 100:\n",
+    "    print('53 is greater than 100')\n",
+    "print('...after conditional')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "num = -3\n",
+    "\n",
+    "if num > 0:\n",
+    "    print(num, \"is positive\")\n",
+    "elif num == 0:\n",
+    "    print(num, \"is zero\")\n",
+    "else:\n",
+    "    print(num, \"is negative\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - How Many Paths?\n",
+    "Which of the following would be printed if you were to run this code?\n",
+    "1. A\n",
+    "1. B\n",
+    "1. C\n",
+    "1. B and C"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if 4 > 5:\n",
+    "    print('A')\n",
+    "elif 4 == 5:\n",
+    "    print('B')\n",
+    "elif 4 < 5:\n",
+    "    print('C')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - What Is Truth?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if '':\n",
+    "    print('empty string is true')\n",
+    "if 'word':\n",
+    "    print('word is true')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if []:\n",
+    "    print('empty list is true')\n",
+    "if [1, 2, 3]:\n",
+    "    print('non-empty list is true')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if 0:\n",
+    "    print('zero is true')\n",
+    "if 1:\n",
+    "    print('one is true')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - That’s Not Not What I Meant"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if not '':\n",
+    "    print('empty string is not true')\n",
+    "if not 'word':\n",
+    "    print('word is not true')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if not False:\n",
+    "    print('not False is true')\n",
+    "if not not True:\n",
+    "    print('not not True is true')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Boolean Operators"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if (1 > 0) and (-1 > 0):\n",
+    "    print('both parts are true')\n",
+    "else:\n",
+    "    print('at least one part is false')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if (1 < 0) or (-1 < 0):\n",
+    "    print('at least one test is true')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Close Enough\n",
+    "Write some conditions that print `True` if the variable `a` is within 10% of the variable `b` and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a = 5\n",
+    "b = 5.1\n",
+    "\n",
+    "if abs(a - b) < 0.1 * abs(b):\n",
+    "    print('True')\n",
+    "else:\n",
+    "    print('False')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - In-Place Operators\n",
+    "Write some code that sums the positive and negative numbers in a list separately, using in-place operators. Here is an example of in-place operators:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = 1    # original value\n",
+    "x += 1   # add one to x, assigning result back to x\n",
+    "x *= 3   # multiply x by 3\n",
+    "print(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "test_list = [3, 4, 6, 1, -1, -5, 0, 7, -8]\n",
+    "positive_sum = 0\n",
+    "negative_sum = 0\n",
+    "\n",
+    "for num in test_list:\n",
+    "    if num > 0:\n",
+    "        positive_sum += num\n",
+    "    elif num < 0:\n",
+    "        negative_sum += num\n",
+    "\n",
+    "print(positive_sum, negative_sum)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Checking our Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
+    "\n",
+    "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "    print('Suspicious looking maxima!')\n",
+    "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "    print('Minima add up to zero!')\n",
+    "else:\n",
+    "    print('Seems OK!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-03.csv', delimiter=',')\n",
+    "\n",
+    "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "    print('Suspicious looking maxima!')\n",
+    "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "    print('Minima add up to zero!')\n",
+    "else:\n",
+    "    print('Seems OK!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/05-cond.ipynb
+++ b/notebooks/05-cond.ipynb
@@ -62,10 +62,10 @@
    },
    "outputs": [],
    "source": [
-    "num = 37\n",
-    "if num > 100:\n",
+    "num = ###\n",
+    "###\n",
     "    print('greater')\n",
-    "else:\n",
+    "###\n",
     "    print('not greater')\n",
     "print('done')"
    ]
@@ -74,7 +74,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![If num greater than 100](../fig/python-flowchart-conditional.png)"
+    "![If num greater than 100](../fig/python-flowchart-conditional.png---)"
    ]
   },
   {
@@ -85,10 +85,10 @@
    },
    "outputs": [],
    "source": [
-    "num = 53\n",
+    "num = ###\n",
     "print('before conditional...')\n",
-    "if num > 100:\n",
-    "    print('53 is greater than 100')\n",
+    "###\n",
+    "    print('--- is greater than 100')\n",
     "print('...after conditional')"
    ]
   },
@@ -100,13 +100,13 @@
    },
    "outputs": [],
    "source": [
-    "num = -3\n",
+    "num = ###\n",
     "\n",
-    "if num > 0:\n",
+    "###\n",
     "    print(num, \"is positive\")\n",
-    "elif num == 0:\n",
+    "###\n",
     "    print(num, \"is zero\")\n",
-    "else:\n",
+    "###\n",
     "    print(num, \"is negative\")"
    ]
   },
@@ -123,19 +123,19 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
    "source": [
+    "```\n",
     "if 4 > 5:\n",
     "    print('A')\n",
     "elif 4 == 5:\n",
     "    print('B')\n",
     "elif 4 < 5:\n",
-    "    print('C')"
+    "    print('C')\n",
+    "```"
    ]
   },
   {
@@ -153,9 +153,9 @@
    },
    "outputs": [],
    "source": [
-    "if '':\n",
+    "if ###:\n",
     "    print('empty string is true')\n",
-    "if 'word':\n",
+    "if ###:\n",
     "    print('word is true')"
    ]
   },
@@ -167,9 +167,9 @@
    },
    "outputs": [],
    "source": [
-    "if []:\n",
+    "if ###:\n",
     "    print('empty list is true')\n",
-    "if [1, 2, 3]:\n",
+    "if ###:\n",
     "    print('non-empty list is true')"
    ]
   },
@@ -181,9 +181,9 @@
    },
    "outputs": [],
    "source": [
-    "if 0:\n",
+    "if ###:\n",
     "    print('zero is true')\n",
-    "if 1:\n",
+    "if ###:\n",
     "    print('one is true')"
    ]
   },
@@ -202,9 +202,9 @@
    },
    "outputs": [],
    "source": [
-    "if not '':\n",
+    "if ###:\n",
     "    print('empty string is not true')\n",
-    "if not 'word':\n",
+    "if ###:\n",
     "    print('word is not true')"
    ]
   },
@@ -216,9 +216,9 @@
    },
    "outputs": [],
    "source": [
-    "if not False:\n",
+    "if ###:\n",
     "    print('not False is true')\n",
-    "if not not True:\n",
+    "if ###:\n",
     "    print('not not True is true')"
    ]
   },
@@ -237,7 +237,7 @@
    },
    "outputs": [],
    "source": [
-    "if (1 > 0) and (-1 > 0):\n",
+    "if ###:\n",
     "    print('both parts are true')\n",
     "else:\n",
     "    print('at least one part is false')"
@@ -251,7 +251,7 @@
    },
    "outputs": [],
    "source": [
-    "if (1 < 0) or (-1 < 0):\n",
+    "if ###:\n",
     "    print('at least one test is true')"
    ]
   },
@@ -274,7 +274,7 @@
     "a = 5\n",
     "b = 5.1\n",
     "\n",
-    "if abs(a - b) < 0.1 * abs(b):\n",
+    "if abs(###) ###\n",
     "    print('True')\n",
     "else:\n",
     "    print('False')"
@@ -314,11 +314,11 @@
     "positive_sum = 0\n",
     "negative_sum = 0\n",
     "\n",
-    "for num in test_list:\n",
-    "    if num > 0:\n",
-    "        positive_sum += num\n",
-    "    elif num < 0:\n",
-    "        negative_sum += num\n",
+    "for ###\n",
+    "    ###\n",
+    "        positive_sum ###\n",
+    "    ###\n",
+    "        negative_sum ###\n",
     "\n",
     "print(positive_sum, negative_sum)"
    ]
@@ -351,9 +351,9 @@
    "source": [
     "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
     "\n",
-    "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "if ###:\n",
     "    print('Suspicious looking maxima!')\n",
-    "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "elif ###:\n",
     "    print('Minima add up to zero!')\n",
     "else:\n",
     "    print('Seems OK!')"
@@ -369,9 +369,9 @@
    "source": [
     "data = numpy.loadtxt(fname='../data/inflammation-03.csv', delimiter=',')\n",
     "\n",
-    "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "if ###:\n",
     "    print('Suspicious looking maxima!')\n",
-    "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "elif ###:\n",
     "    print('Minima add up to zero!')\n",
     "else:\n",
     "    print('Seems OK!')"

--- a/notebooks/06-func.ipynb
+++ b/notebooks/06-func.ipynb
@@ -67,15 +67,15 @@
    },
    "outputs": [],
    "source": [
-    "def fahr_to_kelvin(temp):\n",
-    "    return ((temp - 32) * (5/9)) + 273.15"
+    "### fahr_to_kelvin###\n",
+    "    ### ((temp - 32) * (5/9)) + 273.15"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![def fahr_to_kelvin(temp)](../fig/python-function.svg)"
+    "![def fahr_to_kelvin(temp)](../fig/python-function.svg---)"
    ]
   },
   {
@@ -86,8 +86,8 @@
    },
    "outputs": [],
    "source": [
-    "print('freezing point of water:', fahr_to_kelvin(32))\n",
-    "print('boiling point of water:', fahr_to_kelvin(212))"
+    "print('freezing point of water:', ###)\n",
+    "print('boiling point of water:', ###)"
    ]
   },
   {
@@ -106,8 +106,8 @@
    },
    "outputs": [],
    "source": [
-    "def fence(original, wrapper):\n",
-    "    return wrapper + original + wrapper\n",
+    "###\n",
+    "    ###\n",
     "\n",
     "print(fence('name', '*'))"
    ]
@@ -133,11 +133,11 @@
    "source": [
     "import numpy\n",
     "\n",
-    "def rescale(input_array):\n",
-    "    L = numpy.min(input_array)\n",
-    "    H = numpy.max(input_array)\n",
-    "    output_array = (input_array - L) / (H - L)\n",
-    "    return output_array\n",
+    "###\n",
+    "    L = ###\n",
+    "    H = ###\n",
+    "    ### = (### - L) / (H - L)\n",
+    "    ###\n",
     "\n",
     "print(rescale(numpy.array([10, 12, 16, 20])))"
    ]
@@ -157,7 +157,7 @@
    },
    "outputs": [],
    "source": [
-    "! python2 -c \"print(5/9)\""
+    "###"
    ]
   },
   {
@@ -168,7 +168,7 @@
    },
    "outputs": [],
    "source": [
-    "! python3 -c \"print(5/9)\""
+    "! python### -c \"print(5/9)\""
    ]
   },
   {
@@ -179,10 +179,10 @@
    },
    "outputs": [],
    "source": [
-    "print(float(5)/9)\n",
-    "print(5/float(9))\n",
-    "print(5.0/9)\n",
-    "print(5/9.0)"
+    "print(###(5)/9)\n",
+    "print(5/###(9))\n",
+    "print(5###/9)\n",
+    "print(5/9###)"
    ]
   },
   {
@@ -193,8 +193,8 @@
    },
    "outputs": [],
    "source": [
-    "print(4//2)\n",
-    "print(3//2)"
+    "print(4###2)\n",
+    "print(3###2)"
    ]
   },
   {
@@ -212,8 +212,8 @@
    },
    "outputs": [],
    "source": [
-    "def kelvin_to_celsius(temp_k):\n",
-    "    return temp_k - 273.15\n",
+    "### kelvin_to_celsius###\n",
+    "    ###\n",
     "\n",
     "print('absolute zero in Celsius:', kelvin_to_celsius(0.0))"
    ]
@@ -226,10 +226,10 @@
    },
    "outputs": [],
    "source": [
-    "def fahr_to_celsius(temp_f):\n",
-    "    temp_k = fahr_to_kelvin(temp_f)\n",
-    "    result = kelvin_to_celsius(temp_k)\n",
-    "    return result\n",
+    "### fahr_to_celsius###\n",
+    "    ### = fahr_to_kelvin(###)\n",
+    "    ### = kelvin_to_celsius(###)\n",
+    "    ###\n",
     "\n",
     "print('freezing point of water in Celsius:', fahr_to_celsius(32.0))"
    ]
@@ -262,9 +262,14 @@
    },
    "outputs": [],
    "source": [
-    "def analyze(filename):\n",
+    "# The following code is copied from Chapter 4\n",
+    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "filenames = filenames[0:3]\n",
     "\n",
-    "    data = numpy.loadtxt(fname=filename, delimiter=',')\n",
+    "for f in filenames:\n",
+    "    print(f)\n",
+    "\n",
+    "    data = numpy.loadtxt(fname=f, delimiter=',')\n",
     "\n",
     "    fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
     "\n",
@@ -293,16 +298,15 @@
    },
    "outputs": [],
    "source": [
-    "def detect_problems(filename):\n",
+    "# The following code is copied from Chapter 5\n",
+    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
     "\n",
-    "    data = numpy.loadtxt(fname=filename, delimiter=',')\n",
-    "\n",
-    "    if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
-    "        print('Suspicious looking maxima!')\n",
-    "    elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
-    "        print('Minima add up to zero!')\n",
-    "    else:\n",
-    "        print('Seems OK!')"
+    "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "    print('Suspicious looking maxima!')\n",
+    "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "    print('Minima add up to zero!')\n",
+    "else:\n",
+    "    print('Seems OK!')"
    ]
   },
   {
@@ -313,11 +317,12 @@
    },
    "outputs": [],
    "source": [
+    "# Main code\n",
     "import glob\n",
-    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "###\n",
     "\n",
-    "for f in filenames[:3]:\n",
-    "    print(f)\n",
+    "###\n",
+    "    ###\n",
     "    analyze(f)\n",
     "    detect_problems(f)"
    ]

--- a/notebooks/06-func.ipynb
+++ b/notebooks/06-func.ipynb
@@ -343,7 +343,7 @@
    "outputs": [],
    "source": [
     "def center(data, desired):\n",
-    "    return (data - numpy.mean(data)) + desired"
+    "    return ###"
    ]
   },
   {
@@ -354,8 +354,8 @@
    },
    "outputs": [],
    "source": [
-    "z = numpy.zeros((2,2))\n",
-    "print(center(z, 3))"
+    "z = numpy.zeros(###)\n",
+    "print(center(z, ###))"
    ]
   },
   {
@@ -367,7 +367,7 @@
    "outputs": [],
    "source": [
     "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
-    "print(center(data, 0))"
+    "print(center(###, ###))"
    ]
   },
   {
@@ -378,9 +378,9 @@
    },
    "outputs": [],
    "source": [
-    "print('original min, mean, and max are:', numpy.min(data), numpy.mean(data), numpy.max(data))\n",
-    "centered = center(data, 0)\n",
-    "print('min, mean, and max of centered data are:', numpy.min(centered), numpy.mean(centered), numpy.max(centered))"
+    "print('original min, mean, and max are:', numpy.###(data), numpy.###(data), numpy.###(data))\n",
+    "###\n",
+    "print('min, mean, and max of centered data are:', numpy.min(###), numpy.mean(###), numpy.max(###))"
    ]
   },
   {
@@ -391,7 +391,7 @@
    },
    "outputs": [],
    "source": [
-    "print('std dev before and after:', numpy.std(data), numpy.std(centered))"
+    "print('std dev before and after:', numpy.###(data), numpy.###(centered))"
    ]
   },
   {
@@ -402,7 +402,7 @@
    },
    "outputs": [],
    "source": [
-    "print('difference in standard deviations before and after:', numpy.std(data) - numpy.std(centered))"
+    "print('--- in standard deviations before and after:', numpy.std(data) ### numpy.std(centered))"
    ]
   },
   {
@@ -413,7 +413,7 @@
    },
    "outputs": [],
    "source": [
-    "# center(data, desired): return a new array containing the original data centered around the desired value.\n",
+    "###\n",
     "def center(data, desired):\n",
     "    return (data - numpy.mean(data)) + desired"
    ]
@@ -427,7 +427,7 @@
    "outputs": [],
    "source": [
     "def center(data, desired):\n",
-    "    '''Return a new array containing the original data centered around the desired value.'''\n",
+    "    ### center(data, desired): return a new array containing the original data centered around the desired value.\n",
     "    return (data - numpy.mean(data)) + desired"
    ]
   },
@@ -439,7 +439,7 @@
    },
    "outputs": [],
    "source": [
-    "help(center)"
+    "###"
    ]
   },
   {
@@ -451,11 +451,11 @@
    "outputs": [],
    "source": [
     "def center(data, desired):\n",
-    "    '''Return a new array containing the original data centered around the desired value.\n",
-    "    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''\n",
+    "    ###\n",
+    "    ###\n",
     "    return (data - numpy.mean(data)) + desired\n",
     "\n",
-    "help(center)"
+    "###"
    ]
   },
   {
@@ -475,8 +475,8 @@
    "outputs": [],
    "source": [
     "#help(numpy.arange)\n",
-    "print(\"array =\", numpy.arange(10.0))\n",
-    "rescale(numpy.arange(10.0))"
+    "print(\"array =\", numpy.arange(###))\n",
+    "rescale(numpy.arange(###))"
    ]
   },
   {
@@ -489,8 +489,8 @@
    "outputs": [],
    "source": [
     "#help(numpy.linspace)\n",
-    "print(\"array =\", numpy.linspace(0, 100, 5))\n",
-    "rescale(numpy.linspace(0, 100, 5))"
+    "print(\"array =\", numpy.linspace(###))\n",
+    "rescale(numpy.linspace(###))"
    ]
   },
   {
@@ -502,16 +502,16 @@
    "outputs": [],
    "source": [
     "def rescale(input_array):\n",
-    "    '''Takes an array as input, and returns a corresponding array scaled so\n",
+    "    ###Takes an array as input, and returns a corresponding array scaled so\n",
     "    that 0 corresponds to the minimum and 1 to the maximum value of the input array.\n",
     "\n",
     "    Examples:\n",
-    "    >>> rescale(numpy.arange(10.0))\n",
-    "    array([ 0.        ,  0.11111111,  0.22222222,  0.33333333,  0.44444444,\n",
-    "            0.55555556,  0.66666667,  0.77777778,  0.88888889,  1.        ])\n",
-    "    >>> rescale(numpy.linspace(0, 100, 5))\n",
-    "    array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])\n",
-    "    '''\n",
+    "    >>> ###\n",
+    "    ###\n",
+    "    ###\n",
+    "    >>> ###\n",
+    "    ###\n",
+    "    ###\n",
     "    L = numpy.min(input_array)\n",
     "    H = numpy.max(input_array)\n",
     "    output_array = (input_array - L) / (H - L)\n",
@@ -544,7 +544,7 @@
    },
    "outputs": [],
    "source": [
-    "numpy.loadtxt('../data/inflammation-01.csv', delimiter=',')"
+    "numpy.loadtxt('../data/inflammation-01.csv', ###=',')"
    ]
   },
   {
@@ -555,7 +555,7 @@
    },
    "outputs": [],
    "source": [
-    "numpy.loadtxt('../data/inflammation-01.csv', ',')"
+    "numpy.loadtxt('../data/inflammation-01.csv', ###)"
    ]
   },
   {
@@ -566,9 +566,9 @@
    },
    "outputs": [],
    "source": [
-    "def center(data, desired=0.0):\n",
-    "    '''Return a new array containing the original data centered around the desired value (0 by default).\n",
-    "    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''\n",
+    "def center(data, desired###):\n",
+    "    ###Return a new array containing the original data centered around the desired value (### by default).\n",
+    "    Example: center([1, 2, 3], 0) => [-1, 0, 1]###\n",
     "    return (data - numpy.mean(data)) + desired"
    ]
   },
@@ -581,7 +581,7 @@
    "outputs": [],
    "source": [
     "test_data = numpy.zeros((2, 2))\n",
-    "print(center(test_data, 3))"
+    "print(center(test_data, ###))"
    ]
   },
   {
@@ -592,11 +592,11 @@
    },
    "outputs": [],
    "source": [
-    "more_data = 5 + numpy.zeros((2, 2))\n",
+    "more_data = ### + numpy.zeros((2, 2))\n",
     "print('data before centering:')\n",
-    "print(more_data)\n",
+    "print(###)\n",
     "print('centered data:')\n",
-    "print(center(more_data))"
+    "print(###)"
    ]
   },
   {
@@ -607,7 +607,7 @@
    },
    "outputs": [],
    "source": [
-    "def display(a=1, b=2, c=3):\n",
+    "def display(a###, b###, c###):\n",
     "    print('a:', a, 'b:', b, 'c:', c)"
    ]
   },
@@ -620,7 +620,7 @@
    "outputs": [],
    "source": [
     "print('no parameters:')\n",
-    "display()"
+    "###"
    ]
   },
   {
@@ -632,7 +632,7 @@
    "outputs": [],
    "source": [
     "print('one parameter:')\n",
-    "display(55)"
+    "display(###)"
    ]
   },
   {
@@ -644,7 +644,7 @@
    "outputs": [],
    "source": [
     "print('two parameters:')\n",
-    "display(55, 66)"
+    "display(###)"
    ]
   },
   {
@@ -656,7 +656,7 @@
    "outputs": [],
    "source": [
     "print('only setting the value of c')\n",
-    "display(c=77)"
+    "display(###)"
    ]
   },
   {
@@ -668,7 +668,7 @@
    "outputs": [],
    "source": [
     "# numpy.loadtxt('../data/inflammation-01.csv', ',')\n",
-    "help(numpy.loadtxt)"
+    "help(numpy###)"
    ]
   },
   {
@@ -747,12 +747,12 @@
    },
    "outputs": [],
    "source": [
-    "def rescale(input_array, low_val=0.0, high_val=1.0):\n",
+    "def rescale(input_array, ###, ###):\n",
     "    '''Rescales input array values to lie between low_val and high_val'''\n",
     "    L = numpy.min(input_array)\n",
     "    H = numpy.max(input_array)\n",
-    "    intermed_array = (input_array - L) / (H - L)\n",
-    "    output_array = intermed_array * (high_val - low_val) + low_val\n",
+    "    ### = (input_array - L) / (H - L)\n",
+    "    output_array = ###\n",
     "    return output_array"
    ]
   },

--- a/notebooks/06-func.ipynb
+++ b/notebooks/06-func.ipynb
@@ -1,0 +1,929 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Creating Functions\n",
+    "Questions\n",
+    "* How can I define new functions?\n",
+    "* What’s the difference between defining and calling a function?\n",
+    "* What happens when I call a function?\n",
+    "\n",
+    "Objectives\n",
+    "* Define a function that takes parameters.\n",
+    "* Return a value from a function.\n",
+    "* Test and debug a function.\n",
+    "* Set default values for function parameters.\n",
+    "* Explain why we should divide programs into small, single-purpose functions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining a Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def fahr_to_kelvin(temp):\n",
+    "    return ((temp - 32) * (5/9)) + 273.15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![def fahr_to_kelvin(temp)](../fig/python-function.svg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('freezing point of water:', fahr_to_kelvin(32))\n",
+    "print('boiling point of water:', fahr_to_kelvin(212))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Combining Strings\n",
+    "Write a function called `fence` that takes two parameters called `original` and `wrapper` and returns a new string that has the wrapper character at the beginning and end of the original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fence(original, wrapper):\n",
+    "    return wrapper + original + wrapper\n",
+    "\n",
+    "print(fence('name', '*'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Rescaling an Array\n",
+    "Write a function `rescale` that takes an array as input and returns a corresponding array of values scaled to lie in the range 0.0 to 1.0. Hints:\n",
+    "* L: lowest value\n",
+    "* H: highest value\n",
+    "* scale_value = (value - L) / (H - L)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "\n",
+    "def rescale(input_array):\n",
+    "    L = numpy.min(input_array)\n",
+    "    H = numpy.max(input_array)\n",
+    "    output_array = (input_array - L) / (H - L)\n",
+    "    return output_array\n",
+    "\n",
+    "print(rescale(numpy.array([10, 12, 16, 20])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Integer Division - Python 2 vs Python 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "! python2 -c \"print(5/9)\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "! python3 -c \"print(5/9)\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(float(5)/9)\n",
+    "print(5/float(9))\n",
+    "print(5.0/9)\n",
+    "print(5/9.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(4//2)\n",
+    "print(3//2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Composing Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def kelvin_to_celsius(temp_k):\n",
+    "    return temp_k - 273.15\n",
+    "\n",
+    "print('absolute zero in Celsius:', kelvin_to_celsius(0.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fahr_to_celsius(temp_f):\n",
+    "    temp_k = fahr_to_kelvin(temp_f)\n",
+    "    result = kelvin_to_celsius(temp_k)\n",
+    "    return result\n",
+    "\n",
+    "print('freezing point of water in Celsius:', fahr_to_celsius(32.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tidying up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "import matplotlib.pyplot\n",
+    "% matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def analyze(filename):\n",
+    "\n",
+    "    data = numpy.loadtxt(fname=filename, delimiter=',')\n",
+    "\n",
+    "    fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
+    "\n",
+    "    axes1 = fig.add_subplot(1, 3, 1)\n",
+    "    axes2 = fig.add_subplot(1, 3, 2)\n",
+    "    axes3 = fig.add_subplot(1, 3, 3)\n",
+    "\n",
+    "    axes1.set_ylabel('average')\n",
+    "    axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "    axes2.set_ylabel('max')\n",
+    "    axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "    axes3.set_ylabel('min')\n",
+    "    axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "    fig.tight_layout()\n",
+    "    matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def detect_problems(filename):\n",
+    "\n",
+    "    data = numpy.loadtxt(fname=filename, delimiter=',')\n",
+    "\n",
+    "    if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "        print('Suspicious looking maxima!')\n",
+    "    elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "        print('Minima add up to zero!')\n",
+    "    else:\n",
+    "        print('Seems OK!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "\n",
+    "for f in filenames[:3]:\n",
+    "    print(f)\n",
+    "    analyze(f)\n",
+    "    detect_problems(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing and Documenting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired):\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "z = numpy.zeros((2,2))\n",
+    "print(center(z, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
+    "print(center(data, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('original min, mean, and max are:', numpy.min(data), numpy.mean(data), numpy.max(data))\n",
+    "centered = center(data, 0)\n",
+    "print('min, mean, and max of centered data are:', numpy.min(centered), numpy.mean(centered), numpy.max(centered))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('std dev before and after:', numpy.std(data), numpy.std(centered))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('difference in standard deviations before and after:', numpy.std(data) - numpy.std(centered))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# center(data, desired): return a new array containing the original data centered around the desired value.\n",
+    "def center(data, desired):\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired):\n",
+    "    '''Return a new array containing the original data centered around the desired value.'''\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "help(center)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired):\n",
+    "    '''Return a new array containing the original data centered around the desired value.\n",
+    "    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''\n",
+    "    return (data - numpy.mean(data)) + desired\n",
+    "\n",
+    "help(center)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Testing and Documenting Your Function\n",
+    "Test your `rescale` function with arrays generated with `numpy.arange` and `numpy.linspace`. Use `help()` to see how to use these functions. Once you’ve successfully tested your function, add a docstring that explains what it does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#help(numpy.arange)\n",
+    "print(\"array =\", numpy.arange(10.0))\n",
+    "rescale(numpy.arange(10.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#help(numpy.linspace)\n",
+    "print(\"array =\", numpy.linspace(0, 100, 5))\n",
+    "rescale(numpy.linspace(0, 100, 5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def rescale(input_array):\n",
+    "    '''Takes an array as input, and returns a corresponding array scaled so\n",
+    "    that 0 corresponds to the minimum and 1 to the maximum value of the input array.\n",
+    "\n",
+    "    Examples:\n",
+    "    >>> rescale(numpy.arange(10.0))\n",
+    "    array([ 0.        ,  0.11111111,  0.22222222,  0.33333333,  0.44444444,\n",
+    "            0.55555556,  0.66666667,  0.77777778,  0.88888889,  1.        ])\n",
+    "    >>> rescale(numpy.linspace(0, 100, 5))\n",
+    "    array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])\n",
+    "    '''\n",
+    "    L = numpy.min(input_array)\n",
+    "    H = numpy.max(input_array)\n",
+    "    output_array = (input_array - L) / (H - L)\n",
+    "    return output_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "help(rescale)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining Defaults"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numpy.loadtxt('../data/inflammation-01.csv', delimiter=',')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numpy.loadtxt('../data/inflammation-01.csv', ',')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired=0.0):\n",
+    "    '''Return a new array containing the original data centered around the desired value (0 by default).\n",
+    "    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "test_data = numpy.zeros((2, 2))\n",
+    "print(center(test_data, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "more_data = 5 + numpy.zeros((2, 2))\n",
+    "print('data before centering:')\n",
+    "print(more_data)\n",
+    "print('centered data:')\n",
+    "print(center(more_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def display(a=1, b=2, c=3):\n",
+    "    print('a:', a, 'b:', b, 'c:', c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('no parameters:')\n",
+    "display()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('one parameter:')\n",
+    "display(55)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('two parameters:')\n",
+    "display(55, 66)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('only setting the value of c')\n",
+    "display(c=77)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# numpy.loadtxt('../data/inflammation-01.csv', ',')\n",
+    "help(numpy.loadtxt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Mixing Default and Non-Default Parameters\n",
+    "Given the following code:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "def numbers(one, two=2, three, four=4):\n",
+    "    n = str(one) + str(two) + str(three) + str(four)\n",
+    "    return n\n",
+    "\n",
+    "print(numbers(1, three=3))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "what do you expect will be printed? What is actually printed? What rule do you think Python is following?\n",
+    "\n",
+    "1. `1234`\n",
+    "1. `one2three4`\n",
+    "1. `1239`\n",
+    "1. `SyntaxError`\n",
+    "\n",
+    "Given that, what does the following piece of code display when run?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "def func(a, b = 3, c = 6):\n",
+    "  print('a: ', a, 'b: ', b,'c:', c)\n",
+    "\n",
+    "func(-1, 2)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. `a:  b: 3 c: 6`\n",
+    "1. `a: -1 b: 3 c: 6`\n",
+    "1. `a: -1 b: 2 c: 6`\n",
+    "1. `a:  b: -1 c: 2`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Defining Defaults\n",
+    "Rewrite the `rescale` function so that it scales data to lie between 0.0 and 1.0 by default, but will allow the caller to specify lower and upper bounds if they want. Hints:\n",
+    "* scale_value = (value - L) / (H - L)\n",
+    "* scale_value * (H - L) = (value - L)\n",
+    "* **scale_value * (H - L) + L = value**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def rescale(input_array, low_val=0.0, high_val=1.0):\n",
+    "    '''Rescales input array values to lie between low_val and high_val'''\n",
+    "    L = numpy.min(input_array)\n",
+    "    H = numpy.max(input_array)\n",
+    "    intermed_array = (input_array - L) / (H - L)\n",
+    "    output_array = intermed_array * (high_val - low_val) + low_val\n",
+    "    return output_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rescale(numpy.linspace(0, 100, 5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rescale(numpy.linspace(0, 100, 5), high_val=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rescale(numpy.linspace(0, 100, 5), high_val=0, low_val=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Readable functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def s(p):\n",
+    "    a = 0\n",
+    "    for v in p:\n",
+    "        a += v\n",
+    "    m = a / len(p)\n",
+    "    d = 0\n",
+    "    for v in p:\n",
+    "        d += (v - m) * (v - m)\n",
+    "    return numpy.sqrt(d / (len(p) - 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def std_dev(sample):\n",
+    "    sample_sum = 0\n",
+    "    for value in sample:\n",
+    "        sample_sum += value\n",
+    "\n",
+    "    sample_mean = sample_sum / len(sample)\n",
+    "\n",
+    "    sum_squared_devs = 0\n",
+    "    for value in sample:\n",
+    "        sum_squared_devs += (value - sample_mean) * (value - sample_mean)\n",
+    "\n",
+    "    return numpy.sqrt(sum_squared_devs / (len(sample) - 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Exercise - Variables Inside and Outside Functions\n",
+    "What does the following piece of code display when run - and why?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "f = 0\n",
+    "k = 0\n",
+    "\n",
+    "def f2k(f):\n",
+    "  k = ((f-32)*(5.0/9.0)) + 273.15\n",
+    "  return k\n",
+    "\n",
+    "f2k(8)\n",
+    "f2k(41)\n",
+    "f2k(32)\n",
+    "\n",
+    "print(k)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - The Old Switcheroo\n",
+    "Which of the following would be printed if you were to run this code? Why did you pick this answer?\n",
+    "\n",
+    "1. `7 3`\n",
+    "1. `3 7`\n",
+    "1. `3 3`\n",
+    "1. `7 7`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "a = 3\n",
+    "b = 7\n",
+    "\n",
+    "def swap(a, b):\n",
+    "    temp = a\n",
+    "    a = b\n",
+    "    b = temp\n",
+    "\n",
+    "swap(a, b)\n",
+    "\n",
+    "print(a, b)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/07-errors.ipynb
+++ b/notebooks/07-errors.ipynb
@@ -76,8 +76,8 @@
    },
    "outputs": [],
    "source": [
-    "import errors_01\n",
-    "errors_01.favorite_ice_cream()"
+    "import ###\n",
+    "###"
    ]
   },
   {
@@ -87,12 +87,12 @@
     "### Exercise - Reading Error Messages\n",
     "Read the traceback below, and identify the following pieces of information about it:\n",
     "\n",
-    "1. How many levels does the traceback have? **3 levels**\n",
-    "1. What is the file name where the error occurred? **`errors_02.py`**\n",
-    "1. What is the function name where the error occurred? **`print_message`**\n",
-    "1. On which line number in this function did the error occurr? **11**\n",
-    "1. What is the type of error? **`KeyError`**\n",
-    "1. What is the error message? **`Friday` is not a key in `messages`**"
+    "1. How many levels does the traceback have?\n",
+    "1. What is the file name where the error occurred?\n",
+    "1. What is the function name where the error occurred?\n",
+    "1. On which line number in this function did the error occurr?\n",
+    "1. What is the type of error?\n",
+    "1. What is the error message?"
    ]
   },
   {
@@ -122,10 +122,10 @@
    },
    "outputs": [],
    "source": [
-    "def some_function()\n",
+    "###\n",
     "    msg = \"hello, world!\"\n",
     "    print(msg)\n",
-    "     return msg"
+    "    #return msg"
    ]
   },
   {
@@ -136,10 +136,10 @@
    },
    "outputs": [],
    "source": [
-    "def some_function():\n",
+    "###\n",
     "    msg = \"hello, world!\"\n",
     "    print(msg)\n",
-    "     return msg"
+    "    #return msg"
    ]
   },
   {
@@ -155,10 +155,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "```Python\n",
+    "def another_function\n",
+    "  print(\"Syntax errors are annoying.\")\n",
+    "   print(\"But at least python tells us about them!\")\n",
+    "  print(\"So they are usually not too hard to fix.\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your solution:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -166,25 +187,6 @@
     "  print(\"Syntax errors are annoying.\")\n",
     "   print(\"But at least python tells us about them!\")\n",
     "  print(\"So they are usually not too hard to fix.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`SyntaxErro`r for missing `():` at end of first line, `IndentationError` for mismatch between second and third lines. A fixed version is:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```Python\n",
-    "def another_function():\n",
-    "    print(\"Syntax errors are annoying.\")\n",
-    "    print(\"But at least python tells us about them!\")\n",
-    "    print(\"So they are usually not too hard to fix.\")\n",
-    "```"
    ]
   },
   {
@@ -202,7 +204,7 @@
    },
    "outputs": [],
    "source": [
-    "print(a)"
+    "print(###)"
    ]
   },
   {
@@ -213,7 +215,7 @@
    },
    "outputs": [],
    "source": [
-    "print(hello)"
+    "print(###)"
    ]
   },
   {
@@ -224,9 +226,9 @@
    },
    "outputs": [],
    "source": [
-    "for number in range(10):\n",
-    "    count = count + number\n",
-    "print(\"The count is:\", count)"
+    "for ### in range(10):\n",
+    "    ###\n",
+    "print(\"The count is:\", ###)"
    ]
   },
   {
@@ -237,10 +239,10 @@
    },
    "outputs": [],
    "source": [
-    "Count = 0\n",
-    "for number in range(10):\n",
-    "    count = count + number\n",
-    "print(\"The count is:\", count)"
+    "###\n",
+    "for ### in range(10):\n",
+    "    ###\n",
+    "print(\"The count is:\", ###)"
    ]
   },
   {
@@ -253,6 +255,30 @@
     "1. Run the code, and read the error message. What type of NameError do you think this is? In other words, is it a string with no quotes, a misspelled variable, or a variable that should have been defined but was not?\n",
     "1. Fix the error.\n",
     "1. Repeat steps 2 and 3, until you have fixed all the errors."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "```Python\n",
+    "for number in range(10):\n",
+    "    # use a if the number is a multiple of 3, otherwise use b\n",
+    "    if (Number % 3) == 0:\n",
+    "        message = message + a\n",
+    "    else:\n",
+    "        message = message + \"b\"\n",
+    "print(message)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your solution:"
    ]
   },
   {
@@ -276,29 +302,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fixed version:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```Python\n",
-    "message = \"\"\n",
-    "for number in range(10):\n",
-    "    # use a if the number is a multiple of 3, otherwise use b\n",
-    "    if (number % 3) == 0:\n",
-    "        message = message + \"a\"\n",
-    "    else:\n",
-    "        message = message + \"b\"\n",
-    "print(message)\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Item Errors"
    ]
   },
@@ -311,10 +314,10 @@
    "outputs": [],
    "source": [
     "letters = ['a', 'b', 'c']\n",
-    "print(\"Letter #1 is\", letters[0])\n",
-    "print(\"Letter #2 is\", letters[1])\n",
-    "print(\"Letter #3 is\", letters[2])\n",
-    "print(\"Letter #4 is\", letters[3])"
+    "print(\"Letter #--- is\", letters[###])\n",
+    "print(\"Letter #--- is\", letters[###])\n",
+    "print(\"Letter #--- is\", letters[###])\n",
+    "print(\"Letter #--- is\", letters[###])"
    ]
   },
   {
@@ -329,32 +332,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
+   "source": [
+    "```Python\n",
+    "seasons = ['Spring', 'Summer', 'Fall', 'Winter']\n",
+    "print('My favorite season is ', seasons[4])\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your solution:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
     "seasons = ['Spring', 'Summer', 'Fall', 'Winter']\n",
     "print('My favorite season is ', seasons[4])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`IndexError`; the last entry is `seasons[3]`, so `seasons[4]` doesn’t make sense. A fixed version is:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```Python\n",
-    "seasons = ['Spring', 'Summer', 'Fall', 'Winter']\n",
-    "print('My favorite season is ', seasons[-1])\n",
-    "```"
    ]
   },
   {
@@ -372,7 +377,7 @@
    },
    "outputs": [],
    "source": [
-    "file_handle = open('myfile.txt', 'r')"
+    "file_handle = ###"
    ]
   },
   {
@@ -383,8 +388,8 @@
    },
    "outputs": [],
    "source": [
-    "file_handle = open('myfile.txt', 'w')\n",
-    "file_handle.read()"
+    "file_handle = ###\n",
+    "file_handle.###"
    ]
   },
   {

--- a/notebooks/07-errors.ipynb
+++ b/notebooks/07-errors.ipynb
@@ -1,0 +1,422 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Errors and Exceptions\n",
+    "Questions\n",
+    "* How does Python report errors?\n",
+    "* How can I handle errors in Python programs?\n",
+    "\n",
+    "Objectives\n",
+    "* To be able to read a traceback, and determine where the error took place and what type it is.\n",
+    "* To be able to describe the types of situations in which syntax errors, indentation errors, name errors, index errors, and missing file errors occur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Add code examples in the Python path\n",
+    "import sys\n",
+    "sys.path.append('../code')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tracebacks in Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import errors_01\n",
+    "errors_01.favorite_ice_cream()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Reading Error Messages\n",
+    "Read the traceback below, and identify the following pieces of information about it:\n",
+    "\n",
+    "1. How many levels does the traceback have? **3 levels**\n",
+    "1. What is the file name where the error occurred? **`errors_02.py`**\n",
+    "1. What is the function name where the error occurred? **`print_message`**\n",
+    "1. On which line number in this function did the error occurr? **11**\n",
+    "1. What is the type of error? **`KeyError`**\n",
+    "1. What is the error message? **`Friday` is not a key in `messages`**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import errors_02\n",
+    "errors_02.print_friday_message()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Syntax Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def some_function()\n",
+    "    msg = \"hello, world!\"\n",
+    "    print(msg)\n",
+    "     return msg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def some_function():\n",
+    "    msg = \"hello, world!\"\n",
+    "    print(msg)\n",
+    "     return msg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Identifying Syntax Errors\n",
+    "\n",
+    "1. Read the code below, and (without running it) try to identify what the errors are.\n",
+    "1. Run the code, and read the error message. Is it a SyntaxError or an IndentationError?\n",
+    "1. Fix the error.\n",
+    "1. Repeat steps 2 and 3, until you have fixed all the errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def another_function\n",
+    "  print(\"Syntax errors are annoying.\")\n",
+    "   print(\"But at least python tells us about them!\")\n",
+    "  print(\"So they are usually not too hard to fix.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`SyntaxErro`r for missing `():` at end of first line, `IndentationError` for mismatch between second and third lines. A fixed version is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "def another_function():\n",
+    "    print(\"Syntax errors are annoying.\")\n",
+    "    print(\"But at least python tells us about them!\")\n",
+    "    print(\"So they are usually not too hard to fix.\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variable Name Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(hello)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for number in range(10):\n",
+    "    count = count + number\n",
+    "print(\"The count is:\", count)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Count = 0\n",
+    "for number in range(10):\n",
+    "    count = count + number\n",
+    "print(\"The count is:\", count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Identifying Variable Name Errors\n",
+    "\n",
+    "1. Read the code below, and (without running it) try to identify what the errors are.\n",
+    "1. Run the code, and read the error message. What type of NameError do you think this is? In other words, is it a string with no quotes, a misspelled variable, or a variable that should have been defined but was not?\n",
+    "1. Fix the error.\n",
+    "1. Repeat steps 2 and 3, until you have fixed all the errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "for number in range(10):\n",
+    "    # use a if the number is a multiple of 3, otherwise use b\n",
+    "    if (Number % 3) == 0:\n",
+    "        message = message + a\n",
+    "    else:\n",
+    "        message = message + \"b\"\n",
+    "print(message)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fixed version:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "message = \"\"\n",
+    "for number in range(10):\n",
+    "    # use a if the number is a multiple of 3, otherwise use b\n",
+    "    if (number % 3) == 0:\n",
+    "        message = message + \"a\"\n",
+    "    else:\n",
+    "        message = message + \"b\"\n",
+    "print(message)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Item Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "letters = ['a', 'b', 'c']\n",
+    "print(\"Letter #1 is\", letters[0])\n",
+    "print(\"Letter #2 is\", letters[1])\n",
+    "print(\"Letter #3 is\", letters[2])\n",
+    "print(\"Letter #4 is\", letters[3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Identifying Item Errors\n",
+    "\n",
+    "1. Read the code below, and (without running it) try to identify what the errors are.\n",
+    "1. Run the code, and read the error message. What type of error is it?\n",
+    "1. Fix the error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "seasons = ['Spring', 'Summer', 'Fall', 'Winter']\n",
+    "print('My favorite season is ', seasons[4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`IndexError`; the last entry is `seasons[3]`, so `seasons[4]` doesn’t make sense. A fixed version is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "seasons = ['Spring', 'Summer', 'Fall', 'Winter']\n",
+    "print('My favorite season is ', seasons[-1])\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## File Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "file_handle = open('myfile.txt', 'r')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "file_handle = open('myfile.txt', 'w')\n",
+    "file_handle.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/08-defensive.ipynb
+++ b/notebooks/08-defensive.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Defensive Programming\n",
+    "Questions\n",
+    "* How can I make my programs more reliable?\n",
+    "\n",
+    "Objectives\n",
+    "* Explain what an assertion is.\n",
+    "* Add assertions that check the program’s state is correct.\n",
+    "* Correctly add precondition and postcondition assertions to functions.\n",
+    "* Explain what test-driven development is, and use it when creating new functions.\n",
+    "* Explain why variables should be initialized using actual data values rather than arbitrary constants."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assertions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numbers = [1.5, 2.3, 0.7, -0.001, 4.4]\n",
+    "total = 0.0\n",
+    "for n in numbers:\n",
+    "    assert n > 0.0, 'Data should only contain positive values'\n",
+    "    total += n\n",
+    "print('total is:', total)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def normalize_rectangle(rect):\n",
+    "    '''Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.'''\n",
+    "    assert len(rect) == 4, 'Rectangles must contain 4 coordinates'\n",
+    "    x0, y0, x1, y1 = rect\n",
+    "    assert x0 < x1, 'Invalid X coordinates'\n",
+    "    assert y0 < y1, 'Invalid Y coordinates'\n",
+    "\n",
+    "    dx = x1 - x0\n",
+    "    dy = y1 - y0\n",
+    "    if dx > dy:\n",
+    "        scaled = float(dx) / dy\n",
+    "        upper_x, upper_y = 1.0, scaled\n",
+    "    else:\n",
+    "        scaled = float(dx) / dy\n",
+    "        upper_x, upper_y = scaled, 1.0\n",
+    "\n",
+    "    assert 0 < upper_x <= 1.0, 'Calculated upper X coordinate invalid'\n",
+    "    assert 0 < upper_y <= 1.0, 'Calculated upper Y coordinate invalid'\n",
+    "\n",
+    "    return (0, 0, upper_x, upper_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (0.0, 1.0, 2.0) )) # missing the fourth coordinate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (4.0, 2.0, 1.0, 5.0) )) # X axis inverted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (0.0, 0.0, 1.0, 5.0) ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (0.0, 0.0, 5.0, 1.0) ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Pre- and Post-Conditions\n",
+    "Suppose you are writing a function called `average` that calculates the average of the numbers in a list. What pre-conditions and post-conditions would you write for it?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "\n",
+    "def average(inputList):\n",
+    "    input = numpy.asarray(inputList)\n",
+    "    \n",
+    "    # Pre-conditions\n",
+    "    assert len(input) > 0, 'List length must be non-zero'\n",
+    "    \n",
+    "    average = numpy.mean(input)\n",
+    "    \n",
+    "    # Post-conditions\n",
+    "    assert numpy.min(input) <= average <= numpy.max(input), 'Average should be between min and max of input values'\n",
+    "    \n",
+    "    return average\n",
+    "\n",
+    "print('Average:', average([2, 2, 2]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Testing Assertions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def running(values):\n",
+    "    assert len(values) > 0\n",
+    "    result = [values[0]]\n",
+    "    for v in values[1:]:\n",
+    "        assert result[-1] >= 0\n",
+    "        result.append(result[-1] + v)\n",
+    "        assert result[-1] >= result[0]\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "running([1, 2, 3, 4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Explain in words what the assertions in the function check, and for each one, give an example of input that will make that assertion fail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "running([])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "running([-1, 0, 2, 3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "running([0, 1, 3, -5, 4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test-Driven Development"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Figure - Overlapping Ranges](../fig/python-overlapping-ranges.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)\n",
+    "assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)\n",
+    "assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None\n",
+    "assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def range_overlap(ranges):\n",
+    "    '''Return common overlap among a set of [low, high] ranges.'''\n",
+    "    lowest = 0.0\n",
+    "    highest = 1.0\n",
+    "    for (low, high) in ranges:\n",
+    "        lowest = max(lowest, low)\n",
+    "        highest = min(highest, high)\n",
+    "    return (lowest, highest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def test_range_overlap():\n",
+    "    assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None\n",
+    "    assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None\n",
+    "    assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)\n",
+    "    assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)\n",
+    "    assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "test_range_overlap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Fixing and Testing\n",
+    "Fix `range_overlap`. Re-run `test_range_overlap` after each change you make."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "\n",
+    "def range_overlap(ranges):\n",
+    "    '''Return common overlap among a set of [low, high] ranges.'''\n",
+    "    if len(ranges) == 1: # only one entry, so return it\n",
+    "        return ranges[0]\n",
+    "    lowest = -numpy.inf # lowest possible number\n",
+    "    highest = numpy.inf # highest possible number\n",
+    "    for (low, high) in ranges:\n",
+    "        lowest = max(lowest, low)\n",
+    "        highest = min(highest, high)\n",
+    "    if lowest >= highest: # no overlap\n",
+    "        return None\n",
+    "    else:\n",
+    "        return (lowest, highest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "test_range_overlap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/08-defensive.ipynb
+++ b/notebooks/08-defensive.ipynb
@@ -68,7 +68,7 @@
     "numbers = [1.5, 2.3, 0.7, -0.001, 4.4]\n",
     "total = 0.0\n",
     "for n in numbers:\n",
-    "    assert n > 0.0, 'Data should only contain positive values'\n",
+    "    ###\n",
     "    total += n\n",
     "print('total is:', total)"
    ]
@@ -83,9 +83,9 @@
    "source": [
     "def normalize_rectangle(rect):\n",
     "    '''Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.'''\n",
-    "    assert len(rect) == 4, 'Rectangles must contain 4 coordinates'\n",
+    "    ###, 'Rectangles must contain 4 coordinates'\n",
     "    x0, y0, x1, y1 = rect\n",
-    "    assert x0 < x1, 'Invalid X coordinates'\n",
+    "    assert ###, 'Invalid X coordinates'\n",
     "    assert y0 < y1, 'Invalid Y coordinates'\n",
     "\n",
     "    dx = x1 - x0\n",
@@ -97,7 +97,7 @@
     "        scaled = float(dx) / dy\n",
     "        upper_x, upper_y = scaled, 1.0\n",
     "\n",
-    "    assert 0 < upper_x <= 1.0, 'Calculated upper X coordinate invalid'\n",
+    "    assert ###, 'Calculated upper X coordinate invalid'\n",
     "    assert 0 < upper_y <= 1.0, 'Calculated upper Y coordinate invalid'\n",
     "\n",
     "    return (0, 0, upper_x, upper_y)"
@@ -111,7 +111,7 @@
    },
    "outputs": [],
    "source": [
-    "print(normalize_rectangle( (0.0, 1.0, 2.0) )) # missing the fourth coordinate"
+    "print(normalize_rectangle( (0.0, 1.0, 2.0, ###) )) # missing the fourth coordinate"
    ]
   },
   {
@@ -122,7 +122,7 @@
    },
    "outputs": [],
    "source": [
-    "print(normalize_rectangle( (4.0, 2.0, 1.0, 5.0) )) # X axis inverted"
+    "print(normalize_rectangle( (###, 2.0, ###, 5.0) )) # X axis inverted"
    ]
   },
   {
@@ -133,7 +133,7 @@
    },
    "outputs": [],
    "source": [
-    "print(normalize_rectangle( (0.0, 0.0, 1.0, 5.0) ))"
+    "print(normalize_rectangle( (0.0, 0.0, ###, ###) ))"
    ]
   },
   {
@@ -144,7 +144,7 @@
    },
    "outputs": [],
    "source": [
-    "print(normalize_rectangle( (0.0, 0.0, 5.0, 1.0) ))"
+    "print(normalize_rectangle( (0.0, 0.0, ###, ###) ))"
    ]
   },
   {
@@ -169,12 +169,12 @@
     "    input = numpy.asarray(inputList)\n",
     "    \n",
     "    # Pre-conditions\n",
-    "    assert len(input) > 0, 'List length must be non-zero'\n",
+    "    ###\n",
     "    \n",
     "    average = numpy.mean(input)\n",
     "    \n",
     "    # Post-conditions\n",
-    "    assert numpy.min(input) <= average <= numpy.max(input), 'Average should be between min and max of input values'\n",
+    "    ###\n",
     "    \n",
     "    return average\n",
     "\n",
@@ -233,7 +233,7 @@
    },
    "outputs": [],
    "source": [
-    "running([])"
+    "running(###)"
    ]
   },
   {
@@ -244,7 +244,7 @@
    },
    "outputs": [],
    "source": [
-    "running([-1, 0, 2, 3])"
+    "running(###)"
    ]
   },
   {
@@ -255,7 +255,7 @@
    },
    "outputs": [],
    "source": [
-    "running([0, 1, 3, -5, 4])"
+    "running(###)"
    ]
   },
   {
@@ -280,9 +280,9 @@
    },
    "outputs": [],
    "source": [
-    "assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)\n",
-    "assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)\n",
-    "assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)"
+    "assert range_overlap([ (0.0, 1.0) ]) == ###\n",
+    "assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == ###\n",
+    "assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == ###"
    ]
   },
   {
@@ -293,8 +293,8 @@
    },
    "outputs": [],
    "source": [
-    "assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None\n",
-    "assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None"
+    "assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == ###\n",
+    "assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == ###"
    ]
   },
   {
@@ -323,12 +323,13 @@
    },
    "outputs": [],
    "source": [
-    "def test_range_overlap():\n",
-    "    assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None\n",
-    "    assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None\n",
-    "    assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)\n",
-    "    assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)\n",
-    "    assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)"
+    "###\n",
+    "assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None\n",
+    "assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None\n",
+    "\n",
+    "assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)\n",
+    "assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)\n",
+    "assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)"
    ]
   },
   {
@@ -339,7 +340,7 @@
    },
    "outputs": [],
    "source": [
-    "test_range_overlap()"
+    "###"
    ]
   },
   {
@@ -362,17 +363,16 @@
     "\n",
     "def range_overlap(ranges):\n",
     "    '''Return common overlap among a set of [low, high] ranges.'''\n",
-    "    if len(ranges) == 1: # only one entry, so return it\n",
-    "        return ranges[0]\n",
-    "    lowest = -numpy.inf # lowest possible number\n",
-    "    highest = numpy.inf # highest possible number\n",
+    "    ### # Hint: only one entry, so return it\n",
+    "        ###\n",
+    "    lowest = ### # Hint: lowest possible number\n",
+    "    highest = ### # Hint: highest possible number\n",
     "    for (low, high) in ranges:\n",
     "        lowest = max(lowest, low)\n",
     "        highest = min(highest, high)\n",
-    "    if lowest >= highest: # no overlap\n",
-    "        return None\n",
-    "    else:\n",
-    "        return (lowest, highest)"
+    "    ### # Hint: in case of no overlap\n",
+    "        ###\n",
+    "    return (lowest, highest)"
    ]
   },
   {

--- a/notebooks/soln-01-numpy.ipynb
+++ b/notebooks/soln-01-numpy.ipynb
@@ -55,6 +55,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading Data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -74,6 +81,13 @@
    "outputs": [],
    "source": [
     "numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variables"
    ]
   },
   {
@@ -174,8 +188,37 @@
    },
    "outputs": [],
    "source": [
-    "# Note - Who’s Who in Memory\n",
     "%whos"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise\n",
+    "Draw diagrams showing what variables refer to what values after each statement in the following program:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "mass = 47.5        # mass-> 47.5, age-> undefined\n",
+    "age = 122          # mass-> 47.5, age-> 122\n",
+    "mass = mass * 2.0  # mass-> 95.0, age-> 122\n",
+    "age = age - 20     # mass-> 95.0, age-> 102\n",
+    "print(mass, age)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Arrays"
    ]
   },
   {
@@ -219,7 +262,6 @@
    },
    "outputs": [],
    "source": [
-    "# Note - Data Type\n",
     "print(data.dtype)"
    ]
   },
@@ -264,7 +306,6 @@
    },
    "outputs": [],
    "source": [
-    "# Note - Indices from upper left corner - [rows, columns]\n",
     "print(data[0:4, 0:10])"
    ]
   },
@@ -341,6 +382,73 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercises - Slicing Strings and Arrays\n",
+    "What would be the output?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "element = 'oxygen'\n",
+    "print(element[0:3])    # oxy\n",
+    "print(element[3:6])    # gen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(element[:4])     # oxyg\n",
+    "print(element[4:])     # en\n",
+    "print(element[:])      # oxygen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(element[-1])     # n\n",
+    "print(element[-2])     # e\n",
+    "print(element[1:-1])   # xyge"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(element[3:3])    # Empty string\n",
+    "print(data[3:3, 4:4])  # []\n",
+    "print(data[3:3, :])    # []"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Functions"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -359,7 +467,7 @@
    },
    "outputs": [],
    "source": [
-    "# Note - Not All Functions Have Input\n",
+    "# Not All Functions Have Input\n",
     "import time\n",
     "print(time.ctime())"
    ]
@@ -387,8 +495,15 @@
    },
    "outputs": [],
    "source": [
-    "# Note - Mystery Functions in IPython\n",
+    "# Mystery Functions in IPython\n",
     "numpy.cumprod?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Arrays Axis"
    ]
   },
   {
@@ -455,6 +570,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating Plots"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -473,7 +595,7 @@
    },
    "outputs": [],
    "source": [
-    "# Note - Some IPython Magic\n",
+    "# Some IPython Magic\n",
     "% matplotlib inline"
    ]
   },
@@ -527,6 +649,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Make Your Own Plot\n",
+    "Create a plot showing the standard deviation (numpy.std) of the inflammation data for each day across all patients"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -534,7 +664,26 @@
    },
    "outputs": [],
    "source": [
-    "fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
+    "std_plot = matplotlib.pyplot.plot(numpy.std(data, axis=0))\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Subplots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = matplotlib.pyplot.figure(figsize=(3 * 3.5, 3.0))\n",
     "\n",
     "axes1 = fig.add_subplot(1, 3, 1)\n",
     "axes2 = fig.add_subplot(1, 3, 2)\n",
@@ -555,6 +704,51 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Moving Plots Around\n",
+    "Modify the program to display the three plots on top of one another instead of side by side"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# change figsize (swap width and height)\n",
+    "fig = matplotlib.pyplot.figure(figsize=(3.5, 3 * 3.0))\n",
+    "\n",
+    "# change add_subplot (swap first two parameters)\n",
+    "axes1 = fig.add_subplot(3, 1, 1)\n",
+    "axes2 = fig.add_subplot(3, 1, 2)\n",
+    "axes3 = fig.add_subplot(3, 1, 3)\n",
+    "\n",
+    "axes1.set_ylabel('average')\n",
+    "axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "axes2.set_ylabel('max')\n",
+    "axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "axes3.set_ylabel('min')\n",
+    "axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extra Material"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -562,7 +756,7 @@
    },
    "outputs": [],
    "source": [
-    "# Note - Scientists Dislike Typing\n",
+    "# Scientists Dislike Typing\n",
     "import numpy as np\n",
     "np.pi"
    ]

--- a/notebooks/soln-01-numpy.ipynb
+++ b/notebooks/soln-01-numpy.ipynb
@@ -1,0 +1,111 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Analyzing Patient Data\n",
+    "Questions\n",
+    "* How can I process tabular data files in Python?\n",
+    "\n",
+    "Objectives\n",
+    "* Explain what a library is, and what libraries are used for.\n",
+    "* Import a Python library and use the things it contains.\n",
+    "* Read tabular data from a file into a program.\n",
+    "* Assign values to variables.\n",
+    "* Select individual values and subsections from data.\n",
+    "* Perform operations on arrays of data.\n",
+    "* Display simple graphs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/soln-01-numpy.ipynb
+++ b/notebooks/soln-01-numpy.ipynb
@@ -83,6 +83,457 @@
     "collapsed": true
    },
    "outputs": [],
+   "source": [
+    "weight_kg = 55"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(weight_kg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('weight in pounds:', 2.2 * weight_kg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "weight_kg = 57.5\n",
+    "print('weight in kilograms is now:', weight_kg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Variable as a sticky note](http://swcarpentry.github.io/python-novice-inflammation/fig/python-sticky-note-variables-01.svg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "weight_lb = 2.2 * weight_kg\n",
+    "print('weight in kilograms:', weight_kg, 'and in pounds:', weight_lb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Two variables](http://swcarpentry.github.io/python-novice-inflammation/fig/python-sticky-note-variables-02.svg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "weight_kg = 100.0\n",
+    "print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', weight_lb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Independant variables](http://swcarpentry.github.io/python-novice-inflammation/fig/python-sticky-note-variables-03.svg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%whos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(type(data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data.dtype)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('first value in data:', data[0, 0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('middle value in data:', data[30, 20])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data[0:4, 0:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(data[5:10, 0:10])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "small = data[:3, 36:]\n",
+    "print('small is:')\n",
+    "print(small)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "doubledata = data * 2.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('original:')\n",
+    "print(data[:3, 36:])\n",
+    "print('doubledata:')\n",
+    "print(doubledata[:3, 36:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "tripledata = doubledata + data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('tripledata:')\n",
+    "print(tripledata[:3, 36:])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "print(time.ctime())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "maxval, minval, stdval = numpy.max(data), numpy.min(data), numpy.std(data)\n",
+    "\n",
+    "print('maximum inflammation:', maxval)\n",
+    "print('minimum inflammation:', minval)\n",
+    "print('standard deviation:', stdval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "patient_0 = data[0, :] # 0 on the first axis, everything on the second\n",
+    "print('maximum inflammation for patient 0:', patient_0.max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('maximum inflammation for patient 2:', numpy.max(data[2, :]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Axis 0, 1](http://swcarpentry.github.io/python-novice-inflammation/fig/python-operations-across-axes.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data, axis=0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data, axis=0).shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(numpy.mean(data, axis=1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot\n",
+    "% matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "image  = matplotlib.pyplot.imshow(data)\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ave_inflammation = numpy.mean(data, axis=0)\n",
+    "ave_plot = matplotlib.pyplot.plot(ave_inflammation)\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "max_plot = matplotlib.pyplot.plot(numpy.max(data, axis=0))\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "min_plot = matplotlib.pyplot.plot(numpy.min(data, axis=0))\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
+    "\n",
+    "axes1 = fig.add_subplot(1, 3, 1)\n",
+    "axes2 = fig.add_subplot(1, 3, 2)\n",
+    "axes3 = fig.add_subplot(1, 3, 3)\n",
+    "\n",
+    "axes1.set_ylabel('average')\n",
+    "axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "axes2.set_ylabel('max')\n",
+    "axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "axes3.set_ylabel('min')\n",
+    "axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
    "source": []
   }
  ],

--- a/notebooks/soln-01-numpy.ipynb
+++ b/notebooks/soln-01-numpy.ipynb
@@ -445,7 +445,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Functions"
+    "## Functions and Tuples"
    ]
   },
   {
@@ -497,6 +497,34 @@
    "source": [
     "# Mystery Functions in IPython\n",
     "numpy.cumprod?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Tuples and Exchanges\n",
+    "Use tuples to simplify the following three lines of code:\n",
+    "```Python\n",
+    "temp = left\n",
+    "left = right\n",
+    "right = temp\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "left = 'L'\n",
+    "right = 'R'\n",
+    "\n",
+    "left, right = right, left\n",
+    "print(left, right)"
    ]
   },
   {

--- a/notebooks/soln-01-numpy.ipynb
+++ b/notebooks/soln-01-numpy.ipynb
@@ -125,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Variable as a sticky note](http://swcarpentry.github.io/python-novice-inflammation/fig/python-sticky-note-variables-01.svg)"
+    "![Variable as a sticky note](../fig/python-sticky-note-variables-01.png)"
    ]
   },
   {
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Two variables](http://swcarpentry.github.io/python-novice-inflammation/fig/python-sticky-note-variables-02.svg)"
+    "![Two variables](../fig/python-sticky-note-variables-02.png)"
    ]
   },
   {
@@ -163,7 +163,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Independant variables](http://swcarpentry.github.io/python-novice-inflammation/fig/python-sticky-note-variables-03.svg)"
+    "![Independant variables](../fig/python-sticky-note-variables-03.png)"
    ]
   },
   {
@@ -174,6 +174,7 @@
    },
    "outputs": [],
    "source": [
+    "# Note - Who’s Who in Memory\n",
     "%whos"
    ]
   },
@@ -218,6 +219,7 @@
    },
    "outputs": [],
    "source": [
+    "# Note - Data Type\n",
     "print(data.dtype)"
    ]
   },
@@ -262,6 +264,7 @@
    },
    "outputs": [],
    "source": [
+    "# Note - Indices from upper left corner - [rows, columns]\n",
     "print(data[0:4, 0:10])"
    ]
   },
@@ -356,6 +359,7 @@
    },
    "outputs": [],
    "source": [
+    "# Note - Not All Functions Have Input\n",
     "import time\n",
     "print(time.ctime())"
    ]
@@ -373,6 +377,18 @@
     "print('maximum inflammation:', maxval)\n",
     "print('minimum inflammation:', minval)\n",
     "print('standard deviation:', stdval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Note - Mystery Functions in IPython\n",
+    "numpy.cumprod?"
    ]
   },
   {
@@ -402,7 +418,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![Axis 0, 1](http://swcarpentry.github.io/python-novice-inflammation/fig/python-operations-across-axes.png)"
+    "![Axis 0, 1](../fig/python-operations-across-axes.png)"
    ]
   },
   {
@@ -446,7 +462,18 @@
    },
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot\n",
+    "import matplotlib.pyplot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Note - Some IPython Magic\n",
     "% matplotlib inline"
    ]
   },
@@ -525,6 +552,19 @@
     "fig.tight_layout()\n",
     "\n",
     "matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Note - Scientists Dislike Typing\n",
+    "import numpy as np\n",
+    "np.pi"
    ]
   },
   {

--- a/notebooks/soln-01-numpy.ipynb
+++ b/notebooks/soln-01-numpy.ipynb
@@ -51,7 +51,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/soln-02-loop.ipynb
+++ b/notebooks/soln-02-loop.ipynb
@@ -46,7 +46,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/soln-02-loop.ipynb
+++ b/notebooks/soln-02-loop.ipynb
@@ -1,0 +1,314 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Repeating Actions with Loops\n",
+    "Questions\n",
+    "* How can I do the same operations on many different values?\n",
+    "\n",
+    "Objectives\n",
+    "* Explain what a for loop does.\n",
+    "* Correctly write for loops to repeat simple calculations.\n",
+    "* Trace changes to a loop variable as the loop runs.\n",
+    "* Trace changes to other variables as they are updated by a for loop."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Repeated Actions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "word = 'lead'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(word[0])\n",
+    "print(word[1])\n",
+    "print(word[2])\n",
+    "print(word[3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "word = 'tin'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(word[0])\n",
+    "print(word[1])\n",
+    "print(word[2])\n",
+    "print(word[3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using Loops"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "word = 'lead'\n",
+    "for char in word:\n",
+    "    print(char)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "word = 'oxygen'\n",
+    "for char in word:\n",
+    "    print(char)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loops Syntax\n",
+    "```\n",
+    "for variable in collection:\n",
+    "    do things with variable\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![What happens when accessing each letter](../fig/loops_image.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Using `range()`\n",
+    "```Python\n",
+    "for i in range(3):         # 0, 1, 2\n",
+    "for i in range(2, 5):      # 2, 3, 4\n",
+    "for i in range(3, 10, 3):  # 3, 6, 9\n",
+    "```\n",
+    "But how can we get 1, 2, 3?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for i in range(1, 4):\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modifying Variables in a Loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "length = 0\n",
+    "for vowel in 'aeiou':\n",
+    "    length = length + 1\n",
+    "print('There are', length, 'vowels')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "letter = 'z'\n",
+    "for letter in 'abc':\n",
+    "    print(letter)\n",
+    "print('after the loop, letter is', letter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(len('aeiou'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Computing Powers With Loops\n",
+    "```Python\n",
+    "print(5 ** 3)  # 125 = 5 * 5 * 5\n",
+    "```\n",
+    "Write a loop that calculates the same result as `5 ** 3` using multiplication (and without exponentiation)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "result = 1\n",
+    "for i in range(0, 3):\n",
+    "   result = result * 5\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Reverse a String\n",
+    "Write a loop that takes a string, and produces a new string with the characters in reverse order, so `'Newton'` becomes `'notweN'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "newstring = ''\n",
+    "oldstring = 'Newton'\n",
+    "length_old = len(oldstring)\n",
+    "\n",
+    "for char_index in range(length_old):\n",
+    "   newstring = newstring + oldstring[length_old - char_index - 1]\n",
+    "\n",
+    "print(newstring)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/soln-03-lists.ipynb
+++ b/notebooks/soln-03-lists.ipynb
@@ -1,0 +1,353 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Storing Multiple Values in Lists\n",
+    "Questions\n",
+    "* How can I store many values together?\n",
+    "\n",
+    "Objectives\n",
+    "* Explain what a list is.\n",
+    "* Create and index lists of simple values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lists in Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "odds = [1, 3, 5, 7]\n",
+    "print('odds are:', odds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('first and last:', odds[0], odds[-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for number in odds:\n",
+    "    print(number)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mutable vs Immutable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "names = ['Newton', 'Darwing', 'Turing'] # typo in Darwin's name\n",
+    "print('names is originally:', names)\n",
+    "\n",
+    "names[1] = 'Darwin' # correct the name\n",
+    "print('final value of names:', names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Strings are immutable\n",
+    "name = 'Darwin'\n",
+    "name[0] = 'd'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Nested Lists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "x = [['pepper', 'zucchini', 'onion'],\n",
+    "     ['cabbage', 'lettuce', 'garlic'],\n",
+    "     ['apple', 'pear', 'banana']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Indexing lists in rstats. Inspired by the Residence Inn](../fig/indexing_lists_python.png)\n",
+    "Thanks to Hadley Wickham for the image above.\n",
+    "Source: https://twitter.com/hadleywickham/status/643381054758363136"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print([x[0]])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(x[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(x[0][0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modifying the Content of Lists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "odds.append(11)\n",
+    "print('odds after adding a value:', odds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "del odds[0]\n",
+    "print('odds after removing the first element:', odds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "odds.reverse()\n",
+    "print('odds after reversing:', odds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "odds = [1, 3, 5, 7]\n",
+    "primes = odds\n",
+    "primes[0] = 2\n",
+    "odds += [9]\n",
+    "\n",
+    "print('primes:', primes)\n",
+    "print('odds:', odds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "odds = [1, 3, 5, 7]\n",
+    "primes = list(odds)\n",
+    "primes[0] = 2\n",
+    "odds += [9]\n",
+    "\n",
+    "print('primes:', primes)\n",
+    "print('odds:', odds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "binomial_name = \"Drosophila melanogaster\"\n",
+    "group = binomial_name[0:10]\n",
+    "print(\"group:\", group)\n",
+    "\n",
+    "species = binomial_name[11:24]\n",
+    "print(\"species:\", species)\n",
+    "\n",
+    "chromosomes = [\"X\", \"Y\", \"2\", \"3\", \"4\"]\n",
+    "autosomes = chromosomes[2:5]\n",
+    "print(\"autosomes:\", autosomes)\n",
+    "\n",
+    "last = chromosomes[-1]\n",
+    "print(\"last:\", last)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "date = \"Monday 4 January 2016\"\n",
+    "day = date[0:6]\n",
+    "print(\"Using 0 to begin range:\", day)\n",
+    "day = date[:6]\n",
+    "print(\"Omitting beginning index:\", day)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "months = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"]\n",
+    "sond = months[8:12]\n",
+    "print(\"With known last position:\", sond)\n",
+    "sond = months[8:len(months)]\n",
+    "print(\"Using len() to get last entry:\", sond)\n",
+    "sond = months[8:]\n",
+    "(\"Omitting ending index:\", sond)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/soln-03-lists.ipynb
+++ b/notebooks/soln-03-lists.ipynb
@@ -264,6 +264,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Turn a String Into a List\n",
+    "Use a for-loop to convert the string “hello” into a list of letters:\n",
+    "```Python\n",
+    "[\"h\", \"e\", \"l\", \"l\", \"o\"]\n",
+    "```\n",
+    "Hint: You can create an empty list like this:\n",
+    "```Python\n",
+    "my_list = []\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "my_list = []\n",
+    "for char in \"hello\":\n",
+    "    my_list.append(char)\n",
+    "print(my_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Slicing Lists"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -311,11 +347,87 @@
    "source": [
     "months = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"]\n",
     "sond = months[8:12]\n",
-    "print(\"With known last position:\", sond)\n",
+    "print(\"With known last position:     \", sond)\n",
     "sond = months[8:len(months)]\n",
     "print(\"Using len() to get last entry:\", sond)\n",
     "sond = months[8:]\n",
-    "(\"Omitting ending index:\", sond)"
+    "print(\"Omitting ending index:        \", sond)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Slicing From the End\n",
+    "Use slicing to access only the last four characters of a string or the last four entries of a list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "string_for_slicing = \"Observation date: 02-Feb-2013\"\n",
+    "list_for_slicing = [[\"fluorine\", \"F\"], [\"chlorine\", \"Cl\"], [\"bromine\", \"Br\"], [\"iodine\", \"I\"], [\"astatine\", \"At\"]]\n",
+    "\n",
+    "print(string_for_slicing[-4:])\n",
+    "print(list_for_slicing[-4:])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Non-Continuous Slices\n",
+    "```Python\n",
+    "a_slice = a_list[start_index:end_index:step_size]\n",
+    "```\n",
+    "Use the step size argument to create a new string that contains only every other character in the string \"In an octopus’s garden in the shade\":\n",
+    "```\n",
+    "I notpssgre ntesae\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "beatles = \"In an octopus's garden in the shade\"\n",
+    "print(beatles[::2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Operators with Lists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "counts = [2, 4, 6, 8, 10]\n",
+    "repeats = counts * 2\n",
+    "\n",
+    "#my_solution = [4, 8, 12, 16, 20]\n",
+    "#my_solution = [2, 2, 4, 4, 6, 6, 8, 8, 10, 10]\n",
+    "my_solution = [2, 4, 6, 8, 10, 2, 4, 6, 8, 10]\n",
+    "#my_solution = [[2, 4, 6, 8, 10],[2, 4, 6, 8, 10]]\n",
+    "\n",
+    "print(\"Python soln:\", repeats)\n",
+    "print(\"My solution:\", my_solution)"
    ]
   },
   {

--- a/notebooks/soln-03-lists.ipynb
+++ b/notebooks/soln-03-lists.ipynb
@@ -44,7 +44,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/soln-04-files.ipynb
+++ b/notebooks/soln-04-files.ipynb
@@ -1,0 +1,166 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Analyzing Data from Multiple Files\n",
+    "Questions\n",
+    "* How can I do the same operations on many different files?\n",
+    "\n",
+    "Objectives\n",
+    "* Use a library function to get a list of filenames that match a simple wildcard pattern.\n",
+    "* Use a for loop to process multiple files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using `glob`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import glob"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(glob.glob('../data/inflammation*.csv'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading Files in Sorted Order"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "import matplotlib.pyplot\n",
+    "% matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "filenames = filenames[0:3]\n",
+    "\n",
+    "for f in filenames:\n",
+    "    print(f)\n",
+    "\n",
+    "    data = numpy.loadtxt(fname=f, delimiter=',')\n",
+    "\n",
+    "    fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
+    "\n",
+    "    axes1 = fig.add_subplot(1, 3, 1)\n",
+    "    axes2 = fig.add_subplot(1, 3, 2)\n",
+    "    axes3 = fig.add_subplot(1, 3, 3)\n",
+    "\n",
+    "    axes1.set_ylabel('average')\n",
+    "    axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "    axes2.set_ylabel('max')\n",
+    "    axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "    axes3.set_ylabel('min')\n",
+    "    axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "    fig.tight_layout()\n",
+    "    matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/soln-04-files.ipynb
+++ b/notebooks/soln-04-files.ipynb
@@ -132,6 +132,35 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Exercise - Plotting Differences\n",
+    "Plot the difference between the average of the first dataset and the average of the second dataset, i.e., the difference between the leftmost plot of the first two figures."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "\n",
+    "data0 = numpy.loadtxt(fname=filenames[0], delimiter=',')\n",
+    "data1 = numpy.loadtxt(fname=filenames[1], delimiter=',')\n",
+    "\n",
+    "matplotlib.pyplot.ylabel('Difference in average')\n",
+    "matplotlib.pyplot.plot(data0.mean(axis=0) - data1.mean(axis=0))\n",
+    "\n",
+    "matplotlib.pyplot.show()"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/notebooks/soln-04-files.ipynb
+++ b/notebooks/soln-04-files.ipynb
@@ -44,7 +44,7 @@
     "D D          | Delete the current cell\n",
     "\n",
     "To reset all cells:\n",
-    "* Go to the top menu, and select Kernel -> Restart & Clear Output* "
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
    ]
   },
   {

--- a/notebooks/soln-05-cond.ipynb
+++ b/notebooks/soln-05-cond.ipynb
@@ -111,6 +111,125 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - How Many Paths?\n",
+    "Which of the following would be printed if you were to run this code?\n",
+    "1. A\n",
+    "1. B\n",
+    "1. C\n",
+    "1. B and C"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if 4 > 5:\n",
+    "    print('A')\n",
+    "elif 4 == 5:\n",
+    "    print('B')\n",
+    "elif 4 < 5:\n",
+    "    print('C')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - What Is Truth?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if '':\n",
+    "    print('empty string is true')\n",
+    "if 'word':\n",
+    "    print('word is true')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if []:\n",
+    "    print('empty list is true')\n",
+    "if [1, 2, 3]:\n",
+    "    print('non-empty list is true')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if 0:\n",
+    "    print('zero is true')\n",
+    "if 1:\n",
+    "    print('one is true')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - That’s Not Not What I Meant"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if not '':\n",
+    "    print('empty string is not true')\n",
+    "if not 'word':\n",
+    "    print('word is not true')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if not False:\n",
+    "    print('not False is true')\n",
+    "if not not True:\n",
+    "    print('not not True is true')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Boolean Operators"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -140,6 +259,74 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Close Enough\n",
+    "Write some conditions that print `True` if the variable `a` is within 10% of the variable `b` and `False` otherwise."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "a = 5\n",
+    "b = 5.1\n",
+    "\n",
+    "if abs(a - b) < 0.1 * abs(b):\n",
+    "    print('True')\n",
+    "else:\n",
+    "    print('False')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - In-Place Operators\n",
+    "Write some code that sums the positive and negative numbers in a list separately, using in-place operators. Here is an example of in-place operators:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = 1    # original value\n",
+    "x += 1   # add one to x, assigning result back to x\n",
+    "x *= 3   # multiply x by 3\n",
+    "print(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "test_list = [3, 4, 6, 1, -1, -5, 0, 7, -8]\n",
+    "positive_sum = 0\n",
+    "negative_sum = 0\n",
+    "\n",
+    "for num in test_list:\n",
+    "    if num > 0:\n",
+    "        positive_sum += num\n",
+    "    elif num < 0:\n",
+    "        negative_sum += num\n",
+    "\n",
+    "print(positive_sum, negative_sum)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Checking our Data"
    ]
   },
@@ -163,6 +350,7 @@
    "outputs": [],
    "source": [
     "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
+    "\n",
     "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
     "    print('Suspicious looking maxima!')\n",
     "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
@@ -180,6 +368,7 @@
    "outputs": [],
    "source": [
     "data = numpy.loadtxt(fname='../data/inflammation-03.csv', delimiter=',')\n",
+    "\n",
     "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
     "    print('Suspicious looking maxima!')\n",
     "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",

--- a/notebooks/soln-05-cond.ipynb
+++ b/notebooks/soln-05-cond.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Making Choices\n",
+    "Questions\n",
+    "* How can my programs do different things based on data values?\n",
+    "\n",
+    "Objectives\n",
+    "* Write conditional statements including `if`, `elif`, and `else` branches.\n",
+    "* Correctly evaluate expressions containing `and` and `or`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conditionals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "num = 37\n",
+    "if num > 100:\n",
+    "    print('greater')\n",
+    "else:\n",
+    "    print('not greater')\n",
+    "print('done')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![If num greater than 100](../fig/python-flowchart-conditional.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "num = 53\n",
+    "print('before conditional...')\n",
+    "if num > 100:\n",
+    "    print('53 is greater than 100')\n",
+    "print('...after conditional')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "num = -3\n",
+    "\n",
+    "if num > 0:\n",
+    "    print(num, \"is positive\")\n",
+    "elif num == 0:\n",
+    "    print(num, \"is zero\")\n",
+    "else:\n",
+    "    print(num, \"is negative\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if (1 > 0) and (-1 > 0):\n",
+    "    print('both parts are true')\n",
+    "else:\n",
+    "    print('at least one part is false')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if (1 < 0) or (-1 < 0):\n",
+    "    print('at least one test is true')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Checking our Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
+    "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "    print('Suspicious looking maxima!')\n",
+    "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "    print('Minima add up to zero!')\n",
+    "else:\n",
+    "    print('Seems OK!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-03.csv', delimiter=',')\n",
+    "if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "    print('Suspicious looking maxima!')\n",
+    "elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "    print('Minima add up to zero!')\n",
+    "else:\n",
+    "    print('Seems OK!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/soln-06-func.ipynb
+++ b/notebooks/soln-06-func.ipynb
@@ -457,6 +457,77 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Testing and Documenting Your Function\n",
+    "Test your `rescale` function with arrays generated with `numpy.arange` and `numpy.linspace`. Use `help()` to see how to use these functions. Once you’ve successfully tested your function, add a docstring that explains what it does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#help(numpy.arange)\n",
+    "print(\"array =\", numpy.arange(10.0))\n",
+    "rescale(numpy.arange(10.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "#help(numpy.linspace)\n",
+    "print(\"array =\", numpy.linspace(0, 100, 5))\n",
+    "rescale(numpy.linspace(0, 100, 5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def rescale(input_array):\n",
+    "    '''Takes an array as input, and returns a corresponding array scaled so\n",
+    "    that 0 corresponds to the minimum and 1 to the maximum value of the input array.\n",
+    "\n",
+    "    Examples:\n",
+    "    >>> rescale(numpy.arange(10.0))\n",
+    "    array([ 0.        ,  0.11111111,  0.22222222,  0.33333333,  0.44444444,\n",
+    "            0.55555556,  0.66666667,  0.77777778,  0.88888889,  1.        ])\n",
+    "    >>> rescale(numpy.linspace(0, 100, 5))\n",
+    "    array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])\n",
+    "    '''\n",
+    "    L = numpy.min(input_array)\n",
+    "    H = numpy.max(input_array)\n",
+    "    output_array = (input_array - L) / (H - L)\n",
+    "    return output_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "help(rescale)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Defining Defaults"
    ]
   },
@@ -599,6 +670,67 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Defining Defaults\n",
+    "Rewrite the `rescale` function so that it scales data to lie between 0.0 and 1.0 by default, but will allow the caller to specify lower and upper bounds if they want. Hints:\n",
+    "* scale_value = (value - L) / (H - L)\n",
+    "* scale_value * (H - L) = (value - L)\n",
+    "* **scale_value * (H - L) + L = value**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def rescale(input_array, low_val=0.0, high_val=1.0):\n",
+    "    '''Rescales input array values to lie between low_val and high_val'''\n",
+    "    L = numpy.min(input_array)\n",
+    "    H = numpy.max(input_array)\n",
+    "    intermed_array = (input_array - L) / (H - L)\n",
+    "    output_array = intermed_array * (high_val - low_val) + low_val\n",
+    "    return output_array"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rescale(numpy.linspace(0, 100, 5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rescale(numpy.linspace(0, 100, 5), high_val=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rescale(numpy.linspace(0, 100, 5), high_val=0, low_val=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Readable functions"
    ]
   },
@@ -654,6 +786,7 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
    "display_name": "Python [Root]",
    "language": "python",

--- a/notebooks/soln-06-func.ipynb
+++ b/notebooks/soln-06-func.ipynb
@@ -670,6 +670,63 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Mixing Default and Non-Default Parameters\n",
+    "Given the following code:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "def numbers(one, two=2, three, four=4):\n",
+    "    n = str(one) + str(two) + str(three) + str(four)\n",
+    "    return n\n",
+    "\n",
+    "print(numbers(1, three=3))\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "what do you expect will be printed? What is actually printed? What rule do you think Python is following?\n",
+    "\n",
+    "1. `1234`\n",
+    "1. `one2three4`\n",
+    "1. `1239`\n",
+    "1. `SyntaxError`\n",
+    "\n",
+    "Given that, what does the following piece of code display when run?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "def func(a, b = 3, c = 6):\n",
+    "  print('a: ', a, 'b: ', b,'c:', c)\n",
+    "\n",
+    "func(-1, 2)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. `a:  b: 3 c: 6`\n",
+    "1. `a: -1 b: 3 c: 6`\n",
+    "1. `a: -1 b: 2 c: 6`\n",
+    "1. `a:  b: -1 c: 2`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Exercise - Defining Defaults\n",
     "Rewrite the `rescale` function so that it scales data to lie between 0.0 and 1.0 by default, but will allow the caller to specify lower and upper bounds if they want. Hints:\n",
     "* scale_value = (value - L) / (H - L)\n",
@@ -773,6 +830,68 @@
     "        sum_squared_devs += (value - sample_mean) * (value - sample_mean)\n",
     "\n",
     "    return numpy.sqrt(sum_squared_devs / (len(sample) - 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "### Exercise - Variables Inside and Outside Functions\n",
+    "What does the following piece of code display when run - and why?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "f = 0\n",
+    "k = 0\n",
+    "\n",
+    "def f2k(f):\n",
+    "  k = ((f-32)*(5.0/9.0)) + 273.15\n",
+    "  return k\n",
+    "\n",
+    "f2k(8)\n",
+    "f2k(41)\n",
+    "f2k(32)\n",
+    "\n",
+    "print(k)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - The Old Switcheroo\n",
+    "Which of the following would be printed if you were to run this code? Why did you pick this answer?\n",
+    "\n",
+    "1. `7 3`\n",
+    "1. `3 7`\n",
+    "1. `3 3`\n",
+    "1. `7 7`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "a = 3\n",
+    "b = 7\n",
+    "\n",
+    "def swap(a, b):\n",
+    "    temp = a\n",
+    "    a = b\n",
+    "    b = temp\n",
+    "\n",
+    "swap(a, b)\n",
+    "\n",
+    "print(a, b)\n",
+    "```"
    ]
   },
   {

--- a/notebooks/soln-06-func.ipynb
+++ b/notebooks/soln-06-func.ipynb
@@ -94,6 +94,58 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Combining Strings\n",
+    "Write a function called `fence` that takes two parameters called `original` and `wrapper` and returns a new string that has the wrapper character at the beginning and end of the original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fence(original, wrapper):\n",
+    "    return wrapper + original + wrapper\n",
+    "\n",
+    "print(fence('name', '*'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Rescaling an Array\n",
+    "Write a function `rescale` that takes an array as input and returns a corresponding array of values scaled to lie in the range 0.0 to 1.0. Hints:\n",
+    "* L: lowest value\n",
+    "* H: highest value\n",
+    "* scale_value = (value - L) / (H - L)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "\n",
+    "def rescale(input_array):\n",
+    "    L = numpy.min(input_array)\n",
+    "    H = numpy.max(input_array)\n",
+    "    output_array = (input_array - L) / (H - L)\n",
+    "    return output_array\n",
+    "\n",
+    "print(rescale(numpy.array([10, 12, 16, 20])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Integer Division - Python 2 vs Python 3"
    ]
   },

--- a/notebooks/soln-06-func.ipynb
+++ b/notebooks/soln-06-func.ipynb
@@ -1,0 +1,625 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Creating Functions\n",
+    "Questions\n",
+    "* How can I define new functions?\n",
+    "* What’s the difference between defining and calling a function?\n",
+    "* What happens when I call a function?\n",
+    "\n",
+    "Objectives\n",
+    "* Define a function that takes parameters.\n",
+    "* Return a value from a function.\n",
+    "* Test and debug a function.\n",
+    "* Set default values for function parameters.\n",
+    "* Explain why we should divide programs into small, single-purpose functions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining a Function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def fahr_to_kelvin(temp):\n",
+    "    return ((temp - 32) * (5/9)) + 273.15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![def fahr_to_kelvin(temp)](../fig/python-function.svg)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('freezing point of water:', fahr_to_kelvin(32))\n",
+    "print('boiling point of water:', fahr_to_kelvin(212))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Integer Division - Python 2 vs Python 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "! python2 -c \"print(5/9)\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "! python3 -c \"print(5/9)\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(float(5)/9)\n",
+    "print(5/float(9))\n",
+    "print(5.0/9)\n",
+    "print(5/9.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(4//2)\n",
+    "print(3//2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Composing Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def kelvin_to_celsius(temp_k):\n",
+    "    return temp_k - 273.15\n",
+    "\n",
+    "print('absolute zero in Celsius:', kelvin_to_celsius(0.0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def fahr_to_celsius(temp_f):\n",
+    "    temp_k = fahr_to_kelvin(temp_f)\n",
+    "    result = kelvin_to_celsius(temp_k)\n",
+    "    return result\n",
+    "\n",
+    "print('freezing point of water in Celsius:', fahr_to_celsius(32.0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tidying up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "import matplotlib.pyplot\n",
+    "% matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def analyze(filename):\n",
+    "\n",
+    "    data = numpy.loadtxt(fname=filename, delimiter=',')\n",
+    "\n",
+    "    fig = matplotlib.pyplot.figure(figsize=(10.0, 3.0))\n",
+    "\n",
+    "    axes1 = fig.add_subplot(1, 3, 1)\n",
+    "    axes2 = fig.add_subplot(1, 3, 2)\n",
+    "    axes3 = fig.add_subplot(1, 3, 3)\n",
+    "\n",
+    "    axes1.set_ylabel('average')\n",
+    "    axes1.plot(numpy.mean(data, axis=0))\n",
+    "\n",
+    "    axes2.set_ylabel('max')\n",
+    "    axes2.plot(numpy.max(data, axis=0))\n",
+    "\n",
+    "    axes3.set_ylabel('min')\n",
+    "    axes3.plot(numpy.min(data, axis=0))\n",
+    "\n",
+    "    fig.tight_layout()\n",
+    "    matplotlib.pyplot.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def detect_problems(filename):\n",
+    "\n",
+    "    data = numpy.loadtxt(fname=filename, delimiter=',')\n",
+    "\n",
+    "    if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:\n",
+    "        print('Suspicious looking maxima!')\n",
+    "    elif numpy.sum(numpy.min(data, axis=0)) == 0:\n",
+    "        print('Minima add up to zero!')\n",
+    "    else:\n",
+    "        print('Seems OK!')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "filenames = sorted(glob.glob('../data/inflammation*.csv'))\n",
+    "\n",
+    "for f in filenames[:3]:\n",
+    "    print(f)\n",
+    "    analyze(f)\n",
+    "    detect_problems(f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Testing and Documenting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired):\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "z = numpy.zeros((2,2))\n",
+    "print(center(z, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = numpy.loadtxt(fname='../data/inflammation-01.csv', delimiter=',')\n",
+    "print(center(data, 0))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('original min, mean, and max are:', numpy.min(data), numpy.mean(data), numpy.max(data))\n",
+    "centered = center(data, 0)\n",
+    "print('min, mean, and max of centered data are:', numpy.min(centered), numpy.mean(centered), numpy.max(centered))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('std dev before and after:', numpy.std(data), numpy.std(centered))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('difference in standard deviations before and after:', numpy.std(data) - numpy.std(centered))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# center(data, desired): return a new array containing the original data centered around the desired value.\n",
+    "def center(data, desired):\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired):\n",
+    "    '''Return a new array containing the original data centered around the desired value.'''\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "help(center)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired):\n",
+    "    '''Return a new array containing the original data centered around the desired value.\n",
+    "    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''\n",
+    "    return (data - numpy.mean(data)) + desired\n",
+    "\n",
+    "help(center)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Defining Defaults"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numpy.loadtxt('../data/inflammation-01.csv', delimiter=',')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numpy.loadtxt('../data/inflammation-01.csv', ',')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def center(data, desired=0.0):\n",
+    "    '''Return a new array containing the original data centered around the desired value (0 by default).\n",
+    "    Example: center([1, 2, 3], 0) => [-1, 0, 1]'''\n",
+    "    return (data - numpy.mean(data)) + desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "test_data = numpy.zeros((2, 2))\n",
+    "print(center(test_data, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "more_data = 5 + numpy.zeros((2, 2))\n",
+    "print('data before centering:')\n",
+    "print(more_data)\n",
+    "print('centered data:')\n",
+    "print(center(more_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def display(a=1, b=2, c=3):\n",
+    "    print('a:', a, 'b:', b, 'c:', c)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('no parameters:')\n",
+    "display()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('one parameter:')\n",
+    "display(55)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('two parameters:')\n",
+    "display(55, 66)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print('only setting the value of c')\n",
+    "display(c=77)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# numpy.loadtxt('../data/inflammation-01.csv', ',')\n",
+    "help(numpy.loadtxt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Readable functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def s(p):\n",
+    "    a = 0\n",
+    "    for v in p:\n",
+    "        a += v\n",
+    "    m = a / len(p)\n",
+    "    d = 0\n",
+    "    for v in p:\n",
+    "        d += (v - m) * (v - m)\n",
+    "    return numpy.sqrt(d / (len(p) - 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def std_dev(sample):\n",
+    "    sample_sum = 0\n",
+    "    for value in sample:\n",
+    "        sample_sum += value\n",
+    "\n",
+    "    sample_mean = sample_sum / len(sample)\n",
+    "\n",
+    "    sum_squared_devs = 0\n",
+    "    for value in sample:\n",
+    "        sum_squared_devs += (value - sample_mean) * (value - sample_mean)\n",
+    "\n",
+    "    return numpy.sqrt(sum_squared_devs / (len(sample) - 1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/soln-07-errors.ipynb
+++ b/notebooks/soln-07-errors.ipynb
@@ -84,6 +84,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Reading Error Messages\n",
+    "Read the traceback below, and identify the following pieces of information about it:\n",
+    "\n",
+    "1. How many levels does the traceback have? **3 levels**\n",
+    "1. What is the file name where the error occurred? **`errors_02.py`**\n",
+    "1. What is the function name where the error occurred? **`print_message`**\n",
+    "1. On which line number in this function did the error occurr? **11**\n",
+    "1. What is the type of error? **`KeyError`**\n",
+    "1. What is the error message? **`Friday` is not a key in `messages`**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import errors_02\n",
+    "errors_02.print_friday_message()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Syntax Errors"
    ]
   },
@@ -113,6 +140,51 @@
     "    msg = \"hello, world!\"\n",
     "    print(msg)\n",
     "     return msg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Identifying Syntax Errors\n",
+    "\n",
+    "1. Read the code below, and (without running it) try to identify what the errors are.\n",
+    "1. Run the code, and read the error message. Is it a SyntaxError or an IndentationError?\n",
+    "1. Fix the error.\n",
+    "1. Repeat steps 2 and 3, until you have fixed all the errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def another_function\n",
+    "  print(\"Syntax errors are annoying.\")\n",
+    "   print(\"But at least python tells us about them!\")\n",
+    "  print(\"So they are usually not too hard to fix.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`SyntaxErro`r for missing `():` at end of first line, `IndentationError` for mismatch between second and third lines. A fixed version is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "def another_function():\n",
+    "    print(\"Syntax errors are annoying.\")\n",
+    "    print(\"But at least python tells us about them!\")\n",
+    "    print(\"So they are usually not too hard to fix.\")\n",
+    "```"
    ]
   },
   {
@@ -175,6 +247,58 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Identifying Variable Name Errors\n",
+    "\n",
+    "1. Read the code below, and (without running it) try to identify what the errors are.\n",
+    "1. Run the code, and read the error message. What type of NameError do you think this is? In other words, is it a string with no quotes, a misspelled variable, or a variable that should have been defined but was not?\n",
+    "1. Fix the error.\n",
+    "1. Repeat steps 2 and 3, until you have fixed all the errors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "for number in range(10):\n",
+    "    # use a if the number is a multiple of 3, otherwise use b\n",
+    "    if (Number % 3) == 0:\n",
+    "        message = message + a\n",
+    "    else:\n",
+    "        message = message + \"b\"\n",
+    "print(message)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fixed version:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "message = \"\"\n",
+    "for number in range(10):\n",
+    "    # use a if the number is a multiple of 3, otherwise use b\n",
+    "    if (number % 3) == 0:\n",
+    "        message = message + \"a\"\n",
+    "    else:\n",
+    "        message = message + \"b\"\n",
+    "print(message)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Item Errors"
    ]
   },
@@ -191,6 +315,46 @@
     "print(\"Letter #2 is\", letters[1])\n",
     "print(\"Letter #3 is\", letters[2])\n",
     "print(\"Letter #4 is\", letters[3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Identifying Item Errors\n",
+    "\n",
+    "1. Read the code below, and (without running it) try to identify what the errors are.\n",
+    "1. Run the code, and read the error message. What type of error is it?\n",
+    "1. Fix the error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "seasons = ['Spring', 'Summer', 'Fall', 'Winter']\n",
+    "print('My favorite season is ', seasons[4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`IndexError`; the last entry is `seasons[3]`, so `seasons[4]` doesn’t make sense. A fixed version is:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```Python\n",
+    "seasons = ['Spring', 'Summer', 'Fall', 'Winter']\n",
+    "print('My favorite season is ', seasons[-1])\n",
+    "```"
    ]
   },
   {

--- a/notebooks/soln-07-errors.ipynb
+++ b/notebooks/soln-07-errors.ipynb
@@ -172,7 +172,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`SyntaxErro`r for missing `():` at end of first line, `IndentationError` for mismatch between second and third lines. A fixed version is:"
+    "`SyntaxError` for missing `():` at end of first line, `IndentationError` for mismatch between second and third lines. A fixed version is:"
    ]
   },
   {

--- a/notebooks/soln-07-errors.ipynb
+++ b/notebooks/soln-07-errors.ipynb
@@ -1,0 +1,258 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Errors and Exceptions\n",
+    "Questions\n",
+    "* How does Python report errors?\n",
+    "* How can I handle errors in Python programs?\n",
+    "\n",
+    "Objectives\n",
+    "* To be able to read a traceback, and determine where the error took place and what type it is.\n",
+    "* To be able to describe the types of situations in which syntax errors, indentation errors, name errors, index errors, and missing file errors occur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Add code examples in the Python path\n",
+    "import sys\n",
+    "sys.path.append('../code')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tracebacks in Python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import errors_01\n",
+    "errors_01.favorite_ice_cream()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Syntax Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def some_function()\n",
+    "    msg = \"hello, world!\"\n",
+    "    print(msg)\n",
+    "     return msg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def some_function():\n",
+    "    msg = \"hello, world!\"\n",
+    "    print(msg)\n",
+    "     return msg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Variable Name Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(hello)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for number in range(10):\n",
+    "    count = count + number\n",
+    "print(\"The count is:\", count)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Count = 0\n",
+    "for number in range(10):\n",
+    "    count = count + number\n",
+    "print(\"The count is:\", count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Item Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "letters = ['a', 'b', 'c']\n",
+    "print(\"Letter #1 is\", letters[0])\n",
+    "print(\"Letter #2 is\", letters[1])\n",
+    "print(\"Letter #3 is\", letters[2])\n",
+    "print(\"Letter #4 is\", letters[3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## File Errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "file_handle = open('myfile.txt', 'r')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "file_handle = open('myfile.txt', 'w')\n",
+    "file_handle.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/soln-08-defensive.ipynb
+++ b/notebooks/soln-08-defensive.ipynb
@@ -151,6 +151,117 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Exercise - Pre- and Post-Conditions\n",
+    "Suppose you are writing a function called `average` that calculates the average of the numbers in a list. What pre-conditions and post-conditions would you write for it?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "\n",
+    "def average(inputList):\n",
+    "    input = numpy.asarray(inputList)\n",
+    "    \n",
+    "    # Pre-conditions\n",
+    "    assert len(input) > 0, 'List length must be non-zero'\n",
+    "    \n",
+    "    average = numpy.mean(input)\n",
+    "    \n",
+    "    # Post-conditions\n",
+    "    assert numpy.min(input) <= average <= numpy.max(input), 'Average should be between min and max of input values'\n",
+    "    \n",
+    "    return average\n",
+    "\n",
+    "print('Average:', average([2, 2, 2]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Testing Assertions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def running(values):\n",
+    "    assert len(values) > 0\n",
+    "    result = [values[0]]\n",
+    "    for v in values[1:]:\n",
+    "        assert result[-1] >= 0\n",
+    "        result.append(result[-1] + v)\n",
+    "        assert result[-1] >= result[0]\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "running([1, 2, 3, 4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Explain in words what the assertions in the function check, and for each one, give an example of input that will make that assertion fail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "running([])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "running([-1, 0, 2, 3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "running([0, 1, 3, -5, 4])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Test-Driven Development"
    ]
   },
@@ -225,6 +336,50 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "test_range_overlap()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise - Fixing and Testing\n",
+    "Fix `range_overlap`. Re-run `test_range_overlap` after each change you make."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy\n",
+    "\n",
+    "def range_overlap(ranges):\n",
+    "    '''Return common overlap among a set of [low, high] ranges.'''\n",
+    "    if len(ranges) == 1: # only one entry, so return it\n",
+    "        return ranges[0]\n",
+    "    lowest = -numpy.inf # lowest possible number\n",
+    "    highest = numpy.inf # highest possible number\n",
+    "    for (low, high) in ranges:\n",
+    "        lowest = max(lowest, low)\n",
+    "        highest = min(highest, high)\n",
+    "    if lowest >= highest: # no overlap\n",
+    "        return None\n",
+    "    else:\n",
+    "        return (lowest, highest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
    },
    "outputs": [],
    "source": [

--- a/notebooks/soln-08-defensive.ipynb
+++ b/notebooks/soln-08-defensive.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Programming with Python\n",
+    "## Defensive Programming\n",
+    "Questions\n",
+    "* How can I make my programs more reliable?\n",
+    "\n",
+    "Objectives\n",
+    "* Explain what an assertion is.\n",
+    "* Add assertions that check the program’s state is correct.\n",
+    "* Correctly add precondition and postcondition assertions to functions.\n",
+    "* Explain what test-driven development is, and use it when creating new functions.\n",
+    "* Explain why variables should be initialized using actual data values rather than arbitrary constants."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### How to Use Jupyter\n",
+    "When a cell is in edit mode:\n",
+    "\n",
+    "  Shortcut  | Description\n",
+    "----------- | -----------\n",
+    "Shift+Enter | Run the cell, and go to the next\n",
+    "Tab         | Indent code or auto-completion\n",
+    "Esc         | Go to command mode\n",
+    "\n",
+    "When a cell is in command mode:\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "Shift+Enter  | Run the cell, and go to the next\n",
+    "Double-click | Go to edit mode\n",
+    "Enter        | Go to edit mode\n",
+    "\n",
+    "  Shortcut   | Description\n",
+    "------------ | -----------\n",
+    "A            | Insert a cell above\n",
+    "B            | Insert a cell below\n",
+    "C            | Copy the current cell\n",
+    "V            | Paste the cell below\n",
+    "D D          | Delete the current cell\n",
+    "\n",
+    "To reset all cells:\n",
+    "* Go to the top menu, and select Kernel -> Restart & Clear Output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Assertions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "numbers = [1.5, 2.3, 0.7, -0.001, 4.4]\n",
+    "total = 0.0\n",
+    "for n in numbers:\n",
+    "    assert n > 0.0, 'Data should only contain positive values'\n",
+    "    total += n\n",
+    "print('total is:', total)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def normalize_rectangle(rect):\n",
+    "    '''Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.'''\n",
+    "    assert len(rect) == 4, 'Rectangles must contain 4 coordinates'\n",
+    "    x0, y0, x1, y1 = rect\n",
+    "    assert x0 < x1, 'Invalid X coordinates'\n",
+    "    assert y0 < y1, 'Invalid Y coordinates'\n",
+    "\n",
+    "    dx = x1 - x0\n",
+    "    dy = y1 - y0\n",
+    "    if dx > dy:\n",
+    "        scaled = float(dx) / dy\n",
+    "        upper_x, upper_y = 1.0, scaled\n",
+    "    else:\n",
+    "        scaled = float(dx) / dy\n",
+    "        upper_x, upper_y = scaled, 1.0\n",
+    "\n",
+    "    assert 0 < upper_x <= 1.0, 'Calculated upper X coordinate invalid'\n",
+    "    assert 0 < upper_y <= 1.0, 'Calculated upper Y coordinate invalid'\n",
+    "\n",
+    "    return (0, 0, upper_x, upper_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (0.0, 1.0, 2.0) )) # missing the fourth coordinate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (4.0, 2.0, 1.0, 5.0) )) # X axis inverted"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (0.0, 0.0, 1.0, 5.0) ))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print(normalize_rectangle( (0.0, 0.0, 5.0, 1.0) ))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Test-Driven Development"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![Figure - Overlapping Ranges](../fig/python-overlapping-ranges.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)\n",
+    "assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)\n",
+    "assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None\n",
+    "assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def range_overlap(ranges):\n",
+    "    '''Return common overlap among a set of [low, high] ranges.'''\n",
+    "    lowest = 0.0\n",
+    "    highest = 1.0\n",
+    "    for (low, high) in ranges:\n",
+    "        lowest = max(lowest, low)\n",
+    "        highest = min(highest, high)\n",
+    "    return (lowest, highest)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def test_range_overlap():\n",
+    "    assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None\n",
+    "    assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None\n",
+    "    assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)\n",
+    "    assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)\n",
+    "    assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "test_range_overlap()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [Root]",
+   "language": "python",
+   "name": "Python [Root]"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
With the Python workshop, typing everything takes too much time. Participants are concentrated to copy what we type, and they do not listen to explanations. With these notebooks, I want them to focus on the new thing they are learning. For example, if I want to teach the for loop, all print statements are already there.

Exercises are no longer at the end of the chapter. I tried to apply the principle of "doing an exercise after learning up to 7 new things". This is why exercises are distributed in the appropriate sections of each chapter.

In the same "notebooks" folder, we can find notebooks with blanks (0x-yyy.ipynb) and their solution (soln-0x-yyy.ipynb).

Now, regarding _episodes/03-lists.md, I have improved the primes/odds examples. I have also fixed a print statement.

EDIT: I would like to use these notebooks for the event of September 8 in Montreal (Canada). Thanks!
