### PR TITLE
Add definition for whitespace

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -300,4 +300,5 @@ See also: [syntax error](#syntax-error).
 :   A loop that keeps executing as long as some condition is true.
 See also: [for loop](#for-loop).
 
-
+[whitespace]{#whitespace}
+:   The space, newline, carriage return, and horizontal and vertical tab characters that take up space but do not create a visible mark.


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Fixes #1098

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

Adds a definition for "whitespace" to the lesson glossary. The definition is taken from [Glosario](https://glosario.carpentries.org/en/#whitespace).
_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
