### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -29,8 +29,8 @@ Any Python interpreter can be used as a calculator:
 
 This is great but not very interesting.
 To do anything useful with data, we need to assign its value to a _variable_.
-In Python, we can [assign]({{ page.root }}/reference/#assign) a value to a
-[variable]({{ page.root }}/reference/#variable), using the equals sign `=`.
+In Python, we can [assign]({{ page.root }}/reference.html#assign) a value to a
+[variable]({{ page.root }}/reference.html#variable), using the equals sign `=`.
 For example, to assign value `60` to a variable `weight_kg`, we would execute:
 
 ~~~
@@ -45,7 +45,7 @@ In Python, variable names:
 
  - can include letters, digits, and underscores
  - cannot start with a digit
- - are [case sensitive]({{ page.root }}/reference/#case-sensitive).
+ - are [case sensitive]({{ page.root }}/reference.html#case-sensitive).
 
 This means that, for example:
  - `weight0` is a valid variable name, whereas `0weight` is not
@@ -181,7 +181,7 @@ weight in kilograms is now: 65.0
 
 > ## Check Your Understanding
 >
-> What values do the variables `mass` and `age` have after each of the following statements? 
+> What values do the variables `mass` and `age` have after each of the following statements?
 > Test your answer by executing the lines.
 >
 > ~~~

--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -25,7 +25,7 @@ keypoints:
 Words are useful, but what's more useful are the sentences and stories we build with them.
 Similarly, while a lot of powerful, general tools are built into Python,
 specialized tools built up from these basic units live in
-[libraries]({{ page.root }}/reference/#library)
+[libraries]({{ page.root }}/reference.html#library)
 that can be called upon when needed.
 
 ## Loading data into Python
@@ -35,7 +35,7 @@ We can do that using a library called
 [NumPy](http://docs.scipy.org/doc/numpy/ "NumPy Documentation"), which stands for Numerical Python.
 In general, you should use this library when you want to do fancy things with lots of numbers,
 especially if you have matrices or arrays. To tell Python that we'd like to start using NumPy,
-we need to [import]({{ page.root }}/reference/#import) it:
+we need to [import]({{ page.root }}/reference.html#import) it:
 
 ~~~
 import numpy
@@ -66,9 +66,9 @@ array([[ 0.,  0.,  1., ...,  3.,  0.,  0.],
 ~~~
 {: .output}
 
-The expression `numpy.loadtxt(...)` is a [function call]({{ page.root }}/reference/#function-call)
-that asks Python to run the [function]({{ page.root }}/reference/#function) `loadtxt` which
-belongs to the `numpy` library. This [dotted notation]({{ page.root }}/reference/#dotted-notation)
+The expression `numpy.loadtxt(...)` is a [function call]({{ page.root }}/reference.html#function-call)
+that asks Python to run the [function]({{ page.root }}/reference.html#function) `loadtxt` which
+belongs to the `numpy` library. This [dotted notation]({{ page.root }}/reference.html#dotted-notation)
 is used everywhere in Python: the thing that appears before the dot contains the thing that
 appears after.
 
@@ -76,13 +76,13 @@ As an example, John Smith is the John that belongs to the Smith family.
 We could use the dot notation to write his name `smith.john`,
 just as `loadtxt` is a function that belongs to the `numpy` library.
 
-`numpy.loadtxt` has two [parameters]({{ page.root }}/reference/#parameter): the name of the file
-we want to read and the [delimiter]({{ page.root }}/reference/#delimiter) that separates values on
-a line. These both need to be character strings (or [strings]({{ page.root }}/reference/#string)
+`numpy.loadtxt` has two [parameters]({{ page.root }}/reference.html#parameter): the name of the file
+we want to read and the [delimiter]({{ page.root }}/reference.html#delimiter) that separates values on
+a line. These both need to be character strings (or [strings]({{ page.root }}/reference.html#string)
 for short), so we put them in quotes.
 
 Since we haven't told it to do anything else with the function's output,
-the [notebook]({{ page.root }}/reference/#notebook) displays it.
+the [notebook]({{ page.root }}/reference.html#notebook) displays it.
 In this case,
 that output is the data we just loaded.
 By default,
@@ -92,7 +92,7 @@ Note that, to save space when displaying NumPy arrays, Python does not show us t
 
 > ## Importing libraries with shortcuts
 >
-> In this lesson we use the `import numpy` [syntax]({{ page.root }}/reference/#syntax) to import NumPy.
+> In this lesson we use the `import numpy` [syntax]({{ page.root }}/reference.html#syntax) to import NumPy.
 > However, shortcuts such as `import numpy as np` are frequently used.  Importing NumPy this way means that after the
 > inital import, rather than writing `numpy.loadtxt(...)`, you can now write `np.loadtxt(...)`. Some
 > people prefer this as it is quicker to type and results in shorter lines of code - especially for libraries
@@ -137,7 +137,7 @@ print(data)
 Now that the data are in memory,
 we can manipulate them.
 First,
-let's ask what [type]({{ page.root }}/reference/#type) of thing `data` refers to:
+let's ask what [type]({{ page.root }}/reference.html#type) of thing `data` refers to:
 
 ~~~
 print(type(data))
@@ -175,10 +175,10 @@ are their daily inflammation measurements.
 > {: .output}
 >
 > This tells us that the NumPy array's elements are
-> [floating-point numbers]({{ page.root }}/reference/#floating-point number).
+> [floating-point numbers]({{ page.root }}/reference.html#floating-point number).
 {: .callout}
 
-With the following command, we can see the array's [shape]({{ page.root }}/reference/#shape):
+With the following command, we can see the array's [shape]({{ page.root }}/reference.html#shape):
 
 ~~~
 print(data.shape)
@@ -192,14 +192,14 @@ print(data.shape)
 
 The output tells us that the `data` array variable contains 60 rows and 40 columns. When we
 created the variable `data` to store our arthritis data, we did not only create the array; we also
-created information about the array, called [members]({{ page.root }}/reference/#member) or
+created information about the array, called [members]({{ page.root }}/reference.html#member) or
 attributes. This extra information describes `data` in the same way an adjective describes a noun.
 `data.shape` is an attribute of `data` which describes the dimensions of `data`. We use the same
 dotted notation for the attributes of variables that we use for the functions in libraries because
 they have the same part-and-whole relationship.
 
 If we want to get a single number from the array, we must provide an
-[index]({{ page.root }}/reference/#index) in square brackets after the variable name, just as we
+[index]({{ page.root }}/reference.html#index) in square brackets after the variable name, just as we
 do in math when referring to an element of a matrix.  Our inflammation data has two dimensions, so
 we will need to use two indices to refer to one specific value:
 
@@ -275,7 +275,7 @@ print(data[0:4, 0:10])
 ~~~
 {: .output}
 
-The [slice]({{ page.root }}/reference/#slice) `0:4` means, "Start at index 0 and go up to, but not
+The [slice]({{ page.root }}/reference.html#slice) `0:4` means, "Start at index 0 and go up to, but not
 including, index 4". Again, the up-to-but-not-including takes a bit of getting used to, but the
 rule is that the difference between the upper and lower bounds is the number of values in the slice.
 
@@ -332,8 +332,8 @@ print(numpy.mean(data))
 ~~~
 {: .output}
 
-`mean` is a [function]({{ page.root }}/reference/#function) that takes
-an array as an [argument]({{ page.root }}/reference/#argument).
+`mean` is a [function]({{ page.root }}/reference.html#function) that takes
+an array as an [argument]({{ page.root }}/reference.html#argument).
 
 > ## Not All Functions Have Input
 >
@@ -415,7 +415,7 @@ maximum inflammation for patient 0: 18.0
 {: .output}
 
 Everything in a line of code following the '#' symbol is a
-[comment]({{ page.root }}/reference/#comment) that is ignored by Python.
+[comment]({{ page.root }}/reference.html#comment) that is ignored by Python.
 Comments allow programmers to leave explanatory notes for other
 programmers or their future selves.
 
@@ -499,7 +499,7 @@ which is the average inflammation per patient across all days.
 
 > ## Slicing Strings
 >
-> A section of an array is called a [slice]({{ page.root }}/reference/#slice).
+> A section of an array is called a [slice]({{ page.root }}/reference.html#slice).
 > We can take slices of character strings as well:
 >
 > ~~~
@@ -549,7 +549,7 @@ which is the average inflammation per patient across all days.
 >
 > How can we rewrite the slice for getting the last three characters of `element`,
 > so that it works even if we assign a different string to `element`?
-> Test your solution with the following strings: `carpentry`, `clone`, `hi`. 
+> Test your solution with the following strings: `carpentry`, `clone`, `hi`.
 >
 > > ## Solution
 > > ~~~
@@ -575,7 +575,7 @@ which is the average inflammation per patient across all days.
 
 > ## Thin Slices
 >
-> The expression `element[3:3]` produces an [empty string]({{ page.root }}/reference/#empty-string),
+> The expression `element[3:3]` produces an [empty string]({{ page.root }}/reference.html#empty-string),
 > i.e., a string that contains no characters.
 > If `data` holds our array of patient data,
 > what does `data[3:3, 4:4]` produce?
@@ -693,7 +693,7 @@ which is the average inflammation per patient across all days.
 > The `numpy.diff()` function takes an array and returns the differences
 > between two successive values. Let's use it to examine the changes
 > each day across the first week of patient 3 from our inflammation dataset.
-> 
+>
 > ~~~
 > patient3_week1 = data[3, :7]
 > print(patient3_week1)
@@ -727,7 +727,7 @@ which is the average inflammation per patient across all days.
 > Note that the array of differences is shorter by one element (length 6).
 >
 > When calling `numpy.diff` with a multi-dimensional array, an `axis` argument may
-> be passed to the function to specify which axis to process. When applying 
+> be passed to the function to specify which axis to process. When applying
 > `numpy.diff` to our 2D inflammation array `data`, which axis would we specify?
 >
 > > ## Solution

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -72,7 +72,7 @@ You can group similar plots in a single figure using subplots.
 This script below uses a number of new commands. The function `matplotlib.pyplot.figure()`
 creates a space into which we will place all of our plots. The parameter `figsize`
 tells Python how big to make this space. Each subplot is placed into the figure using
-its `add_subplot` [method]({{ page.root }}/reference/#method). The `add_subplot` method takes 3
+its `add_subplot` [method]({{ page.root }}/reference.html#method). The `add_subplot` method takes 3
 parameters. The first denotes how many total rows of subplots there are, the second parameter
 refers to the total number of subplot columns, and the final parameter denotes which subplot
 your variable is referencing (left-to-right, top-to-bottom). Each subplot is stored in a
@@ -110,7 +110,7 @@ matplotlib.pyplot.show()
 
 ![The Previous Plots as Subplots](../fig/inflammation-01-group-plot.svg)
 
-The [call]({{ page.root }}/reference/#function-call) to `loadtxt` reads our data,
+The [call]({{ page.root }}/reference.html#function-call) to `loadtxt` reads our data,
 and the rest of the program tells the plotting library
 how large we want the figure to be,
 that we're creating three subplots,

--- a/_episodes/04-loop.md
+++ b/_episodes/04-loop.md
@@ -135,7 +135,7 @@ n
 ~~~
 {: .output}
 
-The improved version uses a [for loop]({{ page.root }}/reference/#for-loop)
+The improved version uses a [for loop]({{ page.root }}/reference.html#for-loop)
 to repeat an operation --- in this case, printing --- once for each thing in a sequence.
 The general form of a loop is:
 
@@ -153,7 +153,7 @@ where each character (`char`) in the variable `word` is looped through and print
 after another. The numbers in the diagram denote which loop cycle the character was printed in (1
 being the first loop, and 6 being the final loop).
 
-We can call the [loop variable]({{ page.root }}/reference/#loop-variable) anything we like, but
+We can call the [loop variable]({{ page.root }}/reference.html#loop-variable) anything we like, but
 there must be a colon at the end of the line starting the loop, and we must indent anything we
 want to run inside the loop. Unlike many other languages, there is no command to signify the end
 of the loop body (e.g. `end for`); what is indented after the `for` statement belongs to the loop.

--- a/_episodes/05-lists.md
+++ b/_episodes/05-lists.md
@@ -116,8 +116,8 @@ does not.
 
 > ## Ch-Ch-Ch-Ch-Changes
 >
-> Data which can be modified in place is called [mutable]({{ page.root }}/reference/#mutable),
-> while data which cannot be modified is called [immutable]({{ page.root }}/reference/#immutable).
+> Data which can be modified in place is called [mutable]({{ page.root }}/reference.html#mutable),
+> while data which cannot be modified is called [immutable]({{ page.root }}/reference.html#immutable).
 > Strings and numbers are immutable. This does not mean that variables with string or number values
 > are constants, but when we want to change the value of a string or number variable, we can only
 > replace the old value with a completely new value.
@@ -181,7 +181,7 @@ does not.
 >
 > [![x is represented as a pepper shaker containing several packets of pepper. [x[0]] is represented
 > as a pepper shaker containing a single packet of pepper. x[0] is represented as a single packet of
-> pepper. x[0][0] is represented as single grain of pepper.  Adapted 
+> pepper. x[0][0] is represented as single grain of pepper.  Adapted
 > from @hadleywickham.](../fig/indexing_lists_python.png)][hadleywickham-tweet]
 >
 > Using the previously declared list `x`, these would be the results of the

--- a/_episodes/07-cond.md
+++ b/_episodes/07-cond.md
@@ -348,7 +348,7 @@ freeing us from having to manually examine every plot for features we've seen be
 > ## In-Place Operators
 >
 > Python (and most other languages in the C family) provides
-> [in-place operators]({{ page.root }}/reference/#in-place-operators)
+> [in-place operators]({{ page.root }}/reference.html#in-place-operators)
 > that work like this:
 >
 > ~~~

--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -59,7 +59,7 @@ def fahr_to_celsius(temp):
 
 The function definition opens with the keyword `def` followed by the
 name of the function (`fahr_to_celsius`) and a parenthesized list of parameter names (`temp`). The
-[body]({{ page.root }}/reference/#body) of the function --- the
+[body]({{ page.root }}/reference.html#body) of the function --- the
 statements that are executed when it runs --- is indented below the
 definition line.  The body concludes with a `return` keyword followed by the return value.
 
@@ -67,7 +67,7 @@ When we call the function,
 the values we pass to it are assigned to those variables
 so that we can use them inside the function.
 Inside the function,
-we use a [return statement]({{ page.root }}/reference/#return-statement) to send a result
+we use a [return statement]({{ page.root }}/reference.html#return-statement) to send a result
 back to whoever asked for it.
 
 Let's try running our function.
@@ -118,7 +118,7 @@ What about converting Fahrenheit to Kelvin?
 We could write out the formula,
 but we don't need to.
 Instead,
-we can [compose]({{ page.root }}/reference/#compose) the two functions we have already created:
+we can [compose]({{ page.root }}/reference.html#compose) the two functions we have already created:
 
 ~~~
 def fahr_to_kelvin(temp_f):
@@ -323,11 +323,11 @@ the difference is very small.
 It's still possible that our function is wrong,
 but it seems unlikely enough that we should probably get back to doing our analysis.
 We have one more task first, though:
-we should write some [documentation]({{ page.root }}/reference/#documentation) for our function
+we should write some [documentation]({{ page.root }}/reference.html#documentation) for our function
 to remind ourselves later what it's for and how to use it.
 
 The usual way to put documentation in software is
-to add [comments]({{ page.root }}/reference/#comment) like this:
+to add [comments]({{ page.root }}/reference.html#comment) like this:
 
 ~~~
 # offset_mean(data, target_mean_value):
@@ -365,7 +365,7 @@ offset_mean(data, target_mean_value)
 ~~~
 {: .output}
 
-A string like this is called a [docstring]({{ page.root }}/reference/#docstring).
+A string like this is called a [docstring]({{ page.root }}/reference.html#docstring).
 We don't need to use triple quotes when we write one,
 but if we do,
 we can break the string across multiple lines:
@@ -484,7 +484,7 @@ print(offset_mean(test_data, 3))
 
 But we can also now call it with just one parameter,
 in which case `target_mean_value` is automatically assigned
-the [default value]({{ page.root }}/reference/#default-value) of 0.0:
+the [default value]({{ page.root }}/reference.html#default-value) of 0.0:
 
 ~~~
 more_data = 5 + numpy.zeros((2, 2))

--- a/_episodes/09-errors.md
+++ b/_episodes/09-errors.md
@@ -38,7 +38,7 @@ Once you know *why* you get certain types of errors,
 they become much easier to fix.
 
 Errors in Python have a very specific form,
-called a [traceback]({{ page.root }}/reference/#traceback).
+called a [traceback]({{ page.root }}/reference.html#traceback).
 Let's examine one:
 
 ~~~
@@ -88,7 +88,7 @@ In this case:
 The last level is the actual place where the error occurred.
 The other level(s) show what function the program executed to get to the next level down.
 So, in this case, the program first performed a
-[function call]({{ page.root }}/reference/#function-call) to the function `favorite_ice_cream`.
+[function call]({{ page.root }}/reference.html#function-call) to the function `favorite_ice_cream`.
 Inside this function,
 the program encountered an error on Line 6, when it tried to run the code `print(ice_creams[3])`.
 
@@ -132,7 +132,7 @@ hopefully the custom error message is informative enough to help you figure out 
 When you forget a colon at the end of a line,
 accidentally add one space too many when indenting under an `if` statement,
 or forget a parenthesis,
-you will encounter a [syntax error]({{ page.root }}/reference/#syntax-error).
+you will encounter a [syntax error]({{ page.root }}/reference.html#syntax-error).
 This means that Python couldn't figure out how to read your program.
 This is similar to forgetting punctuation in English:
 for example,
@@ -196,7 +196,7 @@ it *always* means that there is a problem with how your code is indented.
 >
 > Some indentation errors are harder to spot than others.
 > In particular, mixing spaces and tabs can be difficult to spot
-> because they are both [whitespace]({{ page.root }}/reference/#whitespace).
+> because they are both [whitespace]({{ page.root }}/reference.html#whitespace).
 > In the example below, the first two lines in the body of the function
 > `some_function` are indented with tabs, while the third line &mdash; with spaces.
 > If you're working in a Jupyter notebook, be sure to copy and paste this example
@@ -253,7 +253,7 @@ because it depends on what your code is supposed to do.
 However,
 there are a few very common reasons why you might have an undefined variable.
 The first is that you meant to use a
-[string]({{ page.root }}/reference/#string), but forgot to put quotes around it:
+[string]({{ page.root }}/reference.html#string), but forgot to put quotes around it:
 
 ~~~
 print(hello)
@@ -296,7 +296,7 @@ NameError: name 'count' is not defined
 Finally, the third possibility is that you made a typo when you were writing your code.
 Let's say we fixed the error above by adding the line `Count = 0` before the for loop.
 Frustratingly, this actually does not fix the error.
-Remember that variables are [case-sensitive]({{ page.root }}/reference/#case-sensitive),
+Remember that variables are [case-sensitive]({{ page.root }}/reference.html#case-sensitive),
 so the variable `count` is different from `Count`. We still get the same error,
 because we still have not defined `count`:
 

--- a/_episodes/10-defensive.md
+++ b/_episodes/10-defensive.md
@@ -52,9 +52,9 @@ is much greater than the time that measuring takes.
 The first step toward getting the right answers from our programs
 is to assume that mistakes *will* happen
 and to guard against them.
-This is called [defensive programming]({{ page.root }}/reference/#defensive-programming),
+This is called [defensive programming]({{ page.root }}/reference.html#defensive-programming),
 and the most common way to do it is to add
-[assertions]({{ page.root }}/reference/#assertion) to our code
+[assertions]({{ page.root }}/reference.html#assertion) to our code
 so that it checks itself as it runs.
 An assertion is simply a statement that something must be true at a certain point in a program.
 When Python sees one,
@@ -97,17 +97,17 @@ are there to check that the other 80–90% are working correctly.
 Broadly speaking,
 assertions fall into three categories:
 
-*   A [precondition]({{ page.root }}/reference/#precondition)
+*   A [precondition]({{ page.root }}/reference.html#precondition)
     is something that must be true at the start of a function in order for it to work correctly.
 
-*   A [postcondition]({{ page.root }}/reference/#postcondition)
+*   A [postcondition]({{ page.root }}/reference.html#postcondition)
     is something that the function guarantees is true when it finishes.
 
-*   An [invariant]({{ page.root }}/reference/#invariant)
+*   An [invariant]({{ page.root }}/reference.html#invariant)
     is something that is always true at a particular point inside a piece of code.
 
 For example,
-suppose we are representing rectangles using a [tuple]({{ page.root }}/reference/#tuple)
+suppose we are representing rectangles using a [tuple]({{ page.root }}/reference.html#tuple)
 of four coordinates `(x0, y0, x1, y1)`,
 representing the lower left and upper right corners of the rectangle.
 In order to do some calculations,
@@ -258,7 +258,7 @@ If you made a mistake in a piece of code,
 the odds are good that you have made other mistakes nearby,
 or will make the same mistake (or a related one)
 the next time you change it.
-Writing assertions to check that you haven't [regressed]({{ page.root }}/reference/#regression)
+Writing assertions to check that you haven't [regressed]({{ page.root }}/reference.html#regression)
 (i.e., haven't re-introduced an old problem)
 can save a lot of time in the long run,
 and helps to warn people who are reading the code
@@ -293,7 +293,7 @@ there's a better way:
 3.  If `range_overlap` produces any wrong answers, fix it and re-run the test functions.
 
 Writing the tests *before* writing the function they exercise
-is called [test-driven development]({{ page.root }}/reference/#test-driven-development) (TDD).
+is called [test-driven development]({{ page.root }}/reference.html#test-driven-development) (TDD).
 Its advocates believe it produces better code faster because:
 
 1.  If people write tests after writing the thing to be tested,

--- a/_episodes/11-debugging.md
+++ b/_episodes/11-debugging.md
@@ -65,7 +65,7 @@ scientists tend to do the following:
     our first test should hold temperature, precipitation, and other factors constant.
 
 3.  *Compare to an oracle.*
-    A [test oracle]({{ page.root }}/reference/#test-oracle) is something whose results are trusted,
+    A [test oracle]({{ page.root }}/reference.html#test-oracle) is something whose results are trusted,
     such as experimental data, an older program, or a human expert.
     We use test oracles to determine if our new program produces the correct results.
     If we have a test oracle,

--- a/_episodes/12-cmdline.md
+++ b/_episodes/12-cmdline.md
@@ -67,7 +67,7 @@ $ python ../code/readings_04.py --max inflammation-*.csv
 Our scripts should do the following:
 
 1. If no filename is given on the command line, read data from
-[standard input]({{ page.root }}/reference/#standard-input).
+[standard input]({{ page.root }}/reference.html#standard-input).
 2. If one or more filenames are given, read data from them and report statistics for each file
 separately.
 3. Use the `--min`, `--mean`, or `--max` flag to determine what statistic to print.
@@ -495,7 +495,7 @@ but there are several things wrong with it:
    command-line, one for the **flag** and one for the **filename**, but only
    one, the program will not throw an exception but will run. It assumes that the file
    list is empty, as `sys.argv[1]` will be considered the `action`, even if it
-   is a filename. [Silent failures]({{ page.root }}/reference/#silence-failure)  like this
+   is a filename. [Silent failures]({{ page.root }}/reference.html#silence-failure)  like this
    are always hard to debug.
 
 3. The program should check if the submitted `action` is one of the three recognized flags.

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/additional_material.md
+++ b/_extras/additional_material.md
@@ -1,9 +1,7 @@
 ---
-layout: page
 title: "Additional material"
-permalink: /extra_material/
 ---
-A collection of facts about Python that do not fit into the main lesson 
+A collection of facts about Python that do not fit into the main lesson
 either due to the scope or time constraints of the main lesson.
 
 
@@ -116,4 +114,3 @@ use a double-slash:
 1
 ~~~
 {: .output}
-

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 ## Rules of Debugging
 
@@ -147,7 +145,7 @@ span of data: 20.0
 {: .output}
 
 We don't expect `diff` to have the value 20.0 after this function call,
-so the name `diff` cannot refer to the same thing inside `span` 
+so the name `diff` cannot refer to the same thing inside `span`
 as it does in the main body of our program.
 And yes,
 we could probably choose a different name than `diff` in our main program in this case,

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -36,7 +36,7 @@ The diagram below shows what memory looks like after the first line has been exe
 When we call `fahr_to_celsius`,
 Python *doesn't* create the variable `temp` right away.
 Instead,
-it creates something called a [stack frame]({{ page.root }}/reference/#stack-frame)
+it creates something called a [stack frame]({{ page.root }}/reference.html#stack-frame)
 to keep track of the variables defined by `fahr_to_kelvin`.
 Initially,
 this stack frame only holds the value of `temp`:
@@ -153,7 +153,7 @@ but we don't want to have to read every line of NumPy to see what variable names
 before calling any of those functions,
 just in case they change the values of our variables.
 
-The big idea here is [encapsulation]({{ page.root }}/reference/#encapsulation),
+The big idea here is [encapsulation]({{ page.root }}/reference.html#encapsulation),
 and it's the key to writing correct, comprehensible programs.
 A function's job is to turn several operations into one
 so that we can think about a single function call
@@ -223,9 +223,9 @@ grid lines on: True
 The obvious thing to do with a grid like this is color in its cells,
 but in order to do that,
 we need to know how computers represent color.
-The most common schemes are [RGB]({{ page.root }}/reference/#rgb),
+The most common schemes are [RGB]({{ page.root }}/reference.html#rgb),
 which is short for "red, green, blue".
-RGB is an [additive color model]({{ page.root }}/reference/#additive-color-model):
+RGB is an [additive color model]({{ page.root }}/reference.html#additive-color-model):
 every shade is some combination of red, green, and blue intensities.
 We can think of these three values as being the axes in a cube:
 
@@ -234,7 +234,7 @@ We can think of these three values as being the axes in a cube:
 An RGB color is an example of a multi-part value:
 like a Cartesian coordinate,
 it is one thing with several parts.
-We can represent such a value in Python using a [tuple]({{ page.root }}/reference/#tuple),
+We can represent such a value in Python using a [tuple]({{ page.root }}/reference.html#tuple),
 which we write using parentheses instead of the square brackets used for a list:
 
 ~~~
@@ -267,7 +267,7 @@ first element of color is: 10
 Unlike lists and arrays,
 though,
 tuples cannot be changed after they are created --- in technical terms,
-they are [immutable]({{ page.root }}/reference/#immutable):
+they are [immutable]({{ page.root }}/reference.html#immutable):
 
 ~~~
 color[0] = 40

--- a/_extras/extra_exercises.md
+++ b/_extras/extra_exercises.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Additional Exercises"
-permalink: /extra_exercises/
 ---
 A collection of exercises that have been either removed from
 or not (yet) added to the main lesson.

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Instructor Notes"
-permalink: /guide/
 ---
 
 ## About the lesson

--- a/index.md
+++ b/index.md
@@ -38,11 +38,13 @@ To do all that, we'll have to learn a little bit about programming.
 >
 > You need to understand the concepts of **files** and **directories** and how to start a Python
 > interpreter before tackling this lesson. This lesson sometimes references Jupyter
-> Notebook although you can use any Python interpreter mentioned in the [Setup](setup/).
+> Notebook although you can use any Python interpreter mentioned in the [Setup][lesson-setup].
 >
 > The commands in this lesson pertain to **Python 3**.
 {: .prereq}
 
 ### Getting Started
-To get started, follow the directions on the "[Setup](setup/)" page to download data
+To get started, follow the directions on the "[Setup][lesson-setup]" page to download data
 and install a Python interpreter.
+
+{% include links.md %}

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ so this introduction to Python is built around a common scientific task:
 ### Arthritis Inflammation
 We are studying **inflammation in patients** who have been given a new treatment for arthritis, and
 need to analyze the first dozen data sets of their daily inflammation. The data sets are stored in
-[comma-separated values]({{ page.root }}/reference/#comma-separated-values) (CSV) format:
+[comma-separated values]({{ page.root }}/reference.html#comma-separated-values) (CSV) format:
 
 - each row holds information for a single patient,
 - columns represent successive days.

--- a/reference.md
+++ b/reference.md
@@ -1,7 +1,5 @@
 ---
 layout: reference
-permalink: /reference/
-root: ..
 ---
 
 ## Glossary
@@ -162,7 +160,7 @@ mutable
     created. See [immutable](#immutable)."
 
 notebook
-:   Interactive computational environment accessed via your web browser, in which you can write 
+:   Interactive computational environment accessed via your web browser, in which you can write
     and execute Python code and combine it with explanatory text, mathematics and visualizations.
     Examples are IPython or Jupyter notebooks.
 
@@ -247,7 +245,7 @@ string
 
 syntax
 :   The rules that define how code must be written for a computer to understand.
-    
+
 syntax error
 :   A programming error that occurs when statements are in an order or contain characters
     not expected by the programming language.

--- a/setup.md
+++ b/setup.md
@@ -1,8 +1,5 @@
 ---
-layout: page
 title: Setup
-permalink: /setup/index.html
-root: ..
 ---
 
 ## Overview


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://software-carpentry.org/lessons/ to the Instructor Notes page idn't broken, and make another sweep through the lesson pages too. 