### PR TITLE
Fix long line in episode 9

### DIFF
--- a/_episodes/09-errors.md
+++ b/_episodes/09-errors.md
@@ -495,7 +495,8 @@ often reveals common reasons why you might get that error.
 > > 2. `print_message`
 > > 3. 11
 > > 4. `KeyError`
-> > 5. There isn't really a message; you're supposed to infer that `Friday` is not a key in `messages`.
+> > 5. There isn't really a message; you're supposed
+> > to infer that `Friday` is not a key in `messages`.
 > {: .solution}
 {: .challenge}
 


### PR DESCRIPTION
Fixes long lines in episode 9, converting them to max 100 characters.

Partially addresses #498 