### PR TITLE
FIX: Correcting line breaks for episode 4 on lists

### DIFF
--- a/episodes/04-lists.md
+++ b/episodes/04-lists.md
@@ -540,7 +540,7 @@ counts + counts
 
 - `[value1, value2, value3, ...]` creates a list.
 - Lists can contain any Python object, including lists (i.e., list of lists).
-- Lists are indexed and sliced with square brackets (e.g., list\[0\] and list\[2:9\]), in the same way as strings and arrays.
+- Lists are indexed and sliced with square brackets (e.g., `list[0]` and `list[2:9]`), in the same way as strings and arrays.
 - Lists are mutable (i.e., their values can be changed in place).
 - Strings are immutable (i.e., the characters in them cannot be changed).
 


### PR DESCRIPTION
## Fixes: #1050 

The key points were broken in episode 4 due to math rendering. This is a quick fix.

---

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

---
