### PR TITLE
Update 03-lists.md

### DIFF
--- a/_episodes/03-lists.md
+++ b/_episodes/03-lists.md
@@ -149,7 +149,8 @@ does not.
 >
 > ~~~
 > salsa = ['peppers', 'onions', 'cilantro', 'tomatoes']
-> my_salsa = list(salsa)        # <-- makes a *copy* of the list
+> import copy
+> my_salsa = copy.deepcopy(salsa)        # <-- makes a *copy* of the list
 > salsa[0] = 'hot peppers'
 > print('Ingredients in my salsa:', my_salsa)
 > ~~~


### PR DESCRIPTION
Changed instructions on copying lists.  Instead of using 
 ```python
my_salsa = list(salsa)
```
changed to 
```python
my_salsa = copy.deepcopy(salsa)
```

This is because using `list()` is less robust.  The goal was to generate a new list which could be modified, without changing the original list.

However, `list()` will not achieve this if the original list contains a nested list.  Whereas `deepcopy()` will work for any number of nested lists.

The following code illustrates this difference.

```python
TestList_1 = [1,"apple", ["NestedListItem1","NestedListItem2"]]
print('The original list:', TestList_1)
print('Now we use the list() function to create a new list, and change a non-nested element of the list.')
NewList_1 = list(TestList_1)
NewList_1[0] = 2
print('The new list:',NewList_1)
print('In this case the original list remains unchanged.')
print('The original list:',TestList_1)
print('However, now we change a nested element of the new list.')
NewList_1[2][0]= "ChangedNestedListItem1"
print('The new list:',NewList_1)
print('In this case the old list gets changed.')
print('The old list:',TestList_1)

import copy
print('This time do the same thing, but use copy.deepcopy() instead of list().')
TestList_1 = [1,"apple", ["NestedListItem1","NestedListItem2"]]
print('The original list:', TestList_1)
print('Now we use the copy.deepcopy() function to create a new list, and change a non-nested element of the list.')
NewList_1 = copy.deepcopy(TestList_1)
NewList_1[0] = 2
print('The new list:',NewList_1)
print('In this case the original list remains unchanged.')
print('The original list:',TestList_1)
print('However, now we change a nested element of the new list.')
NewList_1[2][0]= "ChangedNestedListItem1"
print('The new list:',NewList_1)
print('In this case the old list also remains unchanged.')
print('The old list:',TestList_1)
```