### PR TITLE
Solution should have the answer not options

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -253,9 +253,6 @@ stuck on it](../fig/python-sticky-note-variables-03.svg)
 >
 > > ## Solution
 > > ~~~
-> > `mass` holds a value of 47.5, `age` does not exist
-> > `mass` still holds a value of 47.5, `age` holds a value of 122
-> > `mass` now has a value of 95.0, `age`'s value is still 122
 > > `mass` still has a value of 95.0, `age` now holds 102
 > > ~~~
 > > {: .output}


### PR DESCRIPTION
Some minor changes. I noticed the solutions dropdown had various options for solutions, which included several common incorrect answers. It wasn't clear what the correct solution was. I can understand if the intent was to have a multiple-choice question, but it was not formatted in that way.