### PR TITLE
link to installation instructions page in workshop template

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -191,7 +191,7 @@ winpty python
 ```
 
 [anaconda-website]: https://www.anaconda.com/
-[anaconda-instructions]: https://carpentries.github.io/workshop-template/#python
+[anaconda-instructions]: https://carpentries.github.io/workshop-template/install_instructions/#python
 [anaconda-install]: https://docs.anaconda.com/anaconda/install
 [zipfile1]: data/python-novice-inflammation-data.zip
 [zipfile2]: ../episodes/files/code/python-novice-inflammation-code.zip


### PR DESCRIPTION
To reduce confusion for learners visiting the installation instructions, this links to a dedicated page of installation instructions in the template workshop website. This is instead of the template landing page, which contains a lot of FIXMEs that can be alarming and give someone the impression that the link has taken them to the wrong place.