### PR TITLE
fix: use normal print instead of percent formatting

### DIFF
--- a/_episodes/11-debugging.md
+++ b/_episodes/11-debugging.md
@@ -268,7 +268,7 @@ not more.
 > for patient in patients:
 >     weight, height = patients[0]
 >     bmi = calculate_bmi(height, weight)
->     print("Patient's BMI is: %f" % bmi)
+>     print("Patient's BMI is:", bmi)
 > ~~~
 > {: .language-python}
 >


### PR DESCRIPTION
This was using the old percent formatting instead of the more modern `.format` (Python 2.6+) or f-strings (Python 3.6+). What's more, string formatting is not introduced or discussed anywhere else in the lesson, and it is not elaborated here. I think the simplest thing for this is to simply not introduce it here, it's not needed, and multi-argument print calls have been introduced.
