### PR TITLE
Improve the explanatory text in the "Variables as Sticky Notes" callout of Episode 1

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -136,14 +136,14 @@ weight in kilograms is now: 65.0
 
 > ## Variables as Sticky Notes
 >
-> A variable is analogous to a sticky note with a name written on it:
+> A variable in Python is analogous to a sticky note with a name written on it:
 > assigning a value to a variable is like putting that sticky note on a particular value.
 >
 > ![Value of 65.0 with weight_kg label stuck on it](../fig/python-sticky-note-variables-01.svg)
 >
-> This means that assigning a value to one variable does **not** change
-> values of other variables.
-> For example, let's store the subject's weight in pounds in its own variable:
+> Using this analogy, we can investigate how assigning a value to one variable
+> does **not** change values of other, seemingly related, variables.  For
+> example, let's store the subject's weight in pounds in its own variable:
 >
 > ~~~
 > # There are 2.2 pounds per kilogram
@@ -159,6 +159,11 @@ weight in kilograms is now: 65.0
 >
 > ![Value of 65.0 with weight_kg label stuck on it, and value of 143.0 with weight_lb label
 stuck on it](../fig/python-sticky-note-variables-02.svg)
+>
+> Similar to above, the expression `2.2 * weight_kg` is evaluated to `143.0`,
+> and then this value is assigned to the variable `weight_lb` (i.e. the sticky
+> note `weight_lb` is placed on `143.0`). At this point, each variable is
+> "stuck" to completely distinct and unrelated values.
 >
 > Let's now change `weight_kg`:
 >


### PR DESCRIPTION
As discussed in swcarpentry/python-novice-inflammation#847, the example in the "Variables as Sticky Notes" callout of Episode 1 makes it sound like the reason that variables don't "remember" where their values come from is a consequence of the fact that variables behave like sticky notes. However, this is inaccurate and could mislead learners. For the moment, some modification of the explanatory text suggested by @ldko has been inserted as a stop-gap until a better example can be crafted.

Closes #847 