### PR TITLE
Update Py version to 3.8+ as 3.7 has reached EOL - issue #1070

### DIFF
--- a/index.md
+++ b/index.md
@@ -62,7 +62,7 @@ interpreter before tackling this lesson. This lesson sometimes references Jupyte
 Notebook although you can use any Python interpreter mentioned in the [Setup](learners/setup.md).
 
 The commands in this lesson pertain to any officially supported Python version, currently **Python
-3\.7+**.  Newer versions usually have better error printouts, so using newer Python versions is
+3\.8+**.  Newer versions usually have better error printouts, so using newer Python versions is
 recommend if possible.
 
 


### PR DESCRIPTION
This is in relation to Issue #1070 

```
The section on prerequisites notes that you should be using any current Python version 3.7+.
Python 3.7 hit EOL on 2023-06-27. This callout should be updated to refer to 3.8+
```
