### PR TITLE
02-numpy.md: wrap 'tab' in <kbd> HTML tag

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -386,7 +386,7 @@ standard deviation: 4.61383319712
 > How did we know what functions NumPy has and how to use them?
 > If you are working in IPython or in a Jupyter Notebook, there is an easy way to find out.
 > If you type the name of something followed by a dot, then you can use tab completion
-> (e.g. type `numpy.` and then press tab)
+> (e.g. type `numpy.` and then press <kbd>Tab</kbd>)
 > to see a list of all functions and attributes that you can use. After selecting one, you
 > can also add a question mark (e.g. `numpy.cumprod?`), and IPython will return an
 > explanation of the method! This is the same as doing `help(numpy.cumprod)`.


### PR DESCRIPTION
Noticed one instance where we don't follow recommended guidelines for keyboard keys (https://carpentries.github.io/lesson-example/06-style-guide/index.html#keyboard-key)
