### PR TITLE
Add a note on the convention of importing matplotlib.pyplot as plt

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -93,20 +93,6 @@ only a few rows and columns are shown
 Note that, to save space when displaying NumPy arrays, Python does not show us trailing zeros,
 so `1.0` becomes `1.`.
 
-> ## Importing libraries with shortcuts
->
-> In this lesson we use the `import numpy` [syntax]({{ page.root }}/reference.html#syntax)
-> to import NumPy. However, shortcuts such as `import numpy as np` are frequently used.
-> Importing NumPy this way means that after the initial import, rather than writing
-> `numpy.loadtxt(...)`, you can now write `np.loadtxt(...)`. Some people prefer this as it is
-> quicker to type and results in shorter lines of code - especially for libraries
-> with long names! You will frequently see Python code online using a NumPy function with `np`,
-> and it's because they've used this shortcut. It makes no difference which approach you choose to
-> take, but you must be consistent as if you use `import numpy as np` then `numpy.loadtxt(...)`
-> will not work, and you must use `np.loadtxt(...)` instead. Because of this, when working with
-> other people it is important you agree on how libraries are imported.
-{: .callout}
-
 Our call to `numpy.loadtxt` read our file
 but didn't save the data in memory.
 To do that,

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -147,7 +147,6 @@ formats, including SVG, PDF, and JPEG.
 > `import matplotlib.pyplot as plt` then `matplotlib.pyplot.plot(...)` will not work, and
 > you must use `plt.plot(...)` instead. Because of this, when working with other people it
 > is important you agree on how libraries are imported.
->
 {: .callout}
 
 > ## Plot Scaling

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -135,7 +135,7 @@ formats, including SVG, PDF, and JPEG.
 > `import matplotlib.pyplot as plt` are frequently used.
 > Importing `pyplot` this way means that after the initial import, rather than writing
 > `matplotlib.pyplot.plot(...)`, you can now write `plt.plot(...)`.
-> Another common convention to use the shortcut `import numpy as np` when importing the
+> Another common convention is to use the shortcut `import numpy as np` when importing the
 > NumPy library. We then can write `np.loadtxt(...)` instead of `numpy.loadtxt(...)`,
 > for example.
 > 

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -130,10 +130,24 @@ formats, including SVG, PDF, and JPEG.
 
 > ## Importing libraries with shortcuts
 >
-> When importing the `pyplot` module of `matplotlib` it is common to use the shortcut
-> `import matplotlib.pyplot as plt`. If we do this we then must write `plt.plot(...)`
-> instead of `matplotlib.pyplot.plot(...)`, for example. This is popular as it saves
-> a lot of typing!
+> In this lesson we use the `import matplotlib.pyplot` [syntax]({{ page.root }}/reference.html#syntax)
+> to import the `pyplot` module of `matplotlib`. However, shortcuts such as
+> `import matplotlib.pyplot as plt` are frequently used.
+> Importing `pyplot` this way means that after the initial import, rather than writing
+> `matplotlib.pyplot.plot(...)`, you can now write `plt.plot(...)`.
+> Another common convention to use the shortcut `import numpy as np` when importing the
+> NumPy library. We then can write `np.loadtxt(...)` instead of `numpy.loadtxt(...)`,
+> for example.
+> 
+> Some people prefer these shortcuts as it is quicker to type and results in shorter
+> lines of code - especially for libraries with long names! You will frequently see
+> Python code online using a `pyplot` function with `plt`, or a NumPy function with
+> `np`, and it's because they've used this shortcut. It makes no difference which
+> approach you choose to take, but you must be consistent as if you use
+> `import matplotlib.pyplot as plt` then `matplotlib.pyplot.plot(...)` will not work, and
+> you must use `plt.plot(...)` instead. Because of this, when working with other people it
+> is important you agree on how libraries are imported.
+>
 {: .callout}
 
 > ## Plot Scaling

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -128,6 +128,13 @@ Matplotlib from the file name ending we specify; here PNG from
 'inflammation.png'. Matplotlib supports many different graphics
 formats, including SVG, PDF, and JPEG.
 
+> ## Importing libraries with shortcuts
+>
+> When importing the `pyplot` module of `matplotlib` it is common to use the shortcut
+> `import matplotlib.pyplot as plt`. If we do this we then must write `plt.plot(...)`
+> instead of `matplotlib.pyplot.plot(...)`, for example. This is popular as it saves
+> a lot of typing!
+{: .callout}
 
 > ## Plot Scaling
 >


### PR DESCRIPTION
As discussed in #830 (and perhaps controversially!) this adds a note to episode 3 to mention that `import matplotlib.pyplot as plt` is a common convention. Note that:

- The same is done in the previous episode for `import numpy as np`. I've used the same heading as that for the pyplot import and kept the content short as it has been seen previously.

- I've put it at the end of the episode, just before the exercises, to try to help avoid cluttering/confusing the flow of the rest of the episode.

Very happy to make any necessary changes based on comments, but I do believe this is a worthwhile addition due to how ubiquitous this syntax is (including in the matplotlib documentation itself).
