### PR TITLE
06-func.md: typo, function was renamed, not docstring

### DIFF
--- a/_episodes/06-func.md
+++ b/_episodes/06-func.md
@@ -382,7 +382,7 @@ help(offset_mean)
 {: .language-python}
 
 ~~~
-Help on function center in module __main__:
+Help on function offset_mean in module __main__:
 
 offset_mean(data, target_mean_value)
     Return a new array containing the original data with its mean offset to match the desired value.


### PR DESCRIPTION
requested [here](https://github.com/swcarpentry/python-novice-inflammation/pull/729/files#r342135330)