### PR TITLE
Add mention of swap idiom to 'The Old Switcheroo' exercise

### DIFF
--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -918,6 +918,10 @@ readable code!
 > > `a` and `b` in this case) and trades their values. The function does not
 > > return any values and does not alter `a` or `b` outside of its local copy.
 > > Therefore the original values of `a` and `b` remain unchanged.
+> >
+> > Note that the recommended way of swapping the content of `a` and `b` in Python is
+> > `a, b = b, a`. You can see why this works in the
+> > [Additional Exercises]({{ page.root }}/extra_exercises/index.html).
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -832,7 +832,11 @@ readable code!
 > > ~~~
 > > {: .output}
 > > `k` is 0 because the `k` inside the function `f2k` doesn't know
-> > about the `k` defined outside the function.
+> > about the `k` defined outside the function. When the f2k function is called, 
+> > it creates a [local variable]({{ page.root }}/reference.html#local-variable)
+> > `k`. The function does not return any values 
+> > and does not alter `k` outside of its local copy. 
+> > Therefore the original value of `k` remains unchanged.
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -832,7 +832,7 @@ readable code!
 > > ~~~
 > > {: .output}
 > > `k` is 0 because the `k` inside the function `f2k` doesn't know
-> > about the `k` defined outside the function. When the f2k function is called, 
+> > about the `k` defined outside the function. When the `f2k` function is called, 
 > > it creates a [local variable]({{ page.root }}/reference.html#local-variable)
 > > `k`. The function does not return any values 
 > > and does not alter `k` outside of its local copy. 

--- a/_episodes/08-func.md
+++ b/_episodes/08-func.md
@@ -889,46 +889,6 @@ readable code!
 > {: .solution}
 {: .challenge}
 
-> ## The Old Switcheroo
->
-> Consider this code:
->
-> ~~~
-> a = 3
-> b = 7
->
-> def swap(a, b):
->     temp = a
->     a = b
->     b = temp
->
-> swap(a, b)
->
-> print(a, b)
-> ~~~
-> {: .language-python}
->
-> Which of the following would be printed if you were to run this code?
-> Why did you pick this answer?
->
-> 1. `7 3`
-> 2. `3 7`
-> 3. `3 3`
-> 4. `7 7`
->
-> > ## Solution
-> > `3 7` is the correct answer. Initially, `a` has a value of 3 and `b` has a value of 7.
-> > When the `swap` function is called, it creates local variables (also called
-> > `a` and `b` in this case) and trades their values. The function does not
-> > return any values and does not alter `a` or `b` outside of its local copy.
-> > Therefore the original values of `a` and `b` remain unchanged.
-> >
-> > Note that the recommended way of swapping the content of `a` and `b` in Python is
-> > `a, b = b, a`. You can see why this works in the
-> > [Additional Exercises]({{ page.root }}/extra_exercises/index.html).
-> {: .solution}
-{: .challenge}
-
 > ## Readable Code
 >
 > Revise a function you wrote for one of the previous exercises to try to make

--- a/_extras/extra_exercises.md
+++ b/_extras/extra_exercises.md
@@ -22,7 +22,7 @@ or not (yet) added to the main lesson.
 > Compare it to:
 >
 > ~~~
-> left, right = [right, left]
+> left, right = right, left
 > ~~~
 > {: .language-python}
 >

--- a/_extras/extra_exercises.md
+++ b/_extras/extra_exercises.md
@@ -44,7 +44,8 @@ or not (yet) added to the main lesson.
 > >
 > > In the first case we used a temporary variable `temp` to keep the value of `left` before we
 > > overwrite it with the value of `right`. In the second case, `right` and `left` are packed into a
-> > list and then unpacked into `left` and `right`.
+> > [tuple]({{ page.root }}/reference.html#tuple)
+> > and then unpacked into `left` and `right`.
 > {: .solution}
 {: .challenge}
 

--- a/reference.md
+++ b/reference.md
@@ -153,7 +153,7 @@ local variable
     block of code in which it is ceated.
 
 loop variable
-:   The variable that keeps track of the progress of the loop. 
+:   The variable that keeps track of the progress of the loop.
 
 member
 :   A variable contained within an [object](#object).

--- a/reference.md
+++ b/reference.md
@@ -148,8 +148,12 @@ library
 :   A family of code units (functions, classes, variables) that implement a set of
     related tasks.
 
+local variable
+:   A variable that is defined in a block of code, and that is not accessible outside the
+    block of code in which it is ceated.
+
 loop variable
-:   The variable that keeps track of the progress of the loop.
+:   The variable that keeps track of the progress of the loop. 
 
 member
 :   A variable contained within an [object](#object).


### PR DESCRIPTION
This pull request proposes to close #883 by adding a brief note about the switch idiom `a, b = b, a` in  **The Old Switcheroo** exercise and linking to the description of the switch idiom already present in the **Extra Exercises** page.

In the **Extra Exercises** page it also replaces `a, b = [b, a]` with the more idiomatic and simpler `a, b = b, a`.