### PR TITLE
Slightly widened figure to fix cut-off text.

### DIFF
--- a/fig/python-zero-index.svg
+++ b/fig/python-zero-index.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 1140 183.2" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 1150 183.2" xmlns="http://www.w3.org/2000/svg">
   <g fill-opacity=".25">
     <!-- vertical rectangles showing columns -->
     <rect x="150" y="54" height="130" rx="8" width="28" fill="#ec008c" stroke="#ec008c"/>


### PR DESCRIPTION
When going through the ["Analyzing Patient Data" lesson](https://swcarpentry.github.io/python-novice-inflammation/02-numpy/index.html), I noticed that the figure illustrating zero indexing was cut-off:

![Screen Shot 2021-01-07 at 1 12 32 PM](https://user-images.githubusercontent.com/9124668/103948237-4e3d2280-50ee-11eb-9aec-322f16cfae3c.png)


This PR widens the viewbox in the SVG slightly to prevent this.