### PR TITLE
Fixed filename in "Moving Plots Around" challange

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -1017,7 +1017,7 @@ the graphs will actually be squeezed together more closely.)
 > > import numpy
 > > import matplotlib.pyplot
 > >
-> > data = numpy.loadtxt(fname='data/inflammation-01.csv', delimiter=',')
+> > data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 > >
 > > # change figsize (swap width and height)
 > > fig = matplotlib.pyplot.figure(figsize=(3.0, 10.0))


### PR DESCRIPTION
Fixed the filename of the input from data/inflammation-01.csv to inflammation-01.csv to be consistent with the rest of the content in this session, assuming that the data/ is the working directory (this also avoids conflicts between unix- and windows-style path descriptions).

