### PR TITLE
Use list instead of tuple in variable swapping exercise

### DIFF
--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -468,7 +468,7 @@ Omitting ending index: ["sep", "oct", "nov", "dec"]
 > Compare it to:
 >
 > ~~~
-> left, right = right, left
+> left, right = [right, left]
 > ~~~
 > {: .python}
 >
@@ -488,7 +488,7 @@ Omitting ending index: ["sep", "oct", "nov", "dec"]
 > > ~~~
 > > {: .output}
 > >
-> >In the first case we used a temporary variable `temp` to keep the value of `left` before we overwrite it with the value of `right`. In the second case, we pack `right` and `left` into a tuple and then unpack it again into `left` and `right`.
+> >In the first case we used a temporary variable `temp` to keep the value of `left` before we overwrite it with the value of `right`. In the second case, `right` and `left` are packed into a list and then unpacked into `left` and `right`.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
> right, left = left, right
> "...we pack right and left into a tuple and then unpack it again into left
> and right."

This example for variable value swapping introduces three new concepts:
    1. the tuple data type
    2. special tuple syntax, omitting parentheses
    3. container unpacking in an assignment

I think using a list is much clearer, and only introduces the concept of
container unpacking.

right, left = [left, right]