### PR TITLE
06-func.md: fix long lines and other fixes

### DIFF
--- a/_episodes/06-func.md
+++ b/_episodes/06-func.md
@@ -18,15 +18,15 @@ keypoints:
 - "Call a function using `function_name(value)`."
 - "Numbers are stored as integers or floating-point numbers."
 - "Variables defined within a function can only be seen and used within the body of the function."
-- "If a variable is not defined within the function it is used, 
+- "If a variable is not defined within the function it is used,
    Python looks for a definition before the function call"
 - "Use `help(thing)` to view help for something."
 - "Put docstrings in functions to provide help for that function."
-- "Specify default values for parameters when defining a function using `name=value` 
+- "Specify default values for parameters when defining a function using `name=value`
    in the parameter list."
-- "Parameters can be passed by matching based on name, by position, 
+- "Parameters can be passed by matching based on name, by position,
    or by omitting them (in which case the default value is used)."
-- "Put code whose parameters change frequently in a function, 
+- "Put code whose parameters change frequently in a function,
    then call it with different parameter values to customize its behavior."
 ---
 
@@ -417,19 +417,18 @@ numpy.loadtxt('inflammation-01.csv', ',')
 {: .language-python}
 
 ~~~
----------------------------------------------------------------------------
-TypeError                                 Traceback (most recent call last)
-<ipython-input-26-e3bc6cf4fd6a> in <module>()
-----> 1 numpy.loadtxt('inflammation-01.csv', ',')
-
-/Users/gwilson/anaconda/lib/python2.7/site-packages/numpy/lib/npyio.pyc in loadtxt(fname, dtype, comments, delimiter, converters, skiprows, usecols, unpack, ndmin)
-    775     try:
-    776         # Make sure we're dealing with a proper dtype
---> 777         dtype = np.dtype(dtype)
-    778         defconv = _getconv(dtype)
-    779
-
-TypeError: data type "," not understood
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/Users/username/anaconda3/lib/python3.6/site-packages/numpy/lib/npyio.py", line 1041, in loa
+dtxt
+    dtype = np.dtype(dtype)
+  File "/Users/username/anaconda3/lib/python3.6/site-packages/numpy/core/_internal.py", line 199, in
+_commastring
+    newitem = (dtype, eval(repeats))
+  File "<string>", line 1
+    ,
+    ^
+SyntaxError: unexpected EOF while parsing
 ~~~
 {: .error}
 
@@ -544,89 +543,15 @@ help(numpy.loadtxt)
 ~~~
 Help on function loadtxt in module numpy.lib.npyio:
 
-loadtxt(fname, dtype=<class 'float'>, comments='#', delimiter=None, converters=None, skiprows=0, usecols=None, unpack=False, ndmin=0)
-
+loadtxt(fname, dtype=<class 'float'>, comments='#', delimiter=None, converters=None, skiprows=0, use
+cols=None, unpack=False, ndmin=0, encoding='bytes')
     Load data from a text file.
 
     Each row in the text file must have the same number of values.
 
     Parameters
     ----------
-    fname : file or str
-        File, filename, or generator to read.  If the filename extension is
-        ``.gz`` or ``.bz2``, the file is first decompressed. Note that
-        generators should return byte strings for Python 3k.
-    dtype : data-type, optional
-        Data-type of the resulting array; default: float.  If this is a
-        record data-type, the resulting array will be 1-dimensional, and
-        each row will be interpreted as an element of the array.  In this
-        case, the number of columns used must match the number of fields in
-        the data-type.
-    comments : str, optional
-        The character used to indicate the start of a comment;
-        default: '#'.
-    delimiter : str, optional
-        The string used to separate values.  By default, this is any
-        whitespace.
-    converters : dict, optional
-        A dictionary mapping column number to a function that will convert
-        that column to a float.  E.g., if column 0 is a date string:
-        ``converters = {0: datestr2num}``.  Converters can also be used to
-        provide a default value for missing data (but see also `genfromtxt`):
-        ``converters = {3: lambda s: float(s.strip() or 0)}``.  Default: None.
-    skiprows : int, optional
-        Skip the first `skiprows` lines; default: 0.
-    usecols : sequence, optional
-        Which columns to read, with 0 being the first.  For example,
-        ``usecols = (1,4,5)`` will extract the 2nd, 5th and 6th columns.
-        The default, None, results in all columns being read.
-    unpack : bool, optional
-        If True, the returned array is transposed, so that arguments may be
-        unpacked using ``x, y, z = loadtxt(...)``.  When used with a record
-        data-type, arrays are returned for each field.  Default is False.
-    ndmin : int, optional
-        The returned array will have at least `ndmin` dimensions.
-        Otherwise mono-dimensional axes will be squeezed.
-        Legal values: 0 (default), 1 or 2.
-        .. versionadded:: 1.6.0
-
-    Returns
-    -------
-    out : ndarray
-        Data read from the text file.
-
-    See Also
-    --------
-    load, fromstring, fromregex
-    genfromtxt : Load data with missing values handled as specified.
-    scipy.io.loadmat : reads MATLAB data files
-
-    Notes
-    -----
-    This function aims to be a fast reader for simply formatted files.  The
-    `genfromtxt` function provides more sophisticated handling of, e.g.,
-    lines with missing values.
-
-    Examples
-    --------
-    >>> from StringIO import StringIO   # StringIO behaves like a file object
-    >>> c = StringIO("0 1\n2 3")
-    >>> np.loadtxt(c)
-    array([[ 0.,  1.],
-           [ 2.,  3.]])
-
-    >>> d = StringIO("M 21 72\nF 35 58")
-    >>> np.loadtxt(d, dtype={'names': ('gender', 'age', 'weight'),
-    ...                      'formats': ('S1', 'i4', 'f4')})
-    array([('M', 21, 72.0), ('F', 35, 58.0)],
-          dtype=[('gender', '|S1'), ('age', '<i4'), ('weight', '<f4')])
-
-    >>> c = StringIO("1,0,2\n3,0,4")
-    >>> x, y = np.loadtxt(c, delimiter=',', usecols=(0, 2), unpack=True)
-    >>> x
-    array([ 1.,  3.])
-    >>> y
-    array([ 2.,  4.])
+...
 ~~~
 {: .output}
 
@@ -634,7 +559,8 @@ There's a lot of information here,
 but the most important part is the first couple of lines:
 
 ~~~
-loadtxt(fname, dtype=<type 'float'>, comments='#', delimiter=None, converters=None, skiprows=0, usecols=None, unpack=False, ndmin=0)
+loadtxt(fname, dtype=<class 'float'>, comments='#', delimiter=None, converters=None, skiprows=0, use
+cols=None, unpack=False, ndmin=0, encoding='bytes')
 ~~~
 {: .output}
 


### PR DESCRIPTION

* Fix long lines
* remove long output of 'help(numpy.loadtxt)'
* use Anaconda 3 (and Python 3.6) for one of the examples