### PR TITLE
[UPDATE] urls to resources in Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ community listed at <https://carpentries.org/connect/> including via social
 media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
-[repo]: https://example.com/FIXME
+[repo]: https://github.com/swcarpentry/python-novice-inflammation
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
@@ -111,7 +111,7 @@ email][contact].
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://carpentries.org/help-wanted-issues/
 [lc-issues]: https://github.com/issues?q=user%3ALibraryCarpentry
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry


### PR DESCRIPTION
### This PR closes issue #1042 

The Contributing Guide, CONTRIBUTING.md, contains two links with URLs that should be updated:

* the How to Contribute to an Open Source Project on GitHub link which used to lead to a 404 has now been updated to link to https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
* the [repo] link reference which used to point to a placeholder URL (https://example.com/FIXME) has been updated with the current repository url.


