### PR TITLE
episode 05 - another way to get start of string

### DIFF
--- a/_episodes/05-cond.md
+++ b/_episodes/05-cond.md
@@ -399,6 +399,16 @@ freeing us from having to manually examine every plot for features we've seen be
 > True
 > ~~~
 > {: .output}
+> Alternatively, we can use the [`list slicing`](http://swcarpentry.github.io/python-novice-inflammation/03-lists/index.html)
+> syntax that we saw earlier to check the start of a string:
+> ~~~
+> "String"[:3] == "Str"
+> ~~~
+> {: .language-python}
+> ~~~
+> True
+> ~~~
+> {: .output}
 > But
 > ~~~
 > "String".startswith("str")


### PR DESCRIPTION
Another way to compare the start of the string using list slicing.

This doesn't introduce any new conceptual burden as learners have already seen list slicing earlier.
I also think it's a more commonly used way to compare substrings, and also helps reinforces the concept of list slicing, which is very useful.
