### PR TITLE
Use a descriptive name for sd plot example

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -1001,7 +1001,7 @@ the graphs will actually be squeezed together more closely.)
 >
 > > ## Solution
 > > ~~~
-> > max_plot = matplotlib.pyplot.plot(numpy.std(data, axis=0))
+> > std_plot = matplotlib.pyplot.plot(numpy.std(data, axis=0))
 > > matplotlib.pyplot.show()
 > > ~~~
 > > {: .python}


### PR DESCRIPTION
Change the name of the variable for the standard deviation plot example, so that it reflects what it contains.