### PR TITLE
Update 08-defensive.md

### DIFF
--- a/_episodes/08-defensive.md
+++ b/_episodes/08-defensive.md
@@ -230,7 +230,7 @@ AssertionError: Calculated upper Y coordinate invalid
 {: .error}
 
 Re-reading our function,
-we realize that line 11 should divide `dy` by `dx` rather than `dx` by `dy`.
+we realize that line 14 should divide `dy` by `dx` rather than `dx` by `dy`.
 (You can display line numbers by typing Ctrl-M, then L.)
 If we had left out the assertion at the end of the function,
 we would have created and returned something that had the right shape as a valid answer,


### PR DESCRIPTION
The line to be corrected from:
~~~
scaled = float(dx) / dy
~~~
to:
~~~
scaled = float(dy) / dx
~~~
is on line number 14, not 11, if the `def` is on line 1.