### PR TITLE
provide detailed alt text to intro image 03.

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -172,7 +172,7 @@ weight in kilograms is now: 65.0
 > ~~~
 > {: .output}
 >
-> ![Updating a Variable](../fig/python-sticky-note-variables-03.svg)
+> ![Value of 100.0 with label weight_kg stuck on it, and value of 143.0 with label weight_lb stuck on it](../fig/python-sticky-note-variables-03.svg)
 >
 > Since `weight_lb` doesn't "remember" where its value comes from,
 > it is not updated when we change `weight_kg`.


### PR DESCRIPTION
Additional variables as Sticky Notes now has a detailed content: ../fig/python-sticky-note-variables-03.svg

Related to https://github.com/swcarpentry/python-novice-inflammation/issues/781

Note: Followed the recommendations at: https://webaim.org/techniques/alttext/#basics trying to be as specific as possible for the content and the function.

- [x] `01-intro.md > ![Updating a Variable](../fig/python-sticky-note-variables-03.svg)`