### PR TITLE
Remove the word "simple" from 06-func.md

### DIFF
--- a/_episodes/06-func.md
+++ b/_episodes/06-func.md
@@ -268,7 +268,7 @@ print(offset_mean(data, 0))
 {: .output}
 
 It's hard to tell from the default output whether the result is correct,
-but there are a few simple tests that will reassure us:
+but there are a few tests that we can run to reassure us:
 
 ~~~
 print('original min, mean, and max are:', numpy.min(data), numpy.mean(data), numpy.max(data))


### PR DESCRIPTION
I feel that using the word "simple" can be a bit dismissive. I don't think we can assume that novices would agree that the tests outlined would be simple for them to come up with when they're first starting out with Python. I think this can be reworded to convey a similar meaning without being as dismissive.