### PR TITLE
Update to styles v9.5.2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,14 +2,16 @@
 # Values for this lesson.
 #------------------------------------------------------------
 
-# Which carpentry is this ("swc", "dc", or "lc")?
+# Which carpentry is this ("swc", "dc", "lc", or "cp")?
+# swc: Software Carpentry
+# dc: Data Carpentry
+# lc: Library Carpentry
+# cp: Carpentries (to use for instructor traning for instance)
 carpentry: "swc"
 
 # Overall title for pages.
 title: "Programming with Python"
 
-# Email address, no mailto:
-email: "lessons@software-carpentry.org"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).
@@ -20,7 +22,11 @@ kind: "lesson"
 
 # Magic to make URLs resolve both locally and on GitHub.
 # See https://help.github.com/articles/repository-metadata-on-github-pages/.
+# Please don't change it: <USERNAME>/<PROJECT> is correct.
 repository: <USERNAME>/<PROJECT>
+
+# Email address, no mailto:
+email: "team@carpentries.org"
 
 # Sites.
 amy_site: "https://amy.software-carpentry.org/workshops"
@@ -44,7 +50,7 @@ pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="
 post_survey: "https://www.surveymonkey.com/r/swc_post_workshop_v1?workshop_id="
 training_post_survey: "https://www.surveymonkey.com/r/post-instructor-training"
 
-# Start time in minutes (0 to be clock-independent, 540 to show a start at 09:00 am)
+# Start time in minutes (0 to be clock-independent, 540 to show a start at 09:00 am).
 start_time: 0
 
 # Specify that things in the episodes collection should be output.

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -9,6 +9,7 @@
 [cran-checkpoint]: https://cran.r-project.org/package=checkpoint
 [cran-knitr]: https://cran.r-project.org/package=knitr
 [cran-stringr]: https://cran.r-project.org/package=stringr
+[dc-lessons]: http://www.datacarpentry.org/lessons/
 [email]: mailto:team@carpentries.org
 [github-importer]: https://import.github.com/
 [importer]: https://github.com/new/import
@@ -17,6 +18,7 @@
 [jekyll-windows]: http://jekyll-windows.juthilo.com/
 [jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
+[lc-lessons]: https://librarycarpentry.org/#portfolio
 [lesson-example]: https://carpentries.github.io/lesson-example/
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [morea]: https://morea-framework.github.io/
@@ -32,6 +34,7 @@
 [ruby-installer]: https://rubyinstaller.org/
 [rubygems]: https://rubygems.org/pages/download/
 [styles]: https://github.com/carpentries/styles/
+[swc-lessons]: https://software-carpentry.org/lessons/ 
 [swc-releases]: https://github.com/swcarpentry/swc-releases
 [workshop-repo]: {{ site.workshop_repo }}
 [yaml]: http://yaml.org/


### PR DESCRIPTION
This pull request brings the latest version of the template to this repository. Release notes are available from the styles GitHub Repository. See [v9.5.1](https://github.com/carpentries/styles/releases/tag/v9.5.1) and [v9.5.2](https://github.com/carpentries/styles/releases/tag/v9.5.2). Deployment progress tracked in carpentries/styles#302.
        