### PR TITLE
Fix the links [issues] and [repo] in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,8 @@ You can also [reach us by email][contact].
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
 [how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
-[issues]: https://github.com/swcarpentry/FIXME/issues/
-[repo]: https://github.com/swcarpentry/FIXME/
+[issues]: https://github.com/swcarpentry/python-novice-inflammation/issues/
+[repo]: https://github.com/swcarpentry/python-novice-inflammation/
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry
 [swc-lessons]: http://software-carpentry.org/lessons/
 [swc-site]: http://software-carpentry.org/


### PR DESCRIPTION
This contribution is for instructor training.
-----------------------------------------------
In the CONTRIBUTING.md file, the links to this repository's "issues" and "master link" are broken. At the bottom of the markdown file, the two global links were defined as:
[issues]: https://github.com/swcarpentry/FIXME/issues/
[repo]: https://github.com/swcarpentry/FIXME/

To fix the broken links, the "FIXME" is replaced by the name of the repository:
[issues]: https://github.com/swcarpentry/python-novice-inflammation/issues/
[repo]: https://github.com/swcarpentry/python-novice-inflammation/