### PR TITLE
provide detailed alt text to numpy image 02.

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -437,7 +437,8 @@ next diagram on the left) or the average for each day (as in the
 diagram on the right)? As the diagram below shows, we want to perform the
 operation across an axis:
 
-![Operations Across Axes](../fig/python-operations-across-axes.png)
+![Per-patient maximum inflammation is computed row-wise across all columns using numpy.max(data, axis=1).
+Per-day average inflammation is computed column-wise across all rows using numpy.mean(data, axis=0).](../fig/python-operations-across-axes.png)
 
 To support this functionality,
 most array functions allow us to specify the axis we want to work on.


### PR DESCRIPTION
Operations across axes now has a detailed content: ../fig/python-operations-across-axes.png

Related to https://github.com/swcarpentry/python-novice-inflammation/issues/781

Note: Followed the recommendations at: https://webaim.org/techniques/alttext/#basics trying to be as specific as possible for the content and the function.

- [x] `02-numpy.md > ![Operations Across Axes](../fig/python-operations-across-axes.png)`