### PR TITLE
07-errors.md: typo

### DIFF
--- a/_episodes/07-errors.md
+++ b/_episodes/07-errors.md
@@ -438,7 +438,7 @@ often reveals common reasons why you might get that error.
 >
 > 1.  How many levels does the traceback have?
 > 2.  What is the function name where the error occurred?
-> 3.  On which line number in this function did the error occurr?
+> 3.  On which line number in this function did the error occur?
 > 4.  What is the type of error?
 > 5.  What is the error message?
 >
@@ -552,7 +552,7 @@ often reveals common reasons why you might get that error.
 > {: .language-python}
 >
 > > ## Solution
-> > 3 `NameError`s for `number` being misspelled, for `message` not defined, 
+> > 3 `NameError`s for `number` being misspelled, for `message` not defined,
 > > and for `a` not being in quotes.
 > >
 > > Fixed version:


### PR DESCRIPTION
Obvious typo: occurr -> occur

My editor also stripped an empty whitespace at the end of another line which is not ideal (I prefer to make clean commits) but I'm going to leave it the way it is because I can never justify submitting a separate PR to remove unnecessary whitespace.