### PR TITLE
Resolve iPython vs. Jupyter Notebook ambiguity

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -602,7 +602,7 @@ standard deviation: 4.61383319712
 > ## Mystery Functions in IPython
 >
 > How did we know what functions NumPy has and how to use them?
-> If you are working in the IPython/Jupyter Notebook, there is an easy way to find out.
+> If you are working in IPython or in a Jupyter Notebook, there is an easy way to find out.
 > If you type the name of something followed by a dot, then you can use tab completion
 > (e.g. type `numpy.` and then press tab)
 > to see a list of all functions and attributes that you can use. After selecting one, you
@@ -731,7 +731,7 @@ can see, inflammation rises and falls over a 40-day period.
 
 > ## Some IPython Magic
 >
-> If you're using an IPython / Jupyter notebook,
+> If you're using a Jupyter notebook,
 > you'll need to execute the following command
 > in order for your matplotlib images to appear
 > in the notebook when `show()` is called:


### PR DESCRIPTION
I propose to remove two places where there's ambiguity between IPython and Jupyter notebook.

In line 605: tab completion works both in IPython (command line) and in the IPython/Jupyter notebook.

Most importantly, line 734 caused a lot of confusion in a recent workshop I was helping at, where 3-4 participants thought using "%matplotlib inline" was needed for all IPython uses (it's appropriate only when using the Notebook). And using it in the command line IPython meant the interpreter could not find the backend, and plotted nothing.

It is unlikely new users today will find anything called "IPython notebook", since it's now called "Jupyter notebook", so I removed the ambiguity.