### PR TITLE
setup.md: Return not Enter

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -38,7 +38,7 @@ $ cd ~/Desktop/swc-python/data
 {: .source}
 
 On Windows, you can use its native Command Prompt program.  The easiest way to start it up is by
-pressing <kbd>Windows Logo Key</kbd>+<kbd>R</kbd>, entering `cmd`, and hitting <kbd>Enter</kbd>. In
+pressing <kbd>Windows Logo Key</kbd>+<kbd>R</kbd>, entering `cmd`, and hitting <kbd>Return</kbd>. In
 the Command Prompt, use the following command to navigate to the `data` folder:
 ~~~
 $ cd /D %userprofile%\Desktop\swc-python\data


### PR DESCRIPTION
According to [this table in the lesson example](https://carpentries.github.io/lesson-example/06-style-guide/index.html#keyboard-key)
we ought to use `Return` instead of `Enter`.