### PR TITLE
re-import data at start of plotting

### DIFF
--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -22,6 +22,7 @@ import the `pyplot` module from `matplotlib` and use two of its functions to cre
 
 ~~~
 import matplotlib.pyplot
+import numpy
 data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 image = matplotlib.pyplot.imshow(data)
 matplotlib.pyplot.show()

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -20,10 +20,22 @@ there is no official plotting library, `matplotlib` is the _de facto_ standard. 
 import the `pyplot` module from `matplotlib` and use two of its functions to create and display a
 [heat map]({{ page.root }}/reference.html#heat-map) of our data:
 
+> ## Making sure we have the data
+>
+> If you are continuing inthe same notebook from the previous episode you already
+> have a `data` variable and have imported `numpy`.  If you are starting a new 
+> notebook at this point you need the following two lines. 
+>
+> ~~~
+> import numpy
+> data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
+> ~~~
+> {: .source}
+{: .callout}
+
+
 ~~~
 import matplotlib.pyplot
-import numpy
-data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 image = matplotlib.pyplot.imshow(data)
 matplotlib.pyplot.show()
 ~~~

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -30,7 +30,7 @@ import the `pyplot` module from `matplotlib` and use two of its functions to cre
 > import numpy
 > data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 > ~~~
-> {: .source}
+> {: .language-python}
 {: .callout}
 
 

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -24,7 +24,7 @@ import the `pyplot` module from `matplotlib` and use two of its functions to cre
 >
 > If you are continuing in the same notebook from the previous episode, you already
 > have a `data` variable and have imported `numpy`.  If you are starting a new 
-> notebook at this point you need the following two lines. 
+> notebook at this point, you need the following two lines:
 >
 > ~~~
 > import numpy

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -20,7 +20,7 @@ there is no official plotting library, `matplotlib` is the _de facto_ standard. 
 import the `pyplot` module from `matplotlib` and use two of its functions to create and display a
 [heat map]({{ page.root }}/reference.html#heat-map) of our data:
 
-> ## Making sure we have the data
+> ## Episode Prerequisites
 >
 > If you are continuing in the same notebook from the previous episode, you already
 > have a `data` variable and have imported `numpy`.  If you are starting a new 
@@ -31,7 +31,7 @@ import the `pyplot` module from `matplotlib` and use two of its functions to cre
 > data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 > ~~~
 > {: .language-python}
-{: .callout}
+{: .prereq}
 
 
 ~~~

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -22,7 +22,7 @@ import the `pyplot` module from `matplotlib` and use two of its functions to cre
 
 > ## Making sure we have the data
 >
-> If you are continuing inthe same notebook from the previous episode you already
+> If you are continuing in the same notebook from the previous episode, you already
 > have a `data` variable and have imported `numpy`.  If you are starting a new 
 > notebook at this point you need the following two lines. 
 >

--- a/_episodes/03-matplotlib.md
+++ b/_episodes/03-matplotlib.md
@@ -22,6 +22,7 @@ import the `pyplot` module from `matplotlib` and use two of its functions to cre
 
 ~~~
 import matplotlib.pyplot
+data = numpy.loadtxt(fname='inflammation-01.csv', delimiter=',')
 image = matplotlib.pyplot.imshow(data)
 matplotlib.pyplot.show()
 ~~~


### PR DESCRIPTION
This makes the individual episodes a little more self-containted and makes it easier for instructors who may swap out between episdoes.  

It also will mean that we do not need to dis-allow this episode for teaching demos [see PR](https://github.com/carpentries/instructor-training/pull/1346/commits/5ecd1baf934afa0a386c74ee82e29027f7ed8d0c)