### PR TITLE
01-numpy.md: simplify wording

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -193,13 +193,11 @@ weight in kilograms is now: 65.0
 > ![Updating a Variable](../fig/python-sticky-note-variables-03.svg)
 >
 > Since `weight_lb` doesn't remember where its value came from,
-> it isn't automatically updated when `weight_kg` changes.
+> it isn't updated when `weight_kg` changes.
 {: .callout}
 
-
-
 Words are useful, but what's more useful are the sentences and stories we build with them.
-Similarly, while a lot of powerful, general tools are built into languages like Python,
+Similarly, while a lot of powerful, general tools are built into Python,
 specialized tools built up from these basic units live in
 [libraries]({{ page.root }}/reference/#library)
 that can be called upon when needed.

--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -192,8 +192,8 @@ weight in kilograms is now: 65.0
 >
 > ![Updating a Variable](../fig/python-sticky-note-variables-03.svg)
 >
-> Since `weight_lb` doesn't remember where its value came from,
-> it isn't updated when `weight_kg` changes.
+> Since `weight_lb` doesn't "remember" where its value comes from,
+> it is not updated when we change `weight_kg`.
 {: .callout}
 
 Words are useful, but what's more useful are the sentences and stories we build with them.


### PR DESCRIPTION
1. `automatically` seems to be unnecessary as the main point is that `weight_lb` is not updated.
2. `languages like` seems to be not necessary either as at this point learners know that we're talking about Python and no need to generalize.
3. Removed two extra blank lines...