### PR TITLE
Updating 02-numpy numpy.diff example to use patient data

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -665,15 +665,15 @@ which is the average inflammation per patient across all days.
 > with NumPy.
 >
 > The `numpy.diff()` function takes an array and returns the differences
-> between two successive values. We would like to use it to examine the changes
+> between two successive values. Let's use it to examine the changes
 > each day across the first week of patient 3 from our inflammation dataset.
 > 
 > ~~~
-> row_start = data[3, :7] 
+> patient3_week1 = data[3, :7] 
 > ~~~
 > {: .language-python}
 >
-> Calling `numpy.diff(row_start)` would do the following calculations
+> Calling `numpy.diff(patient3_week1)` would do the following calculations
 >
 > ~~~
 > [ 0 - 0, 2 - 0, 0 - 2, 4 - 0, 2 - 4, 2 - 2 ]
@@ -683,7 +683,7 @@ which is the average inflammation per patient across all days.
 > and return the 6 difference values in a new array.
 >
 > ~~~
-> numpy.diff(row_start)
+> numpy.diff(patient3_week1)
 > ~~~
 > {: .language-python}
 >
@@ -695,9 +695,8 @@ which is the average inflammation per patient across all days.
 > Note that the array of differences is shorter by one element (length 6).
 >
 > When calling `numpy.diff` with a multi-dimensional array, an `axis` argument may
-> be passed to the function to specify which axis that the function would process.
-> When applying `numpy.diff` to our 2D inflammation array `data`, which axis
-> would we specify?
+> be passed to the function to specify which axis to process. When applying 
+> `numpy.diff` to our 2D inflammation array `data`, which axis would we specify?
 >
 > > ## Solution
 > > Since the row axis (0) is patients, it does not make sense to get the

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -669,9 +669,15 @@ which is the average inflammation per patient across all days.
 > each day across the first week of patient 3 from our inflammation dataset.
 > 
 > ~~~
-> patient3_week1 = data[3, :7] 
+> patient3_week1 = data[3, :7]
+> print(patient3_week1)
 > ~~~
 > {: .language-python}
+>
+> ~~~
+>  [0. 0. 2. 0. 4. 2. 2.]
+> ~~~
+> {: .output}
 >
 > Calling `numpy.diff(patient3_week1)` would do the following calculations
 >

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -688,7 +688,7 @@ which is the average inflammation per patient across all days.
 > {: .language-python}
 >
 > ~~~
-> array([ 0,  2, -2,  4, -2,  0])
+> array([ 0.,  2., -2.,  4., -2.,  0.])
 > ~~~
 > {: .output}
 >

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -665,23 +665,22 @@ which is the average inflammation per patient across all days.
 > with NumPy.
 >
 > The `numpy.diff()` function takes an array and returns the differences
-> between two successive values. First we consider a one-dimensional
-> array of length 5. This could be part of some row `i` of our inflammation data,
-> i.e. `row_start = data[i,:5]`.
->
+> between two successive values. We would like to use it to examine the changes
+> each day across the first week of patient 3 from our inflammation dataset.
+> 
 > ~~~
-> row_start = numpy.array([ 0,  2,  5,  9, 14])
+> row_start = data[3, :7] 
 > ~~~
 > {: .language-python}
 >
 > Calling `numpy.diff(row_start)` would do the following calculations
 >
 > ~~~
-> [ 2 - 0, 5 - 2, 9 - 5, 14 - 9 ]
+> [ 0 - 0, 2 - 0, 0 - 2, 4 - 0, 2 - 4, 2 - 2 ]
 > ~~~
 > {: .language-python}
 >
-> and return the 4 difference values in a new array.
+> and return the 6 difference values in a new array.
 >
 > ~~~
 > numpy.diff(row_start)
@@ -689,14 +688,16 @@ which is the average inflammation per patient across all days.
 > {: .language-python}
 >
 > ~~~
-> array([2, 3, 4, 5])
+> array([ 0,  2, -2,  4, -2,  0])
 > ~~~
 > {: .output}
 >
-> Note that the array of differences is shorter by one element (length 4).
+> Note that the array of differences is shorter by one element (length 6).
 >
+> When calling `numpy.diff` with a multi-dimensional array, an `axis` argument may
+> be passed to the function to specify which axis that the function would process.
 > When applying `numpy.diff` to our 2D inflammation array `data`, which axis
-> would it make sense to use this function along?
+> would we specify?
 >
 > > ## Solution
 > > Since the row axis (0) is patients, it does not make sense to get the


### PR DESCRIPTION
This is a pull request for issue https://github.com/swcarpentry/python-novice-inflammation/issues/780

Change the lesson example from using random data to using patient 3 week 1 data from the included inflammation dataset. Variable name has also been changed to be more descriptive of the data it contains.

Question in the 2D array `numpy.diff` example added introduction to `axis` argument.

