### PR TITLE
Issue #221 - add tab to 'Tabs and Spaces' example

### DIFF
--- a/_episodes/07-errors.md
+++ b/_episodes/07-errors.md
@@ -192,12 +192,11 @@ it *always* means that there is a problem with how your code is indented.
 > the first two lines are using a tab for indentation,
 > while the third line uses four spaces:
 >
-> ~~~
-> def some_function():
->     msg = "hello, world!"
->     print(msg)
->     return msg
-> ~~~
+> <div class="python highlighter-rouge"><div class="highlight"><pre class="highlight"><code>def some_function():
+>         msg = "hello, world!"
+>         print(msg)
+>&#009;return msg
+></code></pre></div>  </div>
 > {: .python}
 >
 > ~~~


### PR DESCRIPTION
Based on info from this site: https://daringfireball.net/projects/markdown/syntax#html
I have replaced the markdown code block with html code (copied the html source from http://swcarpentry.github.io/python-novice-inflammation/07-errors/ and added a tab). The indentation has been increased on all lines as html tabs are 8 characters wide, not 4 and it is hard to change the html tabs to 4 characters.