### PR TITLE
Fix for Python 3

### DIFF
--- a/_episodes/06-func.md
+++ b/_episodes/06-func.md
@@ -821,7 +821,7 @@ readable code!
 > Given the following code:
 >
 > ~~~
-> def numbers(one, two=2, three, four=4):
+> def numbers(one, two=2, three=3, four=4):
 >     n = str(one) + str(two) + str(three) + str(four)
 >     return n
 >


### PR DESCRIPTION
In Python 3, you can't have non-default arguments followed by default arguments, as was presently implemented in the example. The old example returns a syntax error: `SyntaxError: non-default argument follows default argument`. The fix turns the offending default argument into a non-default argument, allowing the example to work.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
