### PR TITLE
use spoiler divs for expandable launch instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -41,13 +41,7 @@ you like.
 A Jupyter Notebook provides a browser-based interface for working with Python.
 If you installed Anaconda, you can launch a notebook in two ways:
 
-:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
-
-<!-- This div is intentionally empty to allow the solution to float alone-->
-
-::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::  solution
+::::::::::::::::: spoiler
 
 ## Anaconda Navigator
 
@@ -67,25 +61,14 @@ If you installed Anaconda, you can launch a notebook in two ways:
 
 :::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
 
-<!-- This div is intentionally empty to allow the solution to float alone-->
-
-::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::  solution
+::::::::::::::::: spoiler
 
 ## Command line (Terminal)
 
 1\. Navigate to the `data` directory:
 
-:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
-
-<!-- This div is intentionally empty to allow the solution to float alone-->
-
-::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::  solution
+::::::::::::::::: spoiler
 
 ## Unix shell
 
@@ -98,13 +81,7 @@ cd ~/Desktop/swc-python/data
 
 :::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
-
-<!-- This div is intentionally empty to allow the solution to float alone-->
-
-::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::  solution
+::::::::::::::::: spoiler
 
 ## Command Prompt (Windows)
 
@@ -121,13 +98,7 @@ cd /D %userprofile%\Desktop\swc-python\data
 
 2\. Start Jupyter server
 
-:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
-
-<!-- This div is intentionally empty to allow the solution to float alone-->
-
-::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::  solution
+::::::::::::::::: spoiler
 
 ## Unix shell
 
@@ -137,13 +108,8 @@ jupyter notebook
 
 :::::::::::::::::::::::::
 
-:::::::::::::::::::::::::::::::::::::::: {.empty-div style="margin-bottom: 50px"}
 
-<!-- This div is intentionally empty to allow the solution to float alone-->
-
-::::::::::::::::::::::::::::::::::::::::
-
-:::::::::::::::  solution
+::::::::::::::::: spoiler
 
 ## Command Prompt (Windows)
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This switches floating solution divs in the setup instructions for the `spoiler` class introduced in the recent release of the lesson infrastructure

_If any relevant discussions have taken place elsewhere, please provide links to these._

See https://github.com/carpentries/sandpaper/pull/502#issuecomment-1698203526 for an example of a spoiler class div in action.