### PR TITLE
[lists-loops branch] replace string loops with lists

### DIFF
--- a/_episodes/03-loop.md
+++ b/_episodes/03-loop.md
@@ -35,7 +35,7 @@ odds = [1, 3, 5, 7]
 
 We can access a number in the list using its index. For example,
 we can get the first
-number in the list `'odds'`,
+number in the list `odds`,
 by using `odds[0]`. One way to print each number is to use
 four `print` statements:
 
@@ -192,8 +192,8 @@ of the loop body (e.g. `end for`); what is indented after the `for` statement be
 Here's another loop that repeatedly updates a variable:
 
 ~~~
-names = ['Curie', 'Darwin', 'Turing']
 length = 0
+names = ['Curie', 'Darwin', 'Turing']
 for value in names:
     length = length + 1
 print('There are', length, 'names in the list.')
@@ -207,7 +207,7 @@ There are 3 names in the list.
 
 It's worth tracing the execution of this little program step by step.
 Since there are three names in `names`,
-the statement on line 3 will be executed three times.
+the statement on line 4 will be executed three times.
 The first time around,
 `length` is zero (the value assigned to it on line 1)
 and `value` is `Curie`.
@@ -221,7 +221,7 @@ After one more update,
 `length` is 3;
 since there is nothing left in `names` for Python to process,
 the loop finishes
-and the `print` statement on line 4 tells us our final answer.
+and the `print` statement on line 5 tells us our final answer.
 
 Note that a loop variable is just a variable that's being used to record progress in a loop.
 It still exists after the loop is over,
@@ -239,7 +239,7 @@ print('after the loop, name is', name)
 Curie
 Darwin
 Turing
-after the loop, name is 'Turing'
+after the loop, name is Turing
 ~~~
 {: .output}
 

--- a/_episodes/03-loop.md
+++ b/_episodes/03-loop.md
@@ -201,7 +201,7 @@ print('There are', length, 'names in the list.')
 {: .language-python}
 
 ~~~
-There are 3 elements in the list.
+There are 3 names in the list.
 ~~~
 {: .output}
 

--- a/_episodes/03-loop.md
+++ b/_episodes/03-loop.md
@@ -192,33 +192,34 @@ of the loop body (e.g. `end for`); what is indented after the `for` statement be
 Here's another loop that repeatedly updates a variable:
 
 ~~~
+names = ['Curie', 'Darwin', 'Turing']
 length = 0
-for vowel in 'aeiou':
+for value in names:
     length = length + 1
-print('There are', length, 'vowels')
+print('There are', length, 'names in the list.')
 ~~~
 {: .language-python}
 
 ~~~
-There are 5 vowels
+There are 3 elements in the list.
 ~~~
 {: .output}
 
 It's worth tracing the execution of this little program step by step.
-Since there are five characters in `'aeiou'`,
-the statement on line 3 will be executed five times.
+Since there are three names in `names`,
+the statement on line 3 will be executed three times.
 The first time around,
 `length` is zero (the value assigned to it on line 1)
-and `vowel` is `'a'`.
+and `value` is `Curie`.
 The statement adds 1 to the old value of `length`,
 producing 1,
 and updates `length` to refer to that new value.
 The next time around,
-`vowel` is `'e'` and `length` is 1,
+`value` is `Darwin` and `length` is 1,
 so `length` is updated to be 2.
-After three more updates,
-`length` is 5;
-since there is nothing left in `'aeiou'` for Python to process,
+After one more update,
+`length` is 3;
+since there is nothing left in `names` for Python to process,
 the loop finishes
 and the `print` statement on line 4 tells us our final answer.
 
@@ -227,31 +228,31 @@ It still exists after the loop is over,
 and we can re-use variables previously defined as loop variables as well:
 
 ~~~
-letter = 'z'
-for letter in 'abc':
-    print(letter)
-print('after the loop, letter is', letter)
+name = 'Rosalind'
+for name in ['Curie', 'Darwin', 'Turing']:
+    print(name)
+print('after the loop, name is', name)
 ~~~
 {: .language-python}
 
 ~~~
-a
-b
-c
-after the loop, letter is c
+Curie
+Darwin
+Turing
+after the loop, name is 'Turing'
 ~~~
 {: .output}
 
-Note also that finding the length of a string is such a common operation
+Note also that finding the length of an object is such a common operation
 that Python actually has a built-in function to do it called `len`:
 
 ~~~
-print(len('aeiou'))
+print(len([0, 1, 2, 3]))
 ~~~
 {: .language-python}
 
 ~~~
-5
+4
 ~~~
 {: .output}
 
@@ -322,20 +323,19 @@ so we should always use it when we can.
 > {: .solution}
 {: .challenge}
 
-> ## Reverse a String
+> ## Summing a list
 >
-> Knowing that two strings can be concatenated using the `+` operator,
-> write a loop that takes a string
-> and produces a new string with the characters in reverse order,
-> so `'Newton'` becomes `'notweN'`.
+> Write a loop that calculates the sum of elements in a list
+> by adding each element and printing the final value, 
+> so `[124, 402, 36]` prints 562
 >
 > > ## Solution
 > > ~~~
-> > newstring = ''
-> > oldstring = 'Newton'
-> > for char in oldstring:
-> >     newstring = char + newstring
-> > print(newstring)
+> > numbers = [124, 402, 36]
+> > summed = 0
+> > for num in numbers:
+> >     summed = summed + num
+> > print(summed)
 > > ~~~
 > > {: .language-python}
 > {: .solution}

--- a/_extras/extra_exercises.md
+++ b/_extras/extra_exercises.md
@@ -49,7 +49,7 @@ or not (yet) added to the main lesson.
 > > list and then unpacked into `left` and `right`.
 > {: .solution}
 {: .challenge}
-> 
+
 > ## Turn a String into a List
 >
 > Use a for-loop to convert the string "hello" into a list of letters:
@@ -72,6 +72,25 @@ or not (yet) added to the main lesson.
 > > for char in "hello":
 > > 	my_list.append(char)
 > > print(my_list)
+> > ~~~
+> > {: .language-python}
+> {: .solution}
+{: .challenge}
+
+> ## Reverse a String
+>
+> Knowing that two strings can be concatenated using the `+` operator,
+> write a loop that takes a string
+> and produces a new string with the characters in reverse order,
+> so `'Newton'` becomes `'notweN'`.
+>
+> > ## Solution
+> > ~~~
+> > newstring = ''
+> > oldstring = 'Newton'
+> > for char in oldstring:
+> >     newstring = char + newstring
+> > print(newstring)
 > > ~~~
 > > {: .language-python}
 > {: .solution}


### PR DESCRIPTION
Removing all looping over strings in the loops episode of the lists-loops episode swap branch to avoid adding in an extra concept to discuss that might not add enough value for learners. Going to read over this again to check for typos and clarity before marking it ready for review (set as a draft for now). Let me know if there's additional changes that could be made. Thanks!

In reference to #496 