### PR TITLE
provide detailed alt text to intro image 01.

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -139,7 +139,7 @@ weight in kilograms is now: 65.0
 > A variable is analogous to a sticky note with a name written on it:
 > assigning a value to a variable is like putting that sticky note on a particular value.
 >
-> ![Variables as Sticky Notes](../fig/python-sticky-note-variables-01.svg)
+> ![Value of 65.0 with weight_kg name stuck on it](../fig/python-sticky-note-variables-01.svg)
 >
 > This means that assigning a value to one variable does **not** change
 > values of other variables.


### PR DESCRIPTION
Variables as Sticky Notes now has a detailed content: ../fig/python-sticky-note-variables-01.svg

Related to https://github.com/swcarpentry/python-novice-inflammation/issues/781

Note: Followed the recommendations at: https://webaim.org/techniques/alttext/#basics trying to be as specific as possible for the content and the function.

- [x] `01-intro.md > ![Variables as Sticky Notes](../fig/python-sticky-note-variables-01.svg)`