### PR TITLE
Option to remove Anaconda as part of setup

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -38,8 +38,6 @@ You can launch a notebook from the command line:
 
 :::::::::::::::: spoiler
 
-:::::::::::::::: spoiler
-
 ## Command line (Terminal)
 
 1\. Navigate to the `data` directory:


### PR DESCRIPTION
based on discussion in https://github.com/datacarpentry/python-ecology-lesson/issues/617

As Anaconda license is more closed and there's a risk to encourage people to use it outside that license, trying to identify cues to novice instructors like myself who aren't aware of alternatives to anaconda.