### PR TITLE
Clarification of 1.0 v 1.

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -89,8 +89,8 @@ that output is the data we just loaded.
 By default,
 only a few rows and columns are shown
 (with `...` to omit elements when displaying big arrays).
-To save space,
-Python displays numbers as `1.` instead of `1.0`
+To save space on the screen
+when printing a numpy array, numbers will be displayed as `1.` instead of `1.0`
 when there's nothing interesting after the decimal point.
 
 > ## Importing libraries with shortcuts

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -89,9 +89,7 @@ that output is the data we just loaded.
 By default,
 only a few rows and columns are shown
 (with `...` to omit elements when displaying big arrays).
-To save space on the screen
-when printing a numpy array, numbers will be displayed as `1.` instead of `1.0`
-when there's nothing interesting after the decimal point.
+To save space on the screen when displaying a NumPy array, numbers are shown as `1.` instead of `1.0` when there's nothing interesting after the decimal point.
 
 > ## Importing libraries with shortcuts
 >

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -89,7 +89,7 @@ that output is the data we just loaded.
 By default,
 only a few rows and columns are shown
 (with `...` to omit elements when displaying big arrays).
-To save space on the screen when displaying a NumPy array, numbers are shown as `1.` instead of `1.0` when there's nothing interesting after the decimal point.
+Note that, to save space when displaying NumPy arrays, Python does not show us trailing zeros, so "1.0" becomes "1.".
 
 > ## Importing libraries with shortcuts
 >

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -89,7 +89,7 @@ that output is the data we just loaded.
 By default,
 only a few rows and columns are shown
 (with `...` to omit elements when displaying big arrays).
-Note that, to save space when displaying NumPy arrays, Python does not show us trailing zeros, so "1.0" becomes "1.".
+Note that, to save space when displaying NumPy arrays, Python does not show us trailing zeros, so `1.0` becomes `1.`.
 
 > ## Importing libraries with shortcuts
 >


### PR DESCRIPTION
The previous explanation implies that Python will always print 1.0 as "1." when there's nothing after the decimal point. However, this is specific to numpy. For example, the statement "print(1.0)" will print "1.0" and not "1.". I changed the description to refer to a numpy array instead of Python in general. I also clarified the space saved was on the screen (rather than in memory, for example).