### PR TITLE
Travis CI: trigger builds for all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 python: 2.7
+branches:
+  only:
+  - gh-pages
+  - /.*/
 before_install:
   - rvm default
   - gem install json kramdown


### PR DESCRIPTION
Travis CI ignores `gh-pages` branch unless it has been explicitly added to the list of "safelist"-ed branches. We want to build PRs against all branches.
