### PR TITLE
Update 01-numpy.md

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -948,8 +948,8 @@ the graphs will actually be squeezed together more closely.)
 >
 > > ## Solution
 > > ~~~
-> > []
-> > []
+> > array([], shape=(0, 0), dtype=float64)
+> > array([], shape=(0, 40), dtype=float64)
 > > ~~~
 > > {: .output}
 > {: .solution}


### PR DESCRIPTION
Although it's true that data[3:3, 4:4] and data[3:3, :] return the empty array [], is that what we see on the output? It's array([], shape=(0, 0), dtype=float64) and array([], shape=(0, 40), dtype=float64) respectively. Should that be shown instead of [] and []? I could go either way on this but just wanted to raise it for your consideration.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
