### PR TITLE
add a callout that shows asserts are not used for user input

### DIFF
--- a/_episodes/08-defensive.md
+++ b/_episodes/08-defensive.md
@@ -560,5 +560,8 @@ This violates another important rule of programming:
 > > {: .language-python}
 > {: .solution}
 {: .challenge}
-
+An afternote: asserts are for debugging only
+Assertions are an excellent way to check program input during development, and this lesson has shown you how to use them to double check you expectations as a program runs. However, they are not designed for checking input from users in critical situations. This is because they can be turned off when you run python in optimised mode:
+{: .callout}
+{: .callout}
 {% include links.md %}

--- a/_episodes/08-defensive.md
+++ b/_episodes/08-defensive.md
@@ -560,8 +560,29 @@ This violates another important rule of programming:
 > > {: .language-python}
 > {: .solution}
 {: .challenge}
-An afternote: asserts are for debugging only
-Assertions are an excellent way to check program input during development, and this lesson has shown you how to use them to double check you expectations as a program runs. However, they are not designed for checking input from users in critical situations. This is because they can be turned off when you run python in optimised mode:
+
+> ## An after-note: asserts are for debugging only
+> Assertions are an excellent way to check a program during development, and this lesson has shown you
+> how to use them to double check you expectations as a program runs. However, they are not designed for checking input 
+> from users. This is because they can be easily turned off when you run python in optimised mode:
+> 
+> ~~~
+> python -O my_script.py # no asserts will be used 
+> ~~~
+> {: .language-bash}
+>
+> therefore in these cases you should replace each assert with an if statement and an Exception
+> 
+> ~~~
+> from math import sqrt
+>
+> def checked_sqrt(val):
+>    if val < 0.0:
+>       raise Exception("I can't take the square root of %i it's negative" % val)
+>    return sqrt(val)
+> ~~~
+> {: .language-python}
 {: .callout}
-{: .callout}
+
+
 {% include links.md %}


### PR DESCRIPTION
add a callout that shows asserts are not used for user input
---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
