### PR TITLE
[ENH] fix long lines _episodes/01-intro.md 

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -157,7 +157,8 @@ weight in kilograms is now: 65.0
 > ~~~
 > {: .output}
 >
-> ![Value of 65.0 with weight_kg label stuck on it, and value of 143.0 with weight_lb label stuck on it](../fig/python-sticky-note-variables-02.svg)
+> ![Value of 65.0 with weight_kg label stuck on it, and value of 143.0 with weight_lb label
+stuck on it](../fig/python-sticky-note-variables-02.svg)
 >
 > Let's now change `weight_kg`:
 >
@@ -172,7 +173,8 @@ weight in kilograms is now: 65.0
 > ~~~
 > {: .output}
 >
-> ![Value of 100.0 with label weight_kg stuck on it, and value of 143.0 with label weight_lb stuck on it](../fig/python-sticky-note-variables-03.svg)
+> ![Value of 100.0 with label weight_kg stuck on it, and value of 143.0 with label weight_lb
+stuck on it](../fig/python-sticky-note-variables-03.svg)
 >
 > Since `weight_lb` doesn't "remember" where its value comes from,
 > it is not updated when we change `weight_kg`.


### PR DESCRIPTION
Regarding issue #498, shortened the lines in episode-01. 

I checked locally, whether the changes broke anything, but I somehow cannot update ruby right now. So I reduced the requirement in the Gemfile, however, not sure what problems come with this little hack. 