### PR TITLE
specify line color to blue

### DIFF
--- a/_episodes/01-numpy.md
+++ b/_episodes/01-numpy.md
@@ -763,7 +763,7 @@ Let's take a look at the average inflammation over time:
 
 ~~~
 ave_inflammation = numpy.mean(data, axis=0)
-ave_plot = matplotlib.pyplot.plot(ave_inflammation)
+ave_plot = matplotlib.pyplot.plot(ave_inflammation, 'b')
 matplotlib.pyplot.show()
 ~~~
 {: .language-python}
@@ -776,7 +776,7 @@ roughly linear rise and fall, which is suspicious: we might instead expect a sha
 fall.  Let's have a look at two other statistics:
 
 ~~~
-max_plot = matplotlib.pyplot.plot(numpy.max(data, axis=0))
+max_plot = matplotlib.pyplot.plot(numpy.max(data, axis=0), 'b')
 matplotlib.pyplot.show()
 ~~~
 {: .language-python}
@@ -784,7 +784,7 @@ matplotlib.pyplot.show()
 ![Maximum Value Along The First Axis](../fig/01-numpy_75_1.png)
 
 ~~~
-min_plot = matplotlib.pyplot.plot(numpy.min(data, axis=0))
+min_plot = matplotlib.pyplot.plot(numpy.min(data, axis=0), 'b')
 matplotlib.pyplot.show()
 ~~~
 {: .language-python}
@@ -1046,7 +1046,7 @@ the graphs will actually be squeezed together more closely.)
 >
 > > ## Solution
 > > ~~~
-> > std_plot = matplotlib.pyplot.plot(numpy.std(data, axis=0))
+> > std_plot = matplotlib.pyplot.plot(numpy.std(data, axis=0), 'b')
 > > matplotlib.pyplot.show()
 > > ~~~
 > > {: .language-python}


### PR DESCRIPTION
The plot generated by the original command might not be identical to the example images shown in the README and that may confuse the learners. I have added 'b' in the pyplot command to literally specify the line color to be blue so that the images generated by the command are identical to the example images in the README.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
