### PR TITLE
Add explanation of negative indexing before first usage

### DIFF
--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -55,7 +55,8 @@ last element: 7
 ~~~
 {: .output}
 
-Yes, we can use negative numbers as indices in Python. When we do so, the index `-1` gives us the last element in the list, `-2` the second to last, and so on.
+Yes, we can use negative numbers as indices in Python. When we do so, the index `-1` gives us the
+last element in the list, `-2` the second to last, and so on.
 Because of this, `odds[3]` and `odds[-1]` point to the same element here.
 
 If we loop over a list, the loop variable is assigned elements one at a time:

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -38,8 +38,8 @@ odds are: [1, 3, 5, 7]
 ~~~
 {: .output}
 
-We can select individual elements from lists by indexing them.
-Indexing allows us to access individual elements inside a container (such as list or string).
+We can access elements of a list using indices -- numbered positions of elements in the list.
+These positions are numbered starting at 0, so the first element has an index of 0.
 
 ~~~
 print('first and last:', odds[0], odds[3], odds[-1])
@@ -51,7 +51,7 @@ first and last: 1 7 7
 ~~~
 {: .output}
 
-We already saw how to use indexing to count elements starting from the beginning of the container, but we can also use negative indices to count backwards from the end.
+We already saw how to use indexing to count elements starting from the beginning of the list, but we can also use negative indices to count backwards from the end.
 Because of this, `odds[3]` and `odds[-1]` point to the same element here.
 
 If we loop over a list, the loop variable is assigned elements one at a time:

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -38,23 +38,23 @@ odds are: [1, 3, 5, 7]
 ~~~
 {: .output}
 
-We select individual elements from lists by indexing them.
+We can select individual elements from lists by indexing them.
 Indexing allows us to access individual elements inside a container (such as list or string).
-Previously, we used indexing to count elements starting from the beginning, but we can also count from the end of the container using negative indices.
-We will discuss this further when we come to the topic of "slicing":
 
 ~~~
-print('first and last:', odds[0], odds[-1])
+print('first and last:', odds[0], odds[3], odds[-1])
 ~~~
 {: .language-python}
 
 ~~~
-first and last: 1 7
+first and last: 1 7 7
 ~~~
 {: .output}
 
-and if we loop over a list,
-the loop variable is assigned elements one at a time:
+We already saw how to use indexing to count elements starting from the beginning of the container, but we can also use negative indices to count backwards from the end.
+Because of this, `odds[3]` and `odds[-1]` point to the same element here.
+
+If we loop over a list, the loop variable is assigned elements one at a time:
 
 ~~~
 for number in odds:

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -42,12 +42,16 @@ We can access elements of a list using indices -- numbered positions of elements
 These positions are numbered starting at 0, so the first element has an index of 0.
 
 ~~~
-print('first and last:', odds[0], odds[3], odds[-1])
+print('first element:', odd[0])
+print('last element:', odd[3])
+print('"-1" element:', odd[-1])
 ~~~
 {: .language-python}
 
 ~~~
-first and last: 1 7 7
+first element: 1
+last element: 7
+"-1" element: 7
 ~~~
 {: .output}
 

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -38,7 +38,10 @@ odds are: [1, 3, 5, 7]
 ~~~
 {: .output}
 
-We select individual elements from lists by indexing them:
+We select individual elements from lists by indexing them.
+Indexing allows us to access individual elements inside a container (such as list or string).
+Previously, we used indexing to count elements starting from the beginning, but we can also count from the end of the container using negative indices.
+We will discuss this further when we come to the topic of "slicing":
 
 ~~~
 print('first and last:', odds[0], odds[-1])
@@ -359,10 +362,10 @@ last: 4
 >
 > ~~~
 > string_for_slicing = "Observation date: 02-Feb-2013"
-> list_for_slicing = [["fluorine", "F"], 
->                     ["chlorine", "Cl"], 
->                     ["bromine", "Br"], 
->                     ["iodine", "I"], 
+> list_for_slicing = [["fluorine", "F"],
+>                     ["chlorine", "Cl"],
+>                     ["bromine", "Br"],
+>                     ["iodine", "I"],
 >                     ["astatine", "At"]]
 > ~~~
 > {: .language-python}
@@ -377,6 +380,8 @@ last: 4
 > the length of the string or list
 > (e.g. if you wanted to apply the solution to a set of lists of different lengths)?
 > If not, try to change your approach to make it more robust.
+>
+> Hint: Remember that indices can be negative as well as positive
 >
 > > ## Solution
 > > Use negative indices to count elements from the end of a container (such as list or string):

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -55,7 +55,7 @@ last element: 7
 ~~~
 {: .output}
 
-We already saw how to use indexing to count elements starting from the beginning of the list, but we can also use negative indices to count backwards from the end.
+Yes, we can use negative numbers as indices in Python. When we do so, the index `-1` gives us the last element in the list, `-2` the second to last, and so on.
 Because of this, `odds[3]` and `odds[-1]` point to the same element here.
 
 If we loop over a list, the loop variable is assigned elements one at a time:


### PR DESCRIPTION
At present, negative indexing is used in lesson 3 of `Programming with Python` before it is defined. This PR adds a short explanation of negative indexing before it is first used. The later explanation of negative indexing (in the section on slicing) now uses reminder of the earlier explanation as a hint.