### PR TITLE
Fix code block color

### DIFF
--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -140,7 +140,6 @@ The general form of a loop is:
 for element in variable:
     do things with element
 ~~~
-{: .python}
 
 Using the oxygen example above, the loop might look like this:
 

--- a/_episodes/05-cond.md
+++ b/_episodes/05-cond.md
@@ -139,7 +139,6 @@ We can check for this inside the `for` loop we wrote with the following conditio
 if numpy.max(data, axis=0)[0] == 0 and numpy.max(data, axis=0)[20] == 20:
     print('Suspicious looking maxima!')
 ~~~
-{: .python}
 
 We also saw a different problem in the third dataset;
 the minima per day were all zero (looks like a healthy person snuck into our study).
@@ -149,7 +148,6 @@ We can also check for this with an `elif` condition:
 elif numpy.sum(numpy.min(data, axis=0)) == 0:
     print('Minima add up to zero!')
 ~~~
-{: .python}
 
 And if neither of these conditions are true, we can use `else` to give the all-clear:
 
@@ -157,7 +155,6 @@ And if neither of these conditions are true, we can use `else` to give the all-c
 else:
     print('Seems OK!')
 ~~~
-{: .python}
 
 Let's test that out:
 


### PR DESCRIPTION
We use box color to help learners to know which block they should **type** and run on their Jupyter Notebook or Python console. This pull request fix the color of one block that learners should not type.

# Before

![screenshot_2017-06-19_14-34-09](https://user-images.githubusercontent.com/1506457/27287799-bfeefde6-54fc-11e7-9dff-c85a3f1078bc.png)

# After

![screenshot_2017-06-19_14-35-48](https://user-images.githubusercontent.com/1506457/27287809-c33957f8-54fc-11e7-9634-a519a0d34284.png)

