### PR TITLE
Wording Change & Folder Name

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -4,13 +4,13 @@ title: Setup
 permalink: /setup/
 ---
 
-You need to download some files to follow this lesson:
+In preparation for this lesson, you will need to download two zipped files and place them in the specified folder:
 
 1. Make a new folder in your Desktop called `python-novice-inflammation`.
 2. Download [python-novice-inflammation-data.zip][zipfile1] and move the file to this folder.
 3. Also download [python-novice-inflammation-code.zip][zipfile2] and move it to the same folder.
 4. If the files aren't unzipped yet, double-click to unzip them. You should end up with 
-two new folders called `data` and `code`.
+two new folders called `data` and `python-novice-inflammation-code`.
 5. To get started, go into the `data` folder from the Unix shell with:
 
 ~~~

--- a/setup.md
+++ b/setup.md
@@ -10,7 +10,7 @@ In preparation for this lesson, you will need to download two zipped files and p
 2. Download [python-novice-inflammation-data.zip][zipfile1] and move the file to this folder.
 3. Also download [python-novice-inflammation-code.zip][zipfile2] and move it to the same folder.
 4. If the files aren't unzipped yet, double-click to unzip them. You should end up with 
-two new folders called `data` and `python-novice-inflammation-code`.
+two new folders called `data` and `code`.
 5. To get started, go into the `data` folder from the Unix shell with:
 
 ~~~


### PR DESCRIPTION
When I unzip the python-novice-inflammation-code.zip file, it becomes a folder called python-novice-inflammation-code NOT (as indicated in the instructions) 'code.' Perhaps this could be fixed at the zipped file level, rather than by changing these instructions.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
