### PR TITLE
resolve #848 - use double triple quotes for docstrings

### DIFF
--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -343,8 +343,8 @@ that string is attached to the function as its documentation:
 
 ~~~
 def offset_mean(data, target_mean_value):
-    '''Return a new array containing the original data
-       with its mean offset to match the desired value.'''
+    """Return a new array containing the original data
+       with its mean offset to match the desired value."""
     return (data - numpy.mean(data)) + target_mean_value
 ~~~
 {: .language-python}
@@ -372,14 +372,14 @@ we can break the string across multiple lines:
 
 ~~~
 def offset_mean(data, target_mean_value):
-    '''Return a new array containing the original data
+    """Return a new array containing the original data
        with its mean offset to match the desired value.
 
     Examples
     --------
     >>> offset_mean([1, 2, 3], 0)
     array([-1.,  0.,  1.])
-    '''
+    """
     return (data - numpy.mean(data)) + target_mean_value
 
 help(offset_mean)
@@ -453,14 +453,14 @@ let's re-define our `offset_mean` function like this:
 
 ~~~
 def offset_mean(data, target_mean_value=0.0):
-    '''Return a new array containing the original data
+    """Return a new array containing the original data
        with its mean offset to match the desired value, (0 by default).
 
     Examples
     --------
     >>> offset_mean([1, 2, 3])
     array([-1.,  0.,  1.])
-    '''
+    """
     return (data - numpy.mean(data)) + target_mean_value
 ~~~
 {: .language-python}
@@ -766,7 +766,7 @@ readable code!
 >
 > > ## Solution
 > > ~~~
-> > '''Takes an array as input, and returns a corresponding array scaled so
+> > """Takes an array as input, and returns a corresponding array scaled so
 > > that 0 corresponds to the minimum and 1 to the maximum value of the input array.
 > >
 > > Examples:
@@ -775,7 +775,7 @@ readable code!
 > >        0.55555556,  0.66666667,  0.77777778,  0.88888889,  1.        ])
 > > >>> rescale(numpy.linspace(0, 100, 5))
 > > array([ 0.  ,  0.25,  0.5 ,  0.75,  1.  ])
-> > '''
+> > """
 > > ~~~
 > > {: .language-python}
 > {: .solution}
@@ -791,7 +791,7 @@ readable code!
 > > ## Solution
 > > ~~~
 > > def rescale(input_array, low_val=0.0, high_val=1.0):
-> >     '''rescales input array values to lie between low_val and high_val'''
+> >     """rescales input array values to lie between low_val and high_val"""
 > >     L = numpy.min(input_array)
 > >     H = numpy.max(input_array)
 > >     intermed_array = (input_array - L) / (H - L)

--- a/_episodes/10-defensive.md
+++ b/_episodes/10-defensive.md
@@ -118,10 +118,10 @@ but checks that its input is correctly formatted and that its result makes sense
 
 ~~~
 def normalize_rectangle(rect):
-    '''Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.
+    """Normalizes a rectangle so that it is at the origin and 1.0 units long on its longest axis.
     Input should be of the format (x0, y0, x1, y1).
     (x0, y0) and (x1, y1) define the lower left and upper right corners
-    of the rectangle, respectively.'''
+    of the rectangle, respectively."""
     assert len(rect) == 4, 'Rectangles must contain 4 coordinates'
     x0, y0, x1, y1 = rect
     assert x0 < x1, 'Invalid X coordinates'
@@ -158,7 +158,7 @@ AssertionError                            Traceback (most recent call last)
 
 <ipython-input-1-c94cf5b065b9> in normalize_rectangle(rect)
       4     (x0, y0) and (x1, y1) define the lower left and upper right corners
-      5     of the rectangle, respectively.'''
+      5     of the rectangle, respectively."""
 ----> 6     assert len(rect) == 4, 'Rectangles must contain 4 coordinates'
       7     x0, y0, x1, y1 = rect
       8     assert x0 < x1, 'Invalid X coordinates'
@@ -403,7 +403,7 @@ but we're now ready to do so:
 
 ~~~
 def range_overlap(ranges):
-    '''Return common overlap among a set of [left, right] ranges.'''
+    """Return common overlap among a set of [left, right] ranges."""
     max_left = 0.0
     min_right = 1.0
     for (left, right) in ranges:

--- a/_episodes/12-cmdline.md
+++ b/_episodes/12-cmdline.md
@@ -749,7 +749,7 @@ the program now does everything we set out to do.
 > > import glob
 > >
 > > def main():
-> >     '''prints names of all files with sys.argv as suffix'''
+> >     """prints names of all files with sys.argv as suffix"""
 > >     assert len(sys.argv) >= 2, 'Argument list cannot be empty'
 > >     suffix = sys.argv[1] # NB: behaviour is not as you'd expect if sys.argv[1] is *
 > >     glob_input = '*.' + suffix # construct the input
@@ -962,8 +962,8 @@ the program now does everything we set out to do.
 > > import sys
 > >
 > > def main():
-> >     '''print each input filename and the number of lines in it,
-> >        and print the sum of the number of lines'''
+> >     """print each input filename and the number of lines in it,
+> >        and print the sum of the number of lines"""
 > >     filenames = sys.argv[1:]
 > >     sum_nlines = 0 #initialize counting variable
 > >
@@ -978,14 +978,14 @@ the program now does everything we set out to do.
 > >         print('total: %d' % sum_nlines)
 > >
 > > def count_file(filename):
-> >     '''count the number of lines in a file'''
+> >     """count the number of lines in a file"""
 > >     f = open(filename,'r')
 > >     nlines = len(f.readlines())
 > >     f.close()
 > >     return(nlines)
 > >
 > > def count_file_like(file_like):
-> >     '''count the number of lines in a file-like object (eg stdin)'''
+> >     """count the number of lines in a file-like object (eg stdin)"""
 > >     n = 0
 > >     for line in file_like:
 > >         n = n+1


### PR DESCRIPTION
Replaced single triple quotes by double triple quotes for Python docstrings in episodes 8, 10, and 12.