### PR TITLE
Do not mention "exceptions"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This lesson is also available in [R][R] and [MATLAB][MATLAB].
 | 6 | [Analyzing Data from Multiple Files][episode06] | 20 | How can I do the same operations on many different files? |
 | 7 | [Making Choices][episode07] | 30 | How can my programs do different things based on data values? |
 | 8 | [Creating Functions][episode08] | 30 | How can I define new functions?<br>What’s the difference between defining and calling a function?<br>What happens when I call a function? |
-| 9 | [Errors and Exceptions][episode09] | 30 | How does Python report errors?<br>How can I handle errors in Python programs? |
+| 9 | [Errors][episode09] | 30 | How does Python report errors?<br>How can I handle errors in Python programs? |
 |10 | [Defensive Programming][episode10] | 30 | How can I make my programs more reliable? |
 |11 | [Debugging][episode11] | 30 | How can I debug my program? |
 |12 | [Command-Line Programs][episode12] | 30 | How can I write Python programs that will work like Unix command-line tools? |

--- a/_episodes/09-errors.md
+++ b/_episodes/09-errors.md
@@ -1,5 +1,5 @@
 ---
-title: Errors and Exceptions
+title: Errors
 teaching: 30
 exercises: 0
 questions:
@@ -29,7 +29,7 @@ keypoints:
 Every programmer encounters errors,
 both those who are just beginning,
 and those who have been programming for years.
-Encountering errors and exceptions can be very frustrating at times,
+Encountering errors can be very frustrating at times,
 and can make coding feel like a hopeless endeavour.
 However,
 understanding what the different types of errors are


### PR DESCRIPTION
The section currently is called 'Errors and Exceptions', but the section itself only mentions 'errors' and just once 'errors and exceptions'. There might be an argument here about what the difference is between both, but neither is it currently made in the material, nor do I think it should in an introductory course like this.

Because of this, I propose to remove the mention of 'exceptions' entirely from this course (only 2 places), and especially from a section heading, to avoid unnecessary confusion by new learners.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
