### PR TITLE
Add debug term to glossary

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -57,6 +57,10 @@ depending on whether a test is true or false.
 :   (CSV) A common textual representation for tables
 in which the values in each row are separated by commas.
 
+[debug](#debug)
+:   The action of finding and resolving errors (also known as 'bugs') 
+within computer programs or systems.
+
 [default value]{#default-value}
 :   A value to use for a [parameter](#parameter) if nothing is specified explicitly.
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._
N/A

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

In the [carpentries glosario repo](https://github.com/carpentries/glosario/issues/384) it was raised that it could be helpful for some learners to include the definition of "debug".

This PR adds the "debug" term to the glossary, using a shorter variant of the definition given in [glosario](https://glosario.carpentries.org/en/#debug)


_If any relevant discussions have taken place elsewhere, please provide links to these._

The suggestion comes from [issue #384 in the glosario repo](https://github.com/carpentries/glosario/issues/384)

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
