### PR TITLE
Suggest changing list example to string example in  02-loops.md, sect…

### DIFF
--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -157,25 +157,7 @@ command to signify the end of the loop body (e.g. `end for`); what is indented a
 > ## What's in a name?
 >
 >
-> In the example above, the loop variable was given the name `char` as a mnemonic; it is short for 'character'. 'Char' is not a keyword in Python that pulls the characters from words or strings. In fact when a similar loop is run over a list rather than a word, the output would be each member of that list printed in order, rather than the characters.
->
-> ~~~
-> word = 'oxygen'
-> for char in word:
->    print(char)
-> ~~~
-> {: .python}
->
-> ~~~
-> o
-> x
-> y
-> g
-> e
-> n
-> ~~~
-> {: .output}
->
+> In the example above, the loop variable was given the name `char` as a mnemonic; it is short for 'character'. 
 > We can choose any name we want for variables. We might just as easily have chosen the name `banana` for the loop variable, as long as we use the same name when we invoke the variable inside the loop:
 >
 > ~~~

--- a/_episodes/02-loop.md
+++ b/_episodes/02-loop.md
@@ -160,16 +160,19 @@ command to signify the end of the loop body (e.g. `end for`); what is indented a
 > In the example above, the loop variable was given the name `char` as a mnemonic; it is short for 'character'. 'Char' is not a keyword in Python that pulls the characters from words or strings. In fact when a similar loop is run over a list rather than a word, the output would be each member of that list printed in order, rather than the characters.
 >
 > ~~~
-> elements = ['oxygen', 'nitrogen', 'argon']
-> for char in elements:
+> word = 'oxygen'
+> for char in word:
 >    print(char)
 > ~~~
 > {: .python}
 >
 > ~~~
-> oxygen
-> nitrogen
-> argon
+> o
+> x
+> y
+> g
+> e
+> n
 > ~~~
 > {: .output}
 >


### PR DESCRIPTION
 Suggest changing list example to string example in  02-loops.md, section "What's in a name"

The original 02-loop section "What's in a name" uses an example using a for loop over a list.
As lists aren't introduced until section 03-lists, I suggest changing this example to a loop over
a string.  Note that there is an excercise "Computing the Value of a Polynomial" in 02-loops that also
uses a list, that may be moved to 03-lists as well.


