### PR TITLE
Added reference to argh library

### DIFF
--- a/episodes/12-cmdline.md
+++ b/episodes/12-cmdline.md
@@ -311,6 +311,8 @@ We will not cover this module in this lesson
 but you can go to Tshepang Lekhonkhobe's
 [Argparse tutorial](https://docs.python.org/3/howto/argparse.html)
 that is part of Python's Official Documentation.
+We can also use the `argh` library, a wrapper around the `argparse` library that simplifies
+its usage (see [here](https://pythonhosted.org/argh/) for more information).
 
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Add a reference to the argh library to make it easier for people to get started with command line interfaces in Python.