### PR TITLE
.travis.yml: Specify ruby 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
   - gh-pages
   - /.*/
 before_install:
-  - rvm default
+  - rvm use 2.7.1 --install --binary --fuzzy --default
   - gem install json kramdown jekyll bundler
 install:
   - pip install pyyaml


### PR DESCRIPTION
This is to align the rvm ruby version with the github-pages requirement and fix the following that is showing up in the [Travis CI build](https://travis-ci.org/github/swcarpentry/python-novice-inflammation/builds/744477676):
```
$ make site
bundle config --local set path .vendor/bundle && bundle install && bundle update && bundle exec jekyll build
Your Ruby version is 2.5.3, but your Gemfile specified >= 2.7.1
Makefile:49: recipe for target 'site' failed
make: *** [site] Error 18
The command "make site" exited with 2.
```

I had tried to update the .travis.yml file according to what was in [bin/boilerplate/.travis.yml](https://github.com/swcarpentry/python-novice-inflammation/blob/d96200187de2d21ea13fcd22fde336b6f7da4dc1/bin/boilerplate/.travis.yml) after the recent carpentries/styles update, but was having an issue with the `ruby` being called in `bin/util.py` via `subprocess.Popen` not being what was installed by Travis.