### PR TITLE
edited explanation of numpy.diff

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -1147,7 +1147,7 @@ the graphs will actually be squeezed together more closely.)
 >example, a NumPy array that looks like this:
 >
 > ~~~
-> npdiff = array([ 0,  2,  5,  9, 14])
+> npdiff = numpy.array([ 0,  2,  5,  9, 14])
 > ~~~
 > {: .language-python}
 >


### PR DESCRIPTION
Array is not a built-in function and hasn't been imported specifically. Changed to call by numpy.array to prevent NameError

