### PR TITLE
adjust wording of range exercise; fix #1053

### DIFF
--- a/episodes/05-loop.md
+++ b/episodes/05-loop.md
@@ -268,7 +268,7 @@ accept 1, 2, or 3 parameters.
   For example, `range(3, 10, 2)` produces `3, 5, 7, 9`.
 
 Using `range`,
-write a loop that uses `range` to print the first 3 natural numbers:
+write a loop that prints the first 3 natural numbers:
 
 ```python
 1


### PR DESCRIPTION
Adjusted the wording of the exercise using `range` in episode 5, to fix the confusion raised in #1053 

I chose to keep the "Using `range`", since the other wording might imply that `range` should do the printing. (I recently encountered a learner trying to call `range` directly for this challenge rather than using a loop with `print` in the body.)