### PR TITLE
Update episode 5 double-quotes to single-quotes

### DIFF
--- a/_episodes/05-lists.md
+++ b/_episodes/05-lists.md
@@ -377,7 +377,7 @@ last: 4
 > {: .language-python}
 >
 > ~~~
-> 2013
+> '2013'
 > [['chlorine', 'Cl'], ['bromine', 'Br'], ['iodine', 'I'], ['astatine', 'At']]
 > ~~~
 > {: .output}

--- a/_episodes/05-lists.md
+++ b/_episodes/05-lists.md
@@ -311,7 +311,7 @@ odds: [1, 3, 5, 7]
 > Use a for-loop to convert the string "hello" into a list of letters:
 >
 > ~~~
-> ["h", "e", "l", "l", "o"]
+> ['h', 'e', 'l', 'l', 'o']
 > ~~~
 > {: .language-python}
 >
@@ -325,7 +325,7 @@ odds: [1, 3, 5, 7]
 > > ## Solution
 > > ~~~
 > > my_list = []
-> > for char in "hello":
+> > for char in 'hello':
 > >     my_list.append(char)
 > > print(my_list)
 > > ~~~
@@ -338,26 +338,26 @@ similar to how we accessed ranges of positions in a NumPy array.
 This is commonly referred to as "slicing" the list/string.
 
 ~~~
-binomial_name = "Drosophila melanogaster"
+binomial_name = 'Drosophila melanogaster'
 group = binomial_name[0:10]
-print("group:", group)
+print('group:', group)
 
 species = binomial_name[11:23]
-print("species:", species)
+print('species:', species)
 
-chromosomes = ["X", "Y", "2", "3", "4"]
+chromosomes = ['X', 'Y', '2', '3', '4']
 autosomes = chromosomes[2:5]
-print("autosomes:", autosomes)
+print('autosomes:', autosomes)
 
 last = chromosomes[-1]
-print("last:", last)
+print('last:', last)
 ~~~
 {: .language-python}
 
 ~~~
 group: Drosophila
 species: melanogaster
-autosomes: ["2", "3", "4"]
+autosomes: ['2', '3', '4']
 last: 4
 ~~~
 {: .output}
@@ -367,18 +367,18 @@ last: 4
 > Use slicing to access only the last four characters of a string or entries of a list.
 >
 > ~~~
-> string_for_slicing = "Observation date: 02-Feb-2013"
-> list_for_slicing = [["fluorine", "F"],
->                     ["chlorine", "Cl"],
->                     ["bromine", "Br"],
->                     ["iodine", "I"],
->                     ["astatine", "At"]]
+> string_for_slicing = 'Observation date: 02-Feb-2013'
+> list_for_slicing = [['fluorine', 'F'],
+>                     ['chlorine', 'Cl'],
+>                     ['bromine', 'Br'],
+>                     ['iodine', 'I'],
+>                     ['astatine', 'At']]
 > ~~~
 > {: .language-python}
 >
 > ~~~
-> "2013"
-> [["chlorine", "Cl"], ["bromine", "Br"], ["iodine", "I"], ["astatine", "At"]]
+> 2013
+> [['chlorine', 'Cl'], ['bromine', 'Br'], ['iodine', 'I'], ['astatine', 'At']]
 > ~~~
 > {: .output}
 >
@@ -414,7 +414,7 @@ last: 4
 > ~~~
 > primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37]
 > subset = primes[0:12:3]
-> print("subset", subset)
+> print('subset', subset)
 > ~~~
 > {: .language-python}
 >
@@ -431,7 +431,7 @@ last: 4
 > ~~~
 > primes = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37]
 > subset = primes[2:12:3]
-> print("subset", subset)
+> print('subset', subset)
 > ~~~
 > {: .language-python}
 >
@@ -483,11 +483,11 @@ If you want to take a slice from the beginning of a sequence, you can omit the f
 range:
 
 ~~~
-date = "Monday 4 January 2016"
+date = 'Monday 4 January 2016'
 day = date[0:6]
-print("Using 0 to begin range:", day)
+print('Using 0 to begin range:', day)
 day = date[:6]
-print("Omitting beginning index:", day)
+print('Omitting beginning index:', day)
 ~~~
 {: .language-python}
 
@@ -501,20 +501,20 @@ And similarly, you can omit the ending index in the range to take a slice to the
 sequence:
 
 ~~~
-months = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"]
+months = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec']
 sond = months[8:12]
-print("With known last position:", sond)
+print('With known last position:', sond)
 sond = months[8:len(months)]
-print("Using len() to get last entry:", sond)
+print('Using len() to get last entry:', sond)
 sond = months[8:]
-print("Omitting ending index:", sond)
+print('Omitting ending index:', sond)
 ~~~
 {: .language-python}
 
 ~~~
-With known last position: ["sep", "oct", "nov", "dec"]
-Using len() to get last entry: ["sep", "oct", "nov", "dec"]
-Omitting ending index: ["sep", "oct", "nov", "dec"]
+With known last position: ['sep", 'oct', 'nov', 'dec']
+Using len() to get last entry: ['sep', 'oct', 'nov', 'dec']
+Omitting ending index: ['sep', 'oct', 'nov', 'dec']
 ~~~
 {: .output}
 

--- a/_episodes/05-lists.md
+++ b/_episodes/05-lists.md
@@ -512,7 +512,7 @@ print('Omitting ending index:', sond)
 {: .language-python}
 
 ~~~
-With known last position: ['sep", 'oct', 'nov', 'dec']
+With known last position: ['sep', 'oct', 'nov', 'dec']
 Using len() to get last entry: ['sep', 'oct', 'nov', 'dec']
 Omitting ending index: ['sep', 'oct', 'nov', 'dec']
 ~~~


### PR DESCRIPTION
to improve consistency in style. There are two instances '"-1"' and "octopus's garden" left to preserve the quote-in-quote.