### PR TITLE
Update example output

### DIFF
--- a/episodes/08-func.md
+++ b/episodes/08-func.md
@@ -327,7 +327,7 @@ print('min, mean, and max of offset data are:',
 
 ```output
 original min, mean, and max are: 0.0 6.14875 20.0
-min, mean, and and max of offset data are: -6.14875 2.84217094304e-16 13.85125
+min, mean, and max of offset data are: -6.14875 2.842170943040401e-16 13.85125
 ```
 
 That seems almost right:
@@ -342,7 +342,7 @@ print('std dev before and after:', numpy.std(data), numpy.std(offset_data))
 ```
 
 ```output
-std dev before and after: 4.61383319712 4.61383319712
+std dev before and after: 4.613833197118566 4.613833197118566
 ```
 
 Those values look the same,
@@ -355,13 +355,11 @@ print('difference in standard deviations before and after:',
 ```
 
 ```output
-difference in standard deviations before and after: -3.5527136788e-15
+difference in standard deviations before and after: 0.0
 ```
 
-Again,
-the difference is very small.
-It's still possible that our function is wrong,
-but it seems unlikely enough that we should probably get back to doing our analysis.
+Everything looks good,
+and we should probably get back to doing our analysis.
 We have one more task first, though:
 we should write some [documentation](../learners/reference.md#documentation) for our function
 to remind ourselves later what it's for and how to use it.

--- a/episodes/08-func.md
+++ b/episodes/08-func.md
@@ -333,8 +333,7 @@ min, mean, and max of offset data are: -6.14875 2.842170943040401e-16 13.85125
 That seems almost right:
 the original mean was about 6.1,
 so the lower bound from zero is now about -6.1.
-The mean of the offset data isn't quite zero --- we'll explore why not in the challenges --- but
-it's pretty close.
+The mean of the offset data isn't quite zero, but it's pretty close.
 We can even go further and check that the standard deviation hasn't changed:
 
 ```python


### PR DESCRIPTION
This fixes #1013 by updating the example output and removing mention of the difference being "very small" - it is now calculated as 0.0.

The second commit also removes the middle of this sentence:

> The mean of the offset data isn’t quite zero — we’ll explore why not in the challenges — but it’s pretty close.

because, as far as I can tell, we do not actually "explore why not in the challenges"