### PR TITLE
provide detailed alt text to numpy image 01 - Zero Index .

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -242,7 +242,10 @@ It takes a bit of getting used to,
 but one way to remember the rule is that
 the index is how many steps we have to take from the start to get the item we want.
 
-![Zero Index](../fig/python-zero-index.png)
+![data array variable illustrating the 0 based index. For a data array variable equal to 
+data = \[\['A','B','C'\],\['D','E','F'\],\['G','H','I'\]\] data\[0\]\[0\]='A', data\[0\]\[1\]='B', 
+data\[0\]\[2\]='C', data\[1\]\[0\]='D', data\[1\]\[1\]='E', data\[1\]\[2\]='F', 
+data\[2\]\[0\]='G', data\[2\]\[1\]='H', data\[2\]\[2\]='I'](../fig/python-zero-index.png)
 
 > ## In the Corner
 >


### PR DESCRIPTION
Zero Index now has a detailed content: ../fig/python-zero-index.png

Related to https://github.com/swcarpentry/python-novice-inflammation/issues/781

Note: Followed the recommendations at: https://webaim.org/techniques/alttext/#basics trying to be as specific as possible for the content and the function.

- [x] `02-numpy.md > ![Zero Index](../fig/python-zero-index.png)`