### PR TITLE
Moved note on importing numpy as np

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -237,6 +237,18 @@ array([[ 0.,  0.,  1., ...,  3.,  0.,  0.],
 ~~~
 {: .output}
 
+> ## Scientists Dislike Typing
+>
+> We will always use the syntax `import numpy` to import NumPy.
+> However, in order to save typing, it is
+> [often suggested](http://www.scipy.org/getting-started.html#an-example-script)
+> to make a shortcut like so: `import numpy as np`.
+> If you ever see Python code online using a NumPy function with `np`
+> (for example, `np.loadtxt(...)`), it's because they've used this shortcut.
+> When working with other people, it is important to agree on a convention of how common libraries
+> are imported.
+{: .callout}
+
 The expression `numpy.loadtxt(...)` is a [function call]({{ page.root }}/reference/#function-call)
 that asks Python to run the [function]({{ page.root }}/reference/#function) `loadtxt` which
 belongs to the `numpy` library. This [dotted notation]({{ page.root }}/reference/#dotted-notation)
@@ -833,18 +845,6 @@ what to draw for each one,
 and that we want a tight layout.
 (If we leave out that call to `fig.tight_layout()`,
 the graphs will actually be squeezed together more closely.)
-
-> ## Scientists Dislike Typing
->
-> We will always use the syntax `import numpy` to import NumPy.
-> However, in order to save typing, it is
-> [often suggested](http://www.scipy.org/getting-started.html#an-example-script)
-> to make a shortcut like so: `import numpy as np`.
-> If you ever see Python code online using a NumPy function with `np`
-> (for example, `np.loadtxt(...)`), it's because they've used this shortcut.
-> When working with other people, it is important to agree on a convention of how common libraries
-> are imported.
-{: .callout}
 
 > ## Check Your Understanding
 >

--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -218,8 +218,21 @@ Importing a library is like getting a piece of lab equipment out of a storage lo
 up on the bench. Libraries provide additional functionality to the basic Python package, much like
 a new piece of equipment adds functionality to a lab space. Just like in the lab, importing too
 many libraries can sometimes complicate and slow down your programs - so we only import what we
-need for each program. Once we've imported the library, we can ask the library to read our data
-file for us:
+need for each program. 
+
+> ## Scientists Dislike Typing
+>
+> We will always use the syntax `import numpy` to import NumPy.
+> However, in order to save typing, it is
+> [often suggested](http://www.scipy.org/getting-started.html#an-example-script)
+> to make a shortcut like so: `import numpy as np`.
+> If you ever see Python code online using a NumPy function with `np`
+> (for example, `np.loadtxt(...)`), it's because they've used this shortcut.
+> When working with other people, it is important to agree on a convention of how common libraries
+> are imported.
+{: .callout}
+
+Once we've imported the library, we can ask the library to read our data file for us:
 
 ~~~
 numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
@@ -236,18 +249,6 @@ array([[ 0.,  0.,  1., ...,  3.,  0.,  0.],
        [ 0.,  0.,  1., ...,  1.,  1.,  0.]])
 ~~~
 {: .output}
-
-> ## Scientists Dislike Typing
->
-> We will always use the syntax `import numpy` to import NumPy.
-> However, in order to save typing, it is
-> [often suggested](http://www.scipy.org/getting-started.html#an-example-script)
-> to make a shortcut like so: `import numpy as np`.
-> If you ever see Python code online using a NumPy function with `np`
-> (for example, `np.loadtxt(...)`), it's because they've used this shortcut.
-> When working with other people, it is important to agree on a convention of how common libraries
-> are imported.
-{: .callout}
 
 The expression `numpy.loadtxt(...)` is a [function call]({{ page.root }}/reference/#function-call)
 that asks Python to run the [function]({{ page.root }}/reference/#function) `loadtxt` which


### PR DESCRIPTION
The note explaining that libraries can be imported with a shorter name seems better placed at the point in the lesson where library imports are introduced.

When reviewing the lesson for the first time in preparation for teaching, when describing how to import I was surprised this wasn't introduced as pretty much every code example I see usual has import numpy as np, so I immediately thought this was a gap in the lesson.  But then I did find this note further down in the lesson which says everything that is needed, but it strikes me as rather tangential in its current position, but I think would be much more relevant in the position I've suggested as at this point import has just been used for the first time.