### PR TITLE
Show how to define a list before using strings/chars to illustrate looping

### DIFF
--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -25,14 +25,14 @@ We have a dozen data sets right now, though, and more on the way.
 We want to create plots for all of our data sets with a single statement.
 To do that, we'll have to teach the computer how to repeat things.
 
-So far, we've seen how to create variables that hold a single value.  For example, we can create a variabe, "a", that holds the integer value 10.
+So far, we've seen how to create variables that hold a single value.  For example, we can create a variable, "a", that holds the integer value 10.
 
 ~~~
 a = 10
 ~~~
 {: .python}
 
-We've also shown how to use these variables to create new values.  For instance, we can create a new variable, "b", that holds the value of the first variable multiplied by ten.
+We've also shown how to use these variables to create new variables.  For instance, we can create a new variable, "b", that holds the value of the first variable multiplied by ten.
 
 ~~~
 b = a * 10
@@ -68,7 +68,7 @@ print(daily_temps[0])
 ~~~
 {: .python}
 
-Note that you can't access an element that doesn't exist!  If you try to access element 7 of this list, python will reply that this index is out of range.  Remember, you start counting from 0, so daily_temps[6] represents the seventh value in this list!
+Note that you can't access an element that doesn't exist.  If you try to access element 7 of this list, python will reply that this index is out of range.  Remember, you start counting from 0, so daily_temps[6] represents the seventh value in this list.
 
 ~~~
 print(daily_temps[6])
@@ -79,7 +79,7 @@ IndexError: list index out of range
 ~~~
 {: .python}
 
-You add, multiply, or do other operations on the elements of a list in the same way you use stand alone variables.  
+You add, multiply, or perform other operations on the elements of a list in the same way you use stand alone variables.  
 
 ~~~
 print(print(daily_temps[0] + daily_temps[1])

--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -41,7 +41,7 @@ print(b)
 ~~~
 {: .python}
 
-However, there will often be occasions when you need a way to store multiple values in a group.  For example, you might want to store daily temperature readings for a week.  You could use single variables for each.
+However, there will often be occasions when you need a way to store multiple values in a group.  For example, you might want to store daily temperature readings for a week.  You could try using a separate variable for each element.
 
 ~~~
 daily_temp_1 = 63
@@ -51,9 +51,7 @@ daily_temp_4 = 66
 ~~~
 {: .python}
 
-With a large number of observations, this approach becomes unmanageable.  What you really need is a way to store a list of values in a single variable.  
-
-Python provides a number of different formats, or data structures, to store collections of variables.  The most basic data structure to store multiple values is a list.  Here's how we can store daily temperature readings in a list.
+With a large number of observations, this approach becomes unmanageable.  What you really need is a way to store a series of values in a single variable.  Python provides a number of different formats, or data structures, to store collections of variables.  The most basic data structure to store multiple values is a list.  Here's one way can store daily temperature readings in a list.
 
 ~~~
 daily_temps = [63, 62, 60, 66, 58, 58, 60]
@@ -62,7 +60,7 @@ print(daily_temps)
 ~~~
 {: .python}
 
-You can access the value for each element of a list by its index.  The index is the position of the element in a list, starting at zero.  For instance, to access the first temperature reading, you could print the value of the variable at position 0.
+You can access the value for each element of a list by its index.  The index is the position of the element in a list, starting at zero.  For instance, to access the first temperature reading, you would print the value of the variable at index 0.
 
 ~~~
 print(daily_temps[0])
@@ -81,7 +79,7 @@ IndexError: list index out of range
 ~~~
 {: .python}
 
-You can perform operations on elements of a list as if they were stand alone variables.  
+You add, multiply, or do other operations on the elements of a list in the same way you use stand alone variables.  
 
 ~~~
 print(print(daily_temps[0] + daily_temps[1])
@@ -89,7 +87,7 @@ print(print(daily_temps[0] + daily_temps[1])
 ~~~
 {: .python}
 
-You could find the average temperature reading for this week this way, by adding each element separately and dividing by the number of observations. This would reduce the value of our list, though, since we'd still have to type out each individual element.  What we need is a way to go through each element of the list, one by one.  
+We could find the average temperature reading for this week this way, by adding each element separately and dividing by the number of observations. This would reduce the usefulness of our list, though, since we'd still have to type out each individual element.  What we need is a way to go through each element of the list, one by one.  
 
 Python provides this ability with a loop, a method that allows you to step (or iterate) through the elements of a list.  
 
@@ -106,7 +104,7 @@ for daily_temp in daily_temps:
 ~~~
 {: .python}
 
-This loop steps through each temperature reading in the list, assigns it to the variable daily_temp, and then prints the value of the daily_temp in the body of the loop.  You can also access and set variables defined outside the loop. For example, here's how we might use a loop to find the average temperature for the week.
+This loop steps through each temperature reading in the list, assigns it to the variable daily_temp, and then prints the value of the daily_temp in the body of the loop.  You can also access and set variables defined outside the loop. For example, here's a loop to find the average temperature for the week.
 
 ~~~
 sum_temp = 0

--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -25,6 +25,76 @@ We have a dozen data sets right now, though, and more on the way.
 We want to create plots for all of our data sets with a single statement.
 To do that, we'll have to teach the computer how to repeat things.
 
+So far, we've seen how to create variables that hold a single value.  For example, we can create a variabe, "a", that holds the integer value 10.
+
+~~~
+a = 10
+~~~
+{: .python}
+
+We've also shown how to use these variables to create new values.  For instance, we can create a new variable, "b", that holds the value of the first variable multiplied by ten.
+
+~~~
+b = a * 10
+print(b)
+100
+~~~
+{: .python}
+
+However, there will often be occasions when you need a way to store multiple values in a group.  For example, you might want to store daily temperature readings for a week.  You could use single variables for each.
+
+~~~
+day1SFreading = 63
+day2SFreading = 62
+day3SFreading = 60
+day4SFreading = 66
+~~~
+{: .python}
+
+With a large number of observations, this approach becomes unmanageable.  What you really need is a way to store a list of values in a single variable.  
+
+Python provides a number of different formats, or data structures, to store collections of variables.  The most basic data structure to store multiple values is a list.  Here's how we can store daily temperature readings in a list.
+
+~~~
+daily_temps = [63, 62, 60, 66, 58, 58, 60]
+print(daily_temps)
+[63, 62, 60, 66, 58, 58, 61]
+~~~
+{: .python}
+
+You can access the value for each element of a list by its index.  The index is the position of the element in a list, starting at zero.  For instance, to access the first temperature reading, you could print the value of the variable at position 0.
+
+~~~
+print(daily_temps[0])
+63
+~~~
+{: .python}
+
+Note that you can't access an element that doesn't exist!  If you try to access element 7 of this list, python will reply that this index is out of range.  Remember, you start counting from 0, so daily_temps[6] represents the seventh value in this list!
+
+~~~
+print(daily_temps[6])
+60
+print(daily_temps[7]
+...
+IndexError: list index out of range
+~~~
+{: .python}
+
+You can perform operations on elements of a list as if they were stand alone variables.  
+
+~~~
+print(print(daily_temps[0] + daily_temps[1])
+125
+~~~
+{: .python}
+
+You could find the average temperature reading for this week this way, by adding each element separately and dividing by the number of observations. This would reduce the value of our list, though, since we'd still have to type out each individual element.  What we need is a way to go through each element of the list, one by one.  
+
+Python 
+
+
+
 An example task that we might want to repeat is printing each character in a
 word on a line of its own.
 

--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -118,7 +118,7 @@ print(sum_temp / count)
 
 We create two variables prior to entering the loop - a running sum of the observed temperatures, and a count of the number of observations.  For each observation in the list, we increase the sum by the value of each new temperature reading, and we increase the count by one.  Once we exit the loop, we divide the sum of the temperature observations by the number of observations to get the average.
 
-As you use different methods and data types, you'll find that python often uses a list to store values, even if it isn't immediately apparant.  In the example above, we explicitely defined a list of numbers.  It turns out that Python also treats words this way as well.  A string, or word, is in fact a list of characters.  For example, the word "lead" is a list composed of 'l', 'e', 'a', 'd'.  
+It turns out that many different data types in python can be accessed through indices and loops.  For example, you can access the individual characters in the word "lead", 'l', 'e', 'a', 'd', through their position in the string.  
 
 Try it out!
 

--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -44,10 +44,10 @@ print(b)
 However, there will often be occasions when you need a way to store multiple values in a group.  For example, you might want to store daily temperature readings for a week.  You could use single variables for each.
 
 ~~~
-day1SFreading = 63
-day2SFreading = 62
-day3SFreading = 60
-day4SFreading = 66
+daily_temp_1 = 63
+daily_temp_2 = 62
+daily_temp_3 = 60
+daily_temp_4 = 66
 ~~~
 {: .python}
 
@@ -91,12 +91,38 @@ print(print(daily_temps[0] + daily_temps[1])
 
 You could find the average temperature reading for this week this way, by adding each element separately and dividing by the number of observations. This would reduce the value of our list, though, since we'd still have to type out each individual element.  What we need is a way to go through each element of the list, one by one.  
 
-Python 
+Python provides this ability with a loop, a method that allows you to step (or iterate) through the elements of a list.  
 
+~~~
+for daily_temp in daily_temps:
+    print(daily_temp)
+63
+62
+60
+66
+58
+58
+60
+~~~
+{: .python}
 
+This loop steps through each temperature reading in the list, assigns it to the variable daily_temp, and then prints the value of the daily_temp in the body of the loop.  You can also access and set variables defined outside the loop. For example, here's how we might use a loop to find the average temperature for the week.
 
-An example task that we might want to repeat is printing each character in a
-word on a line of its own.
+~~~
+sum_temp = 0
+count = 0
+for daily_temp in daily_temps:
+    sum_temp = sum_temp + daily_temp
+    count = count + 1
+print(sum_temp / count)
+~~~
+{: .python}
+
+We create two variables prior to entering the loop - a running sum of the observed temperatures, and a count of the number of observations.  For each observation in the list, we increase the sum by the value of each new temperature reading, and we increase the count by one.  Once we exit the loop, we divide the sum of the temperature observations by the number of observations to get the average.
+
+As you use different methods and data types, you'll find that python often uses a list to store values, even if it isn't immediately apparant.  In the example above, we explicitely defined a list of numbers.  It turns out that Python also treats words this way as well.  A string, or word, is in fact a list of characters.  For example, the word "lead" is a list composed of 'l', 'e', 'a', 'd'.  
+
+Try it out!
 
 ~~~
 word = 'lead'
@@ -123,7 +149,7 @@ d
 ~~~
 {: .output}
 
-This is a bad approach for two reasons:
+As with our explicit list of integers, this is a bad approach for two reasons:
 
 1.  It doesn't scale:
     if we want to print the characters in a string that's hundreds of letters long,


### PR DESCRIPTION
I noticed that the chapter on loops in python introduces the concept of iterating through a list through strings and characters.  I thought that the concepts might be easier to follow if the learners first explicitly defined a list.  This way, a learner isn't encountering two ideas at the same time - first, that variables can be lists as well as single value, second that strings aren't ordinary variables even if they seem that way at first.

I added this to the start of the lesson on python loops, then transition into the notion that strings can also be treated as lists, iterated over, accessed through index, and so forth.  This may lead to a little bit of repetition, similar loops over strings that a learner already did over a list of integers, but I think the slightly different angle might help reinforce the concepts.  

This all does makes the lesson a little longer, but doesn't introduce any new concepts or complexity.  