### PR TITLE
Add complete solution for range_overlap example

### DIFF
--- a/episodes/10-defensive.md
+++ b/episodes/10-defensive.md
@@ -409,12 +409,11 @@ let's put them all in a function:
 
 ```python
 def test_range_overlap():
-    assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
-    assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
     assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
     assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
     assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)
-    assert range_overlap([]) == None
+    assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
+    assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
 ```
 
 We can now test `range_overlap` with a single function call:
@@ -426,20 +425,20 @@ test_range_overlap()
 ```error
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
-<ipython-input-29-cf9215c96457> in <module>()
+Cell , line 1
 ----> 1 test_range_overlap()
 
-<ipython-input-28-5d4cd6fd41d9> in test_range_overlap()
+Cell , line 3, in test_range_overlap()
       1 def test_range_overlap():
-----> 2     assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
-      3     assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
-      4     assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
-      5     assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
+      2     assert range_overlap([ (0.0, 1.0) ]) == (0.0, 1.0)
+----> 3     assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
+      4     assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)
+      5     assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
 
-AssertionError:
+AssertionError: 
 ```
 
-The first test that was supposed to produce `None` fails,
+The test that was supposed to produce a simple range fails,
 so we know something is wrong with our function.
 We *don't* know whether the other tests passed or failed
 because Python halted the program as soon as it spotted the first error.
@@ -450,6 +449,65 @@ we realize that we're initializing `max_left` and `min_right` to 0.0 and 1.0 res
 regardless of the input values.
 This violates another important rule of programming:
 *always initialize from data*.
+
+We can update our function so that it initializes `max_left` and `min_right`
+from the input data itself.
+
+```python
+def range_overlap(ranges):
+    """Return common overlap among a set of [left, right] ranges."""
+    max_left, min_right = ranges[0]
+    for (left, right) in ranges:
+        max_left = max(max_left, left)
+        min_right = min(min_right, right)
+    return (max_left, min_right)
+```
+
+Re-running our tests we see that we now pass the second test,
+but fail one of the non-overlapping cases.
+
+```python
+test_range_overlap()
+```
+```error
+---------------------------------------------------------------------------
+AssertionError                            Traceback (most recent call last)
+Cell , line 1
+----> 1 test_range_overlap()
+
+Cell , line 5, in test_range_overlap()
+      3 assert range_overlap([ (2.0, 3.0), (2.0, 4.0) ]) == (2.0, 3.0)
+      4 assert range_overlap([ (0.0, 1.0), (0.0, 2.0), (-1.0, 1.0) ]) == (0.0, 1.0)
+----> 5 assert range_overlap([ (0.0, 1.0), (5.0, 6.0) ]) == None
+      6 assert range_overlap([ (0.0, 1.0), (1.0, 2.0) ]) == None
+
+AssertionError: 
+```
+It turns out that for our current implementation of the `range_overlap` function 
+we never handled the case where there is no overlap. This shows up when
+`max_left` is either equal to or greater than `min_right`, which isn't an actual range.
+We can edit our function one last time to catch this behaviour and return `None`.
+
+```python
+def range_overlap(ranges):
+    """Return common overlap among a set of [left, right] ranges."""
+    max_left, min_right = ranges[0]
+    for (left, right) in ranges:
+        max_left = max(max_left, left)
+        min_right = min(min_right, right)
+    if max_left >= min_right:
+        overlap = None
+    else:
+        overlap = (max_left, min_right)
+    return overlap
+```
+
+```python
+test_range_overlap()
+```
+
+We get no output from `test_range_overlap()`,
+which means all the tests passed.
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
The range_overlap example stops before giving a final solution, which is annoying if you're teaching from the curriculum. The assertions also change order for no particular reason.

I fix the order of the assertions, and add the complete working function.

_If any relevant discussions have taken place elsewhere, please provide links to these._
Replacing this example has discussed for years https://github.com/swcarpentry/python-novice-inflammation/issues/979, but there hasn't been a good proposal. This PR just makes the existing curriculum more useful, and it's fine if it gets replaced at some point in the future.

<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
