### PR TITLE
chore: touch up error handling for modern Python

### DIFF
--- a/_episodes/09-errors.md
+++ b/_episodes/09-errors.md
@@ -127,6 +127,12 @@ as it is possible to create custom errors.
 In that case,
 hopefully the custom error message is informative enough to help you figure out what went wrong.
 
+> ## Better errors on newer Pythons
+>
+> Newer versions of Python have improved error printouts.  If you are debugging errors, it is often
+> helpful to use the latest Python version, even if you support older versions of Python.
+{: .callout}
+
 ## Syntax Errors
 
 When you forget a colon at the end of a line,
@@ -373,7 +379,9 @@ you will receive a `FileNotFoundError` telling you so.
 If you attempt to write to a file that was opened read-only, Python 3
 returns an `UnsupportedOperationError`.
 More generally, problems with input and output manifest as
-`IOError`s or `OSError`s, depending on the version of Python you use.
+`OSError`s, which may show up as a more specific subclass; you can see
+[the list in the Python docs](https://docs.python.org/3/library/exceptions.html#os-exceptions).
+They all have a unique UNIX `errno`, which is you can see in the error message.
 
 ~~~
 file_handle = open('myfile.txt', 'r')

--- a/_episodes/10-defensive.md
+++ b/_episodes/10-defensive.md
@@ -534,7 +534,7 @@ This violates another important rule of programming:
 > > *   The first assertion checks that the input sequence `values` is not empty.
 > >     An empty sequence such as `[]` will make it fail.
 > > *   The second assertion checks that each value in the list can be turned into an integer.
-> >     Input such as `[1, 2,'c', 3]` will make it fail.
+> >     Input such as `[1, 2, 'c', 3]` will make it fail.
 > > *   The third assertion checks that the total of the list is greater than 0.
 > >     Input such as `[-10, 2, 3]` will make it fail.
 > {: .solution}


### PR DESCRIPTION
This was a holdover from Python 2. While cleaning it up, added recommendations for using newer Pythons for better error messages. The biggest leap is likely the upcoming 3.11, though 3.10 gives big improvements for several situation including invalid syntax.
