### PR TITLE
Update 01-numpy.md: incorrect output from print(data.dtype)

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -344,7 +344,7 @@ are their daily inflammation measurements.
 > {: .language-python}
 >
 > ~~~
-> dtype('float64')
+> float64
 > ~~~
 > {: .output}
 >


### PR DESCRIPTION
Oddly, `print(data.dtype)` actually yields the output `float64` -- not `dtype('float64') -- whereas `data.dtype` yields `dtype('float64')`.

Since we are using print(...) throughout, for consistency, the output in this case should be `float64`.

Compare this behaviour with `print(type(data))` which gives `<class 'numpy.ndarray'>` vs `type(data)` which gives `numpy.ndarray`. Essentially the opposite behaviour with respect to output complexity.

Inconsistent on the part of the numpy developers. Perhaps a PR for NumPy itself.