### PR TITLE
Change mean method in readings_03.py

### DIFF
--- a/code/readings_03.py
+++ b/code/readings_03.py
@@ -6,7 +6,7 @@ def main():
     script = sys.argv[0]
     for filename in sys.argv[1:]:
         data = numpy.loadtxt(filename, delimiter=',')
-        for m in data.mean(axis=1):
+        for m in numpy.mean(data, axis=1):
             print(m)
 
 


### PR DESCRIPTION
Issue #675, notes that in lesson 10, when it points to `readings_03.py`, the code shown in the lesson does not match the code that's in the `readings_03.py` file. The lesson shows the line `numpy.mean(data, axis=1)` while the file has `data.mean(axis=1)`. From a comment on the issue, it was recommended to change the file to match the lesson, since they should show the same code and SWC would prefer to teach functions over methods. This PR applies that change and fixes #675 