### PR TITLE
03-lists.md: update explanation of list references

### DIFF
--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -272,7 +272,7 @@ If we make a list and (attempt to) copy it then modify in place, we can cause al
 ~~~
 odds = [1, 3, 5, 7]
 primes = odds
-primes.append(2)
+primes[0] = 2
 print('primes:', primes)
 print('odds:', odds)
 ~~~
@@ -291,7 +291,7 @@ not modify a list we did not mean to:
 ~~~
 odds = [1, 3, 5, 7]
 primes = list(odds)
-primes.append(2)
+primes[0] = 2
 print('primes:', primes)
 print('odds:', odds)
 ~~~

--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -279,8 +279,8 @@ print('odds:', odds)
 {: .language-python}
 
 ~~~
-primes: [1, 3, 5, 7, 2]
-odds: [1, 3, 5, 7, 2]
+primes: [2, 3, 5, 7]
+odds: [2, 3, 5, 7]
 ~~~
 {: .output}
 
@@ -298,7 +298,7 @@ print('odds:', odds)
 {: .language-python}
 
 ~~~
-primes: [1, 3, 5, 7, 2]
+primes: [2, 3, 5, 7]
 odds: [1, 3, 5, 7]
 ~~~
 {: .output}


### PR DESCRIPTION
The suggested code change for odds and primes would still serve the intended purpose of mutating a referenced vs copied list (replacing a member of the list rather than appending), while being consistent with the generally accepted definition of primality in which 1 is normally not considered a prime. In the case of reference we'll see:

primes: [2, 3, 5, 7]
odds: [2, 3, 5, 7]

and in the case of a copied list we'll see:

primes: [2, 3, 5, 7]
odds: [1, 3, 5, 7]

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
