### PR TITLE
.travis.yml: use Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.6
 branches:
   only:
   - gh-pages


### PR DESCRIPTION
Our Travis builds currently fail because of a recent transition to Python 3.4 syntax in `lesson_check.py`.