### PR TITLE
Clarify lesson-episode term (Episode 1)

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -29,7 +29,7 @@ keypoints:
 - "Use the `pyplot` library from `matplotlib` for creating simple visualizations."
 ---
 
-In this lesson we will learn how to work with arthritis inflammation datasets in Python. However,
+In this episode we will learn how to work with arthritis inflammation datasets in Python. However,
 before we discuss how to deal with many data points, let's learn how to work with
 single data values.
 


### PR DESCRIPTION
Fixes episode/lesson term use in episode 1, following on from issue #602. Using 1 PR per episode as requested.
