### PR TITLE
setup.md: fix header and add instructions to install Anaconda

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -1,9 +1,18 @@
 ---
 layout: page
 title: Setup
-permalink: /setup/
+permalink: /setup/index.html
 root: ..
 ---
+
+### Install Python
+
+In this lesson we will be using Python 3 with some of its scientific libraries.
+Although one can install a "plain vanilla" Python 3 and all required libraries "by hand",
+we recommend installing [Anaconda][workshop-template-python-instructions], a Python distribution
+that comes with everything we need for the lesson.
+
+&nbsp; <!-- vertical spacer -->
 
 ### Obtain lesson materials
 
@@ -89,3 +98,4 @@ $ ipython
 
 [zipfile1]: {{ page.root }}/data/python-novice-inflammation-data.zip
 [zipfile2]: {{ page.root }}/code/python-novice-inflammation-code.zip
+[workshop-template-python-instructions]: https://carpentries.github.io/workshop-template/#python


### PR DESCRIPTION
Two changes:

1. add `index.html` to permalink.

Currently, the link to the setup page works correctly online, when the site is served (locally), but not when it is built with `jekyll build`. Addint `index.html` should solve the last problem.

2. Explicitly mention that one has to install Anaconda as the first step of the setup.
