### PR TITLE
Add explicit parameters for numpy.delete

### DIFF
--- a/_episodes/02-numpy.md
+++ b/_episodes/02-numpy.md
@@ -662,10 +662,11 @@ which is the average inflammation per patient across all days.
 > > ## Solution
 > >
 > > An alternative way to achieve the same result is to use Numpy's
-> > delete function to remove the second column of A.
+> > delete function to remove the second column of A. If you're not
+> > sure what the parameters of numpy.delete mean, use the help files.
 > >
 > > ~~~
-> > D = numpy.delete(A, 1, 1)
+> > D = numpy.delete(arr=A, obj=1, axis=1)
 > > print('D = ')
 > > print(D)
 > > ~~~


### PR DESCRIPTION
The alternative solution of using numpy.delete() to remove a column from an array is helpful, but the meaning of the arguments is not obvious without explicitly including the names. Even then, "obj" is non-obvious, so I also added a note in the solution description reminding them to use help files if necessary.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
