### PR TITLE
Modify to replace initial section regarding Python variable assignmen…

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -28,130 +28,102 @@ keypoints:
 - "Use `numpy.mean(array, axis=0)` or `numpy.mean(array, axis=1)` to calculate statistics across the specified axis."
 - "Use the `pyplot` library from `matplotlib` for creating simple visualizations."
 ---
-In this lesson we will learn how to manipulate the inflammation dataset with Python. But before we discuss how to deal with many data points, we will show how to store a single value on the computer.
+In this lesson we will learn how to manipulate the inflammation dataset with Python.
 
-
-The line below [assigns]({{ page.root }}/reference/#assignment) the value `55` to a [variable]({{ page.root }}/reference/#variable) `weight_kg`:
-
-~~~
-weight_kg = 55
-~~~
-{: .python}
-
-A variable is just a name for a value,
-such as `x_val`, `current_temperature`, or `subject_id`.
-Python's variables must begin with a letter and are [case sensitive]({{ page.root }}/reference/#case-sensitive).
-We can create a new variable by assigning a value to it using `=`.
-When we are finished typing and press Shift+Enter,
-the notebook runs our command.
-
-Once a variable has a value, we can print it to the screen:
+First, lets familiarize ourselves with the raw,
+[comma-separated-values (csv)](https://en.wikipedia.org/wiki/Comma-separated_values)
+data files by reviewing some shell commands to browse their contents. From a shell window,
+ensure you are in the `python-novice-inflammation` directory...
 
 ~~~
-print(weight_kg)
+$ cd ~/Desktop/python-novice-inflammation/
+$ pwd
+/Users/nelle/Desktop/python-novice-inflammation
+$ ls
+code	data
+$ cd data
+$ ls
+inflammation-01.csv	inflammation-04.csv	inflammation-07.csv	inflammation-10.csv	small-01.csv
+inflammation-02.csv	inflammation-05.csv	inflammation-08.csv	inflammation-11.csv	small-02.csv
+inflammation-03.csv	inflammation-06.csv	inflammation-09.csv	inflammation-12.csv	small-03.csv
+$ wc -l infl*
+60 inflammation-01.csv
+60 inflammation-02.csv
+60 inflammation-03.csv
+.
+.
+.
 ~~~
-{: .python}
+{: .shell}
 
-~~~
-55
-~~~
-{: .output}
-
-and do arithmetic with it:
-
-~~~
-print('weight in pounds:', 2.2 * weight_kg)
-~~~
-{: .python}
-
-~~~
-weight in pounds: 121.0
-~~~
-{: .output}
-
-As the example above shows,
-we can print several things at once by separating them with commas.
-
-We can also change a variable's value by assigning it a new one:
-
-~~~
-weight_kg = 57.5
-print('weight in kilograms is now:', weight_kg)
-~~~
-{: .python}
+Notice that the output from the word-count command, `wc -l`, shows that each
+`inflamation-*.csv` file has the same number of *lines*, 60. How many *rows* does
+each file have? Lets examine the first 3 lines of `inflamation-01.csv` using the
+`head` command to see if we can determine how many rows are in that file.
 
 ~~~
-weight in kilograms is now: 57.5
+$ head -n 3 inflammation-01.csv 
+0,0,1,3,1,2,4,7,8,3,3,3,10,5,7,4,7,7,12,18,6,13,11,11,7,7,4,6,8,8,4,4,5,7,3,4,2,3,0,0
+0,1,2,1,2,1,3,2,2,6,10,11,5,9,4,4,7,16,8,6,18,4,12,5,12,7,11,5,11,3,3,5,4,4,5,5,1,1,0,1
+0,1,1,3,3,2,6,2,5,9,5,7,4,5,4,15,5,11,9,10,19,14,12,17,7,12,11,7,4,2,10,5,4,2,2,3,2,2,1,1
 ~~~
-{: .output}
+{: .shell}
 
-If we imagine the variable as a sticky note with a name written on it,
-assignment is like putting the sticky note on a particular value:
-
-![Variables as Sticky Notes](../fig/python-sticky-note-variables-01.svg)
-
-This means that assigning a value to one variable does *not* change the values of other variables.
-For example,
-let's store the subject's weight in pounds in a variable:
+If we had a way to count *only* comma characters, we could determine how many rows are
+on each line. We will use a new shell command, `tr`
+(which is short for "translate characters"), to remove all digit characters.
 
 ~~~
-weight_lb = 2.2 * weight_kg
-print('weight in kilograms:', weight_kg, 'and in pounds:', weight_lb)
+$ head -n 1 inflammation-01.csv | tr -d '0123456789'
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 ~~~
-{: .python}
+{: .shell}
 
-~~~
-weight in kilograms: 57.5 and in pounds: 126.5
-~~~
-{: .output}
-
-![Creating Another Variable](../fig/python-sticky-note-variables-02.svg)
-
-and then change `weight_kg`:
+Here, we use a pipe involving `tr` with the `-d` (for "delete") option to delete all
+characters in the list, `'0123456789'`. From the above output, we see that the only
+characters left are the commas. We can now pipe that result through `wc -c` to count
+the commas.
 
 ~~~
-weight_kg = 100.0
-print('weight in kilograms is now:', weight_kg, 'and weight in pounds is still:', weight_lb)
+$ head -n 1 inflammation-01.csv | tr -d '0123456789' | wc -c
+40
 ~~~
-{: .python}
+{: .shell}
+
+This means there are 40 rows, at least in the *first* line of the file. To confirm
+this same result for all lines in the file, we would need to *loop* over the lines.
+Here is a shell `while` loop that will do that...
 
 ~~~
-weight in kilograms is now: 100.0 and weight in pounds is still: 126.5
+$ while read line; do
+>    echo $line | tr -d '0123456789' | wc -c
+> done < inflammation-01.csv 
+40
+40
+40
+.
+.
+.
+40
 ~~~
-{: .output}
+{: .shell}
 
-![Updating a Variable](../fig/python-sticky-note-variables-03.svg)
+So, this confirms that the first data file, `inflammation-01.csv` 60 lines x 40 rows. The
+same is true for all the other `inflammation-*.csv` files.
 
-Since `weight_lb` doesn't "remember" where its value came from,
-it isn't automatically updated when `weight_kg` changes.
-This is different from the way spreadsheets work.
-
-> ## Who's Who in Memory
+> ## Make Simple Sanity Checks
 >
-> You can use the `%whos` command at any time to see what
-> variables you have created and what modules you have loaded into the computer's memory.
-> As this is an IPython command, it will only work if you are in an IPython terminal or the Jupyter Notebook.
->
-> ~~~
-> %whos
-> ~~~
-> {: .python}
->
-> ~~~
-> Variable    Type       Data/Info
-> --------------------------------
-> weight_kg   float      100.0
-> weight_lb   float      126.5
-> ~~~
-> {: .output}
+> We have used some simple shell commands to breifly examine the raw, csv data in
+> these files to get some idea of their size and *shape* (e.g. #rows and #columns).
+> Now, when we load the data into Python, we have some idea about what to expect.
 {: .callout}
 
-Words are useful,
-but what's more useful are the sentences and stories we build with them.
-Similarly,
-while a lot of powerful, general tools are built into languages like Python,
-specialized tools built up from these basic units live in [libraries]({{ page.root }}/reference/#library)
-that can be called upon when needed.
+Python
+is a powerful tool for two reasons. First, it is a powerful programming *language*. Second,
+the Python community has developed a large number of powerful [libraries]({{ page.root }}/reference/#library)
+for Python. Before learning more about Python as a programming language, in this lesson we will learn how
+to manipulate the inflammation data using a library called
+[NumPy](http://docs.scipy.org/doc/numpy/ "NumPy Documentation").
 
 In order to load our inflammation data,
 we need to access ([import]({{ page.root }}/reference/#import) in Python terminology)
@@ -213,15 +185,17 @@ when there's nothing interesting after the decimal point.
 Our call to `numpy.loadtxt` read our file,
 but didn't save the data in memory.
 To do that,
-we need to assign the array to a variable. Just as we can assign a single value to a variable, we can also assign an array of values
-to a variable using the same syntax.  Let's re-run `numpy.loadtxt` and save its result:
+we need to *assign* the array to a Python variable. Let's re-run `numpy.loadtxt`
+and assign its result:
 
 ~~~
 data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 ~~~
 {: .python}
 
-This statement doesn't produce any output because assignment doesn't display anything.
+This statement says to take the result of `numpy.loadtxt` and put it into (e.g.
+assign it via the `=` opearation) to the Python variable named `data`.
+It doesn't produce any output because assignment doesn't display anything.
 If we want to check that our data has been loaded,
 we can print the variable's value:
 

--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -123,7 +123,8 @@ is a powerful tool for two reasons. First, it is a powerful programming *languag
 the Python community has developed a large number of powerful [libraries]({{ page.root }}/reference/#library)
 for Python. Before learning more about Python as a programming language, in this lesson we will learn how
 to manipulate the inflammation data using a library called
-[NumPy](http://docs.scipy.org/doc/numpy/ "NumPy Documentation").
+[NumPy](http://docs.scipy.org/doc/numpy/ "NumPy Documentation"). We hope this appraoch to teaching
+Python will both demonstrate how powerful Python is as well as motivate the value in learning it.
 
 In order to load our inflammation data,
 we need to access ([import]({{ page.root }}/reference/#import) in Python terminology)


### PR DESCRIPTION
- Replace initial section regarding Python variable assignment with review of some shell commands to browse contents of inflammation data files and orient learners with that data.
- Introduce concept of Python variable and assignment as part of the numpy.loadtxt() command.
- Explain that Python is powerful both as a *language* and as a set of community developed *libraries*.
- Explain that lesson begins with *libraries* and not *language*.

Longer rationale...the lesson begins with somewhat arbitrary step of defining and assigning a python variable for `weight_kg` and `weight_lb`. There is significant space used elaborating on Python variables and assignment here but without any connection to the dataset to be analyzed. I felt the concept of varaible assignment is easily handled at the time `numpy.loadtxt()` is being introduced. I include a couple of lines elaborating that concept there.

Beginning the lesson with a review of shell commands makes the lesson dovetail nicely with shell lesson (which is often taught ahead of this python less in the shell, python git trio). More importantly, it allows learners to underestand and orient themselves with the data in the files they are loading into Python so that once there, they cann connect the dots back to what they see through `head` shell commands, etc.

Finally, previous revision offered little in the way of explanation that this lesson really starts in the _deep end_ of python in the sense that learners are first being exposed to _library_ functionality before they learn much of the basic _language_. I felt it was important to explain this and motivate it slightly.