### PR TITLE
Update 01-intro.md

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -295,9 +295,9 @@ stuck on it](../fig/python-sticky-note-variables-03.svg)
 >
 > > ## Solution
 > > ~~~
-> > type(planet)
-> > type(apples)
-> > type(distance)
+> > print(type(planet))
+> > print(type(apples))
+> > print(type(distance))
 > > ~~~
 > > {: .language-python}
 > >


### PR DESCRIPTION
Jupyter notebook will print only the output of the last command without the print function. 
print function is required to get all 3 outputs.

proposed:
print(type(planet))
print(type(apples))
print(type(distance))


existing:
type(planet)
type(apples)
type(distance)
