### PR TITLE
Python3 fixes

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -133,7 +133,7 @@ print('weight in pounds:', 2.2 * weight_kg)
 {: .python}
 
 ~~~
-weight in pounds: 121.0
+('weight in pounds:', 121.00000000000001)
 ~~~
 {: .output}
 

--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -140,11 +140,23 @@ print('weight in pounds:', 2.2 * weight_kg)
 As the example above shows,
 we can print several things at once by separating them with commas.
 
+For a more readable output, one can use the format function:
+
+~~~
+print('weight in pounds: {}'.format(2.2 * weight_kg))
+~~~
+{: .python}
+
+~~~
+weight in pounds: 121.0
+~~~
+{: .output}
+
 We can also change a variable's value by assigning it a new one:
 
 ~~~
 weight_kg = 57.5
-print('weight in kilograms is now:', weight_kg)
+print('weight in kilograms is now: {}'.format(weight_kg))
 ~~~
 {: .python}
 
@@ -164,7 +176,7 @@ let's store the subject's weight in pounds in a variable:
 
 ~~~
 weight_lb = 2.2 * weight_kg
-print('weight in kilograms:', weight_kg, 'and in pounds:', weight_lb)
+print('weight in kilograms: {} and in pounds: {}'.format(weight_kg, weight_lb))
 ~~~
 {: .python}
 
@@ -179,7 +191,7 @@ and then change `weight_kg`:
 
 ~~~
 weight_kg = 100.0
-print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', weight_lb)
+print('weight in kilograms is now: {} and weight in pounds is still: {}'.format(weight_kg, weight_lb))
 ~~~
 {: .python}
 


### PR DESCRIPTION
Output of the print commands are inconsistent with what either python2 or python3 would return. 
The output would be consistent if one were to use python2 and print without the parentheses. However, the Setup tab (http://swcarpentry.github.io/workshop-template/#setup) clearly requires learners to install python 3.x.  This change mixes the advantages of print with commas and print with format. 