### PR TITLE
03-lists.md: Use `pop()` for consistency of method over statement

### DIFF
--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -243,13 +243,15 @@ odds after adding a value: [1, 3, 5, 7, 11]
 {: .output}
 
 ~~~
-del odds[0]
+removed_element = odds.pop(0)
 print('odds after removing the first element:', odds)
+print('removed_element:', removed_element)
 ~~~
 {: .language-python}
 
 ~~~
 odds after removing the first element: [3, 5, 7, 11]
+removed_element: 1
 ~~~
 {: .output}
 


### PR DESCRIPTION
This is a suggestion to resolve #669 . Since `del` is a statement, not a method/function, the unexplained difference in syntax may be confusing to learners. Using `pop` shows that you can remove a value from a list and make use of the value that was removed.