### PR TITLE
chore: specify the minimum supported version

### DIFF
--- a/index.md
+++ b/index.md
@@ -62,7 +62,9 @@ about programming.
 > interpreter before tackling this lesson. This lesson sometimes references Jupyter
 > Notebook although you can use any Python interpreter mentioned in the [Setup][lesson-setup].
 >
-> The commands in this lesson pertain to **Python 3**.
+> The commands in this lesson pertain to any officially supported Python version, currently **Python
+> 3.7+**.  Newer versions usually have better error printouts, so using newer Python versions is
+> recommend if possible.
 {: .prereq}
 
 ### Getting Started


### PR DESCRIPTION
This specifies a minimum supported Python version. There was a discussion on discuss.python.org about stating "Python 3" vs. a minimum, and the consensus was that you should always state a minimum, rather than a generic "Python 3". Nothing actually works on Python 3.0 (such as NumPy), so it doesn't make sense to treat this as "Python 3", but rather as "Python 3.x". Currently it shoud work just fine on 3.5+, but I think it's best to avoid recommending EoL Python versions.

This will also enable the debugging lesson to use `breakpoint()`, and turn into a real lesson on debugging eventually, if desired. F-strings are something else that might be worth teaching.
