### PR TITLE
Add notebook to references

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -82,7 +82,7 @@ a line. These both need to be character strings (or [strings]({{ page.root }}/re
 for short), so we put them in quotes.
 
 Since we haven't told it to do anything else with the function's output,
-the notebook displays it.
+the [notebook]({{page.root}}/reference/#notebook) displays it.
 In this case,
 that output is the data we just loaded.
 By default,

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -82,7 +82,7 @@ a line. These both need to be character strings (or [strings]({{ page.root }}/re
 for short), so we put them in quotes.
 
 Since we haven't told it to do anything else with the function's output,
-the [notebook]({{page.root}}/reference/#notebook) displays it.
+the [notebook]({{ page.root }}/reference/#notebook) displays it.
 In this case,
 that output is the data we just loaded.
 By default,

--- a/reference.md
+++ b/reference.md
@@ -161,6 +161,10 @@ mutable
 :   Changeable. The value of mutable data can be altered after it has been
     created. See [immutable](#immutable)."
 
+notebook
+:   Interactive computational environment in your web browser, in which you can write and execute Python code.
+    Examples are IPython or Jupyter notebooks
+
 object
 :   A collection of conceptually related variables ([members](#member)) and
     functions using those variables ([methods](#method)).

--- a/reference.md
+++ b/reference.md
@@ -162,8 +162,9 @@ mutable
     created. See [immutable](#immutable)."
 
 notebook
-:   Interactive computational environment in your web browser, in which you can write and execute Python code.
-    Examples are IPython or Jupyter notebooks
+:   Interactive computational environment accessed via your web browser, in which you can write and execute Python code and
+    combine it with explanatory text, mathematics and visualizations.
+    Examples are IPython or Jupyter notebooks.
 
 object
 :   A collection of conceptually related variables ([members](#member)) and

--- a/reference.md
+++ b/reference.md
@@ -162,8 +162,8 @@ mutable
     created. See [immutable](#immutable)."
 
 notebook
-:   Interactive computational environment accessed via your web browser, in which you can write and execute Python code and
-    combine it with explanatory text, mathematics and visualizations.
+:   Interactive computational environment accessed via your web browser, in which you can write 
+    and execute Python code and combine it with explanatory text, mathematics and visualizations.
     Examples are IPython or Jupyter notebooks.
 
 object


### PR DESCRIPTION
I would suggest to link the term notebook in the second episode to an entry in the reference section which I added in this Pull request. The term has not been introduced before and some students might not know what it refers to.
