### PR TITLE
Removing use of gendered term layman

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -42,7 +42,7 @@ weight_kg = 60
 {: .language-python}
 
 From now on, whenever we use `weight_kg`, Python will substitute the value we assigned to
-it. In layman's terms, **a variable is a name for a value**.
+it. In layperson's terms, **a variable is a name for a value**.
 
 In Python, variable names:
 


### PR DESCRIPTION
Fixes #966 

Changes gendered term layman to non-gendered layperson. 

I think @matthewabrown's suggestion in #966 to instead avoid the use of lay[man/person] altogether (which I guess could be considered demotivational language in the sense implying the description should be easy to understood which might not be the case for everyone) by replacing the sentence with

> In essence, a variable is a named location for storing, modifying, and recalling a value

or some variant of this has merit, but as this would be a more significant change I've just made a minimal change to swap layman to layperson for now as this seems unlikely to be controversial.
