### PR TITLE
provide detailed alt text to func image 01.

### DIFF
--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -54,7 +54,7 @@ def fahr_to_celsius(temp):
 ~~~
 {: .language-python}
 
-![The Blueprint for a Python Function](../fig/python-function.svg)
+![Labeled parts of a Python function definition](../fig/python-function.svg)
 
 
 The function definition opens with the keyword `def` followed by the


### PR DESCRIPTION
Python function structure image now has a detailed description: ../fig/python-function.svg

Related to https://github.com/swcarpentry/python-novice-inflammation/issues/781

Note: Followed the recommendations at: https://webaim.org/techniques/alttext/#basics trying to be as specific as possible for the content and the function.

- [x] `08-func.md > ![The Blueprint for a Python Function](../fig/python-function.svg)`