### PR TITLE
use floats instead of integers when introducing functions

### DIFF
--- a/_episodes/06-func.md
+++ b/_episodes/06-func.md
@@ -50,7 +50,7 @@ from Fahrenheit to Celsius:
 
 ~~~
 def fahr_to_celsius(temp):
-    return ((temp - 32) * (5/9))
+    return ((temp - 32.0) * (5.0/9.0))
 ~~~
 {: .language-python}
 
@@ -73,16 +73,16 @@ back to whoever asked for it.
 Let's try running our function.
 
 ~~~
-fahr_to_celsius(32)
+fahr_to_celsius(32.0)
 ~~~
 {: .language-python}
 
-This command should call our function, using "32" as the input and return the function value.
+This command should call our function, using "32.0" as the input and return the function value.
 
 In fact, calling our own function is no different from calling any other function:
 ~~~
-print('freezing point of water:', fahr_to_celsius(32), 'C')
-print('boiling point of water:', fahr_to_celsius(212), 'C')
+print('freezing point of water:', fahr_to_celsius(32.0), 'C')
+print('boiling point of water:', fahr_to_celsius(212.0), 'C')
 ~~~
 {: .language-python}
 
@@ -791,12 +791,12 @@ readable code!
 > k = 0
 >
 > def f2k(f):
->     k = ((f-32)*(5.0/9.0)) + 273.15
+>     k = ((f - 32.0)*(5.0/9.0)) + 273.15
 >     return k
 >
-> f2k(8)
-> f2k(41)
-> f2k(32)
+> f2k(8.0)
+> f2k(41.0)
+> f2k(32.0)
 >
 > print(k)
 > ~~~

--- a/fig/python-function.svg
+++ b/fig/python-function.svg
@@ -1,10 +1,10 @@
-<svg height="130" width="340" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg height="130" width="420" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <marker id="arrowhead" orient="auto" overflow="visible" refX="0" refY="0">
       <path d="m8.7 4-10.9-4 10.9-4c-1.7 2.4-1.7 5.6 0 8z" fill-rule="evenodd" stroke="#000" stroke-linejoin="round" stroke-width=".6" transform="scale(-.6)"/>
     </marker>
   </defs>
-  <text font-family="monospace" font-size="16" text-anchor="middle" x="34.2" xml:space="preserve" y="56.3"><tspan text-anchor="start" x="34.2" y="56.3"><tspan fill="#008000" font-weight="bold">def</tspan> <tspan fill="#00f">fahr_to_celsius</tspan><tspan fill="#6e5494">(temp):</tspan></tspan><tspan text-anchor="start" x="34.2" y="85.1">    <tspan fill="#008000" font-weight="bold">return</tspan> <tspan fill="#6e5494">((temp - 32) * (5/9))</tspan></tspan></text>
+  <text font-family="monospace" font-size="16" text-anchor="middle" x="34.2" xml:space="preserve" y="56.3"><tspan text-anchor="start" x="34.2" y="56.3"><tspan fill="#008000" font-weight="bold">def</tspan> <tspan fill="#00f">fahr_to_celsius</tspan><tspan fill="#6e5494">(temp):</tspan></tspan><tspan text-anchor="start" x="34.2" y="85.1">    <tspan fill="#008000" font-weight="bold">return</tspan> <tspan fill="#6e5494">((temp - 32.0) * (5.0/9.0))</tspan></tspan></text>
   <g fill="none" marker-end="url(#arrowhead)" pointer-events="none" stroke="#000" stroke-miterlimit="10">
     <path d="m66.1 14.7-14.7 21.7"/>
     <path d="m153.8 14.7-14.7 21.7"/>


### PR DESCRIPTION
Apart from changing the example, I have also changed examples further
below in the episode to floats instead of integers.

Motivation:

1) The previous code produced **wrong results** in Python 2.
In Python 2 these two functions do not produce the same result:

```python
def fahr_to_celsius(temp):
    return ((temp - 32) * (5/9))

def fahr_to_celsius_better(temp):
    return ((temp - 32.0) * (5.0/9.0))
```

I know we use Python 3 but I think it is not a good idea to introduce
code which produces a different result with Python 2 which still many
people and codes use.

2) Using decimals annotates to the reader that the function is expected
to work with floats, not only with integers.  If I see an example using
integers, I assume that the function expects integers. Of course this
may be in the category "personal taste".

3) The example is more consistent with the rest of the episode where in
"Composing Functions" we suddenly switch to floats.