### PR TITLE
Fixed CONTRIBUTING.md links 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,8 @@ and to meet some of our community members.
 ## Where to Contribute
 
 1.  If you wish to change this lesson,
-    please work in <https://github.com/swcarpentry/FIXME>,
-    which can be viewed at <https://swcarpentry.github.io/FIXME>.
+    please work in <https://github.com/swcarpentry/python-novice-inflammation>,
+    which can be viewed at <https://swcarpentry.github.io/python-novice-inflammation>.
 
 2.  If you wish to change the example lesson,
     please work in <https://github.com/swcarpentry/lesson-example>,


### PR DESCRIPTION
In CONTRIBUTING.md, there were two "FIXME" placeholders sitting in two links under Point 1 of  "Where to Contribute," instead of "python-novice-inflammation." Fixed.