### PR TITLE
CHG: Bring empty function into namespace for tdd

### DIFF
--- a/_episodes/10-defensive.md
+++ b/_episodes/10-defensive.md
@@ -304,7 +304,15 @@ Its advocates believe it produces better code faster because:
     rather than to find errors.
 2.  Writing tests helps programmers figure out what the function is actually supposed to do.
 
-Here are three test functions for `range_overlap`:
+We start by defining an empty function `range_overlap`:
+
+~~~
+def range_overlap(ranges):
+    pass
+~~~
+{: .language-python}
+
+Here are three test statements for `range_overlap`:
 
 ~~~
 assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
@@ -326,10 +334,9 @@ AssertionError:
 {: .error}
 
 The error is actually reassuring:
-we haven't written `range_overlap` yet,
-so if the tests passed,
-it would be a sign that someone else had
-and that we were accidentally using their function.
+we haven't implemented any logic into `range_overlap` yet,
+so if the tests passed, it would indicate that we've written
+an entirely ineffective test.
 
 And as a bonus of writing these tests,
 we've implicitly defined what our input and output look like:


### PR DESCRIPTION
In lesson `10-defensive.md` under the section `Test-Driven Development` assertions statements are executed without the function `range_overlap` being available in the namespace. 

This actually will yield a `NameError`:
```python
# function is not defined, hence assertion can't be executed at all
assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
>>> NameError: name 'range_overlap' is not defined
```
However in the episode, it is stated that this will raise an `AssertionError` which is not correct:

![Screenshot from 2023-01-20 10:52:04](https://user-images.githubusercontent.com/10595420/213666455-c6c97f7f-9f94-4369-bc4c-fe47301a0c9f.png)


Instead of changing the error I opted to define `range_overlap` first without body, as I learned it as standard procedure for tdd:

```python
def range_overlap(ranges):
    pass

# now we get a failing test
assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
>>> AssertionError:
```
That way the tests can be triggered and raise the expected `AssertionError`, without changing the general flow of the episode. 

As an additional minor change, the displayed tests are merely *statements*, not *functions*.

