### PR TITLE
Fix long lines in _episodes/03-matplotlib.md

### DIFF
--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -130,7 +130,8 @@ formats, including SVG, PDF, and JPEG.
 
 > ## Importing libraries with shortcuts
 >
-> In this lesson we use the `import matplotlib.pyplot` [syntax]({{ page.root }}/reference.html#syntax)
+> In this lesson we use the `import matplotlib.pyplot`
+> [syntax]({{ page.root }}/reference.html#syntax)
 > to import the `pyplot` module of `matplotlib`. However, shortcuts such as
 > `import matplotlib.pyplot as plt` are frequently used.
 > Importing `pyplot` this way means that after the initial import, rather than writing
@@ -138,7 +139,7 @@ formats, including SVG, PDF, and JPEG.
 > Another common convention is to use the shortcut `import numpy as np` when importing the
 > NumPy library. We then can write `np.loadtxt(...)` instead of `numpy.loadtxt(...)`,
 > for example.
-> 
+>
 > Some people prefer these shortcuts as it is quicker to type and results in shorter
 > lines of code - especially for libraries with long names! You will frequently see
 > Python code online using a `pyplot` function with `plt`, or a NumPy function with


### PR DESCRIPTION
Regarding #498, I fixed lines in _episodes/03-matplotlib.md and CONTRIBUTING.md.

The `make lesson-check-all` command now outputs:

```
./README.md: Line(s) too long: 2, 4, 5, 7, 8, 9, 10, 13
```

However, as noted in #911, it may be a challenge to remove those.
