### PR TITLE
[workbench transition] Update setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -45,21 +45,17 @@ If you installed Anaconda, you can launch a notebook in two ways:
 >
 > 1. Launch Anaconda Navigator.
 > It might ask you if you'd like to send anonymized usage information to Anaconda developers:
-> ![Anaconda Navigator first launch](
-{{ page.root }}{% link fig/anaconda-navigator-first-launch.png %})
+> ![Anaconda Navigator first launch]({{ page.root }}{% link fig/anaconda-navigator-first-launch.png %})
 > Make your choice and click "Ok, and don't show again" button.
 > 2. Find the "Notebook" tab and click on the "Launch" button:
-> ![Anaconda Navigator Notebook launch](
-{{ page.root }}{% link fig/anaconda-navigator-notebook-launch.png %})
+> ![Anaconda Navigator Notebook launch]({{ page.root }}{% link fig/anaconda-navigator-notebook-launch.png %})
 > Anaconda will open a new browser window or tab with a Notebook Dashboard showing you the
 > contents of your Home (or User) folder.
 > 3. Navigate to the `data` directory by clicking on the directory names leading to it:
 > `Desktop`, `swc-python`, then `data`:
-> ![Anaconda Navigator Notebook directory](
-{{ page.root }}{% link fig/jupyter-notebook-data-directory.png %})
+> ![Anaconda Navigator Notebook directory]({{ page.root }}{% link fig/jupyter-notebook-data-directory.png %})
 > 4. Launch the notebook by clicking on the "New" button and then selecting "Python 3":
-> ![Anaconda Navigator Notebook directory](
-{{ page.root }}{% link fig/jupyter-notebook-launch-notebook.png %})
+> ![Anaconda Navigator Notebook directory]({{ page.root }}{% link fig/jupyter-notebook-launch-notebook.png %})
 {: .solution}
 
 > ## Command line (Terminal)
@@ -104,8 +100,7 @@ If you installed Anaconda, you can launch a notebook in two ways:
 >
 > 3\. Launch the notebook by clicking on the "New" button on the right and selecting "Python 3"
 > from the drop-down menu:
-> ![Anaconda Navigator Notebook directory](
-{{ page.root }}{% link fig/jupyter-notebook-launch-notebook2.png %})
+> ![Anaconda Navigator Notebook directory]({{ page.root }}{% link fig/jupyter-notebook-launch-notebook2.png %})
 {: .solution}
 
 &nbsp; <!-- vertical spacer -->


### PR DESCRIPTION
I'm updating these links because the commonmark parser does not recognise them and my intervention did not account for this situation. This is the only place in this or any of the other lessons I have modified where this happens, so it's easier for me to update this than to update my intervention and add tests.

FWIW, the link syntax in The Workbench is _much_ simpler:

https://carpentries.github.io/workbench/transition-guide.html#internal-links