### PR TITLE
remove unnecessary type conversion

### DIFF
--- a/_episodes/10-defensive.md
+++ b/_episodes/10-defensive.md
@@ -130,10 +130,10 @@ def normalize_rectangle(rect):
     dx = x1 - x0
     dy = y1 - y0
     if dx > dy:
-        scaled = float(dx) / dy
+        scaled = dx / dy
         upper_x, upper_y = 1.0, scaled
     else:
-        scaled = float(dx) / dy
+        scaled = dx / dy
         upper_x, upper_y = scaled, 1.0
 
     assert 0 < upper_x <= 1.0, 'Calculated upper X coordinate invalid'


### PR DESCRIPTION
This removes the ```float()``` around a (potential) integer division. Since Python3 the result of an integer division is a floating point number. This also removes the time and attention capacity necessary by learners for an explaination of what this does and why it is there. I do not mean to say that type conversions cannot be important, but the focus of this excercise is elsewhere.

Note: it was good to have this in place for Python2, but Python2 is dead today and has been for a while. We also require an installation of Python3 in the setup.

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
