### PR TITLE
Fix "FIXME" in Glossary page title

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -1,8 +1,6 @@
 ---
-title: 'FIXME'
+title: 'Glossary'
 ---
-
-## Glossary
 
 ## Glossary
 


### PR DESCRIPTION
The `reference.md` file that contains the glossary has "FIXME" as a title, and has the "Glossary" heading twice.  This PR fixes both of those issues.