### PR TITLE
change one plot from continuous to discrete

### DIFF
--- a/episodes/03-matplotlib.md
+++ b/episodes/03-matplotlib.md
@@ -124,7 +124,7 @@ axes2 = fig.add_subplot(1, 3, 2)
 axes3 = fig.add_subplot(1, 3, 3)
 
 axes1.set_ylabel('average')
-axes1.plot(numpy.mean(data, axis=0))
+axes1.plot(numpy.mean(data, axis=0), 'x'))
 
 axes2.set_ylabel('max')
 axes2.plot(numpy.amax(data, axis=0))


### PR DESCRIPTION
Reasons for this change:

- we have discrete underlying data (i.e., number of inflammation-bouts are recorded once a day), a line plot suggests that it is continuous data; a bar chart would be an alternative 
- novices might struggle with the column and row notation, if we just add , `, -'x'` to one of the axes, it becomes obvious which axes is reflected in the final image; in other words: if we leave 2 out of 3 plots (i.e., axes) untouched and just adjust one, we can easily spot where our x ticks are shown on the plot and where the others have lines.
- overall, it shows the power of plotting; by adding the simple , `, -'x'` "flag" we can adjust the layout.
- Resulting images attached
- Before  ![image](https://github.com/swcarpentry/python-novice-inflammation/assets/35558560/a9997599-3e79-461f-896d-828e7ee7c1fb)
- After ![image](https://github.com/swcarpentry/python-novice-inflammation/assets/35558560/d17b4d51-3e10-43a6-b44c-eec501ffc97a)
