### PR TITLE
Minor cleanup related to mentions of tuples

### DIFF
--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -406,7 +406,7 @@ last: 4
 > > You can also leave out the beginning and end of the slice to take the whole string
 > > and provide only the step argument to go every second
 > > element:
-> > 
+> >
 > > ~~~
 > > beatles[::2]
 > > ~~~
@@ -451,7 +451,7 @@ Omitting ending index: ["sep", "oct", "nov", "dec"]
 ~~~
 {: .output}
 
-> ## Tuples and Exchanges
+> ## Swapping the contents of variables
 >
 > Explain what the overall effect of this code is:
 >
@@ -482,9 +482,9 @@ Omitting ending index: ["sep", "oct", "nov", "dec"]
 > > print(left, right)
 > > ~~~
 > > {: .python}
-> > 
+> >
 > > ~~~
-> > R L 
+> > R L
 > > ~~~
 > > {: .output}
 > >
@@ -513,11 +513,11 @@ Omitting ending index: ["sep", "oct", "nov", "dec"]
 > The technical term for this is *operator overloading*:
 > a single operator, like `+` or `*`,
 > can do different things depending on what it's applied to.
-> 
+>
 > > ## Solution
-> > 
+> >
 > > The multiplication operator `*` used on a list replicates elements of the list and concatenates them together:
-> > 
+> >
 > > ~~~
 > > [2, 4, 6, 8, 10, 2, 4, 6, 8, 10]
 > > ~~~

--- a/_episodes/05-cond.md
+++ b/_episodes/05-cond.md
@@ -346,39 +346,6 @@ freeing us from having to manually examine every plot for features we've seen be
 > {: .solution}
 {: .challenge}
 
-> ## Tuples and Exchanges
->
-> Explain what the overall effect of this code is:
->
-> ~~~
-> left = 'L'
-> right = 'R'
->
-> temp = left
-> left = right
-> right = temp
-> ~~~
-> {: .python}
->
-> > ## Solution
-> > The code swaps the contents of the variables right and left.
-> {: .solution}
->
-> Compare it to:
->
-> ~~~
-> left, right = right, left
-> ~~~
-> {: .python}
->
-> Do they always do the same thing?
-> Which do you find easier to read?
->
-> > ## Solution
-> > Yes, although it's possible the internal implementation is different.
-> {: .solution}
-{: .challenge}
-
 > ## Sorting a List Into Buckets
 >
 > The folder containing our data files has large data sets whose names start with
@@ -412,7 +379,7 @@ freeing us from having to manually examine every plot for features we've seen be
 > other_files = ['myscript.py']
 > ~~~
 > {: .python}
-> 
+>
 > > ## Solution
 > > ~~~
 > > for file in files:


### PR DESCRIPTION
This addresses two points raised in https://github.com/swcarpentry/python-novice-inflammation/issues/287:
- It renames the title of one of the exercises to make it clearer and not mention tuples
- It removes the same exercise from lesson 5 (this must have been added accidentally since it is not relevant to that lesson)

There are still some mentions of tuples scattered in a few places in the notes - should these be removed too?
