### PR TITLE
Close Enough correction for 07-cond.md

### DIFF
--- a/_episodes/07-cond.md
+++ b/_episodes/07-cond.md
@@ -313,7 +313,7 @@ freeing us from having to manually examine every plot for features we've seen be
 > > a = 5
 > > b = 5.1
 > >
-> > if abs(a - b) < 0.1 * abs(b):
+> > if abs(a - b) <= 0.1 * abs(b):
 > >     print('True')
 > > else:
 > >     print('False')
@@ -323,7 +323,7 @@ freeing us from having to manually examine every plot for features we've seen be
 >
 > > ## Solution 2
 > > ~~~
-> > print(abs(a - b) < 0.1 * abs(b))
+> > print(abs(a - b) <= 0.1 * abs(b))
 > > ~~~
 > > {: .language-python}
 > >


### PR DESCRIPTION
`print(abs(a - b) < 0.1 * abs(b))` (and preceding Solution 2) leaves out the edge case where `a` is exactly 10% of `b`. This issue comes down to the interpretation of "within" 10%. Does a number within 10% of another number include the 10% value? 

Assume `b = 100` and `0.1 * b = 10`, then the value 10 is within 10% by definition since 10 is 10% of 100. Now set `a = 100 + 10 = 110` which is `b` plus 10% of `b`. Then `a - b = b + 0.1 * b - b = 0.1 * b`, which is within 10% of b.

The correct test is `abs(a - b) <= 0.1 * abs(b)` to account for this edge case.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
