### PR TITLE
Added storing plot to a file to Matplotlib example

### DIFF
--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -103,6 +103,7 @@ axes3.plot(numpy.min(data, axis=0))
 
 fig.tight_layout()
 
+matplotlib.pyplot.savefig('inflammation.png')
 matplotlib.pyplot.show()
 ~~~
 {: .language-python}
@@ -117,6 +118,13 @@ what to draw for each one,
 and that we want a tight layout.
 (If we leave out that call to `fig.tight_layout()`,
 the graphs will actually be squeezed together more closely.)
+
+The call to `savefig` stores the plot as a graphics file. This can be
+a convenient way to store your plots for use in other documents, web
+pages etc. The graphics format is automatically determined by
+Matplotlib from the file name ending we specify; here PNG from
+'inflammation.png'. Matplotlib supports many different graphics
+formats, including SVG, PDF, and JPEG.
 
 
 > ## Plot Scaling


### PR DESCRIPTION
As requested in #833, this addition shows an example of how to save a
Matplotlib plot as a graphics file.

<details>
I intended to keep it as short and simple as possible.
I have added a line storing the plot to file *before* the last line `show()`. If the user is not plotting in interactive mode, then the user will have to close the shown plot before the script continues and in that case, there is no plot to store afterwards. Therefore, it is safer to store the plot before we show it.
</details>
