### PR TITLE
Adding a Default Action in 12-cmdline.md solution fails on piped stdin

### DIFF
--- a/_episodes/12-cmdline.md
+++ b/_episodes/12-cmdline.md
@@ -873,13 +873,17 @@ the program now does everything we set out to do.
 > >
 > > def main():
 > >     script = sys.argv[0]
-> >     action = sys.argv[1]
-> >     if action not in ['--min', '--mean', '--max']: # if no action given
-> >         action = '--mean'    # set a default action, that being mean
-> >         filenames = sys.argv[1:] # start the filenames one place earlier in the argv list
+> >     if len(sys.argv) == 1: # there are no args but there may be a pipe
+> >         action = '--mean'  # set default action to --mean
+> >         filenames = []     # try stdin
 > >     else:
-> >         filenames = sys.argv[2:]
-> >
+> >         action = sys.argv[1] # it's safe now to get action argument
+> >         if action not in ['--min', '--mean', '--max']: # if other action given
+> >             action = '--mean'    # set default action to --mean
+> >             filenames = sys.argv[1:] # start one place earlier in the argv list
+> >         else:
+> >             filenames = sys.argv[2:]
+> > 
 > >     if len(filenames) == 0:
 > >         process(sys.stdin, action)
 > >     else:


### PR DESCRIPTION
Solution `readings09.py` fails on piped stdin and no action argument:
``` bash
python ../code/readings_09.py < small-01.csv
Traceback (most recent call last):
  File "../code/readings_09.py", line 33, in <module>
    main()
  File "../code/readings_09.py", line 7, in main
    action = sys.argv[1]
IndexError: list index out of range
```
This error occurs because there is no argument for action or filename. The fix adds a conditional test to handle the case where no args exist. 

The `readings_09.py` file in the `code` folder would also need to be updated for this fix.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
