### PR TITLE
fix SyntaxError in function exercise

### DIFF
--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -841,7 +841,7 @@ readable code!
 > Given the following code:
 >
 > ~~~
-> def numbers(one, two=2, three, four=4):
+> def numbers(one, two=2, three=3, four=4):
 >     n = str(one) + str(two) + str(three) + str(four)
 >     return n
 >


### PR DESCRIPTION
otherwise, `non-default argument follows default argument` is raised