### PR TITLE
[ENH] README.md line length

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,20 @@ Rendered version of the lesson: <https://swcarpentry.github.io/python-novice-inf
 ## Contributing
 [![Travis Build Status](https://travis-ci.org/swcarpentry/python-novice-inflammation.svg?branch=gh-pages)](https://travis-ci.org/swcarpentry/python-novice-inflammation)
 
-We welcome all contributions to improve the lesson! Maintainers will do their best to help you if you have any questions, concerns, or experience any difficulties along the way.
+We welcome all contributions to improve the lesson!
+Maintainers will do their best to help you if you have any questions, concerns,
+or experience any difficulties along the way.
 
-We'd like to ask you to familiarize yourself with our [Contribution Guide](CONTRIBUTING.md) and have a look at the [more detailed guidelines][lesson-example] on proper formatting, ways to render the lesson locally, and even how to write new episodes!
+We'd like to ask you to familiarize yourself with our [Contribution Guide](CONTRIBUTING.md)
+and have a look at the [more detailed guidelines][lesson-example] on proper formatting,
+ways to render the lesson locally, and even how to write new episodes!
 
 ## Maintainers
 
-Lesson maintainers are [Trevor Bekolay][trevor_bekolay], [Maxim Belkin][maxim_belkin], [Anne Fouilloux][anne_fouilloux], [Valentina Staneva][valentina_staneva], [Mike Trizna][mike_trizna], and [creator][swc_history] of Software Carpentry: [Greg Wilson][greg_wilson]
+Lesson maintainers are [Trevor Bekolay][trevor_bekolay], [Maxim Belkin][maxim_belkin],
+[Anne Fouilloux][anne_fouilloux], [Valentina Staneva][valentina_staneva],
+[Mike Trizna][mike_trizna], and [creator][swc_history] of Software Carpentry:
+[Greg Wilson][greg_wilson]
 
 ## Authors
 A list of contributors to the lesson can be found in [AUTHORS](AUTHORS)


### PR DESCRIPTION
In response to #498, adds line breaks in the README.md and _episodes/03-lists.md files to decrease the number of lines with over 100 characters.

I did not address the over-length lines linking the buttons in the README, nor the code snippet for `list_for_slicing` in the episode, since modifying those lines -- to the best of my understanding -- would alter the rendering.

Thank you for your work maintaining these lessons !
