### PR TITLE
Fix 'Computing the Value of a Polynomial' exercise

### DIFF
--- a/_episodes/03-loop.md
+++ b/_episodes/03-loop.md
@@ -390,12 +390,13 @@ so we should always use it when we can.
 > ~~~
 > x = 5
 > coefs = [2, 4, 3]
+> y = coefs[0] * x**0 + coefs[1] * x**1 + coefs[2] * x**2
+> print(y)
 > ~~~
 > {: .language-python}
 >
 > ~~~
-> y = coefs[0] * x**0 + coefs[1] * x**1 + coefs[2] * x**2
-> y = 97
+> 97
 > ~~~
 > {: .output}
 >


### PR DESCRIPTION
The Output block in this exercise contains two assignments to the variable y, which neither looks like an Output nor does it follow from the preceding Python block when run.

I believe the first assignment to y was intended to be part of the Python block, and I also believe the intent was to print the value of y, which is 97, instead of assigning 97 to it in the Output block.

This commit does the following:
- moves the first y assignment from the Output block into the Python block
- adds a print(y) statement to the end of the Python block
- removes the assignment from the y = 97 line, so that the Output block matches the output of the edited Python block when it is run.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
