### PR TITLE
Fix output of %whos, numpy is not imported yet

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -140,7 +140,6 @@ This is different from the way spreadsheets work.
 > ~~~
 > Variable    Type       Data/Info
 > --------------------------------
-> numpy       module     <module 'numpy' from '/Us<...>kages/numpy/__init__.py'>
 > weight_kg   float      100.0
 > weight_lb   float      126.5
 > ~~~


### PR DESCRIPTION
The output of the `%whos` magic shows that the `numpy` module is loaded, while that actually only happens in the next section.  In this branch, I've deleted the output line that shows the module.