### PR TITLE
Update 08-defensive.md — en dash for numeric range

### DIFF
--- a/_episodes/08-defensive.md
+++ b/_episodes/08-defensive.md
@@ -87,7 +87,7 @@ AssertionError: Data should only contain positive values
 {: .error}
 
 Programs like the Firefox browser are full of assertions:
-10-20% of the code they contain
+10–20% of the code they contain
 are there to check that the other 80-90% are working correctly.
 Broadly speaking,
 assertions fall into three categories:


### PR DESCRIPTION
Us an en dash instead of a figure dash in order to represent a numeric range.