### PR TITLE
Remove hard coded print string and changed quotes

### DIFF
--- a/_episodes/05-cond.md
+++ b/_episodes/05-cond.md
@@ -61,7 +61,7 @@ Python simply does nothing if the test is false:
 num = 53
 print('before conditional...')
 if num > 100:
-    print('53 is greater than 100')
+    print(num,' is greater than 100')
 print('...after conditional')
 ~~~
 {: .python}
@@ -80,11 +80,11 @@ The following Python code uses `elif` to print the sign of a number.
 num = -3
 
 if num > 0:
-    print(num, "is positive")
+    print(num, 'is positive')
 elif num == 0:
-    print(num, "is zero")
+    print(num, 'is zero')
 else:
-    print(num, "is negative")
+    print(num, 'is negative')
 ~~~
 {: .python}
 


### PR DESCRIPTION
The print string for the if statement was coded to 53, and can cause confusion in my opinion. I changed to concatenate the num variable which is consistent with the rest of the lesson. I also updated some double-quote string to single-quote strings for better consistency.

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
