### PR TITLE
A number of small nitpicks changes to the temperature function examples

### DIFF
--- a/episodes/08-func.md
+++ b/episodes/08-func.md
@@ -103,36 +103,36 @@ and we have access to the value that we returned.
 ## Composing Functions
 
 Now that we've seen how to turn Fahrenheit into Celsius,
-we can also write the function to turn Celsius into Kelvin:
+we can also write the function to turn Celsius into kelvins:
 
 ```python
-def celsius_to_kelvin(temp_c):
+def celsius_to_kelvins(temp_c):
     return temp_c + 273.15
 
-print('freezing point of water in Kelvin:', celsius_to_kelvin(0.))
+print('freezing point of water in Kelvin:', celsius_to_kelvins(0.0))
 ```
 
 ```output
-freezing point of water in Kelvin: 273.15
+freezing point of water in kelvins: 273.15
 ```
 
-What about converting Fahrenheit to Kelvin?
+What about converting Fahrenheit to kelvins?
 We could write out the formula,
 but we don't need to.
 Instead,
 we can [compose](../learners/reference.md#compose) the two functions we have already created:
 
 ```python
-def fahr_to_kelvin(temp_f):
+def fahr_to_kelvins(temp_f):
     temp_c = fahr_to_celsius(temp_f)
-    temp_k = celsius_to_kelvin(temp_c)
+    temp_k = celsius_to_kelvins(temp_c)
     return temp_k
 
-print('boiling point of water in Kelvin:', fahr_to_kelvin(212.0))
+print('boiling point of water in kelvins:', fahr_to_kelvins(212.0))
 ```
 
 ```output
-boiling point of water in Kelvin: 373.15
+boiling point of water in kelvins: 373.15
 ```
 
 This is our first taste of how larger programs are built:
@@ -145,37 +145,38 @@ or the next person who reads it won't be able to understand what's going on.
 ## Variable Scope
 
 In composing our temperature conversion functions, we created variables inside of those functions,
-`temp`, `temp_c`, `temp_f`, and `temp_k`.
+`temp_c`, `temp_f`, and `temp_k`.
 We refer to these variables as [local variables](../learners/reference.md#local-variable)
 because they no longer exist once the function is done executing.
 If we try to access their values outside of the function, we will encounter an error:
 
 ```python
-print('Again, temperature in Kelvin was:', temp_k)
+print('Again, temperature in kelvins was:', temp_k)
 ```
 
 ```error
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 <ipython-input-1-eed2471d229b> in <module>
-----> 1 print('Again, temperature in Kelvin was:', temp_k)
+----> 1 print('Again, temperature in kelvins was:', temp_k)
 
 NameError: name 'temp_k' is not defined
 ```
 
-If you want to reuse the temperature in Kelvin after you have calculated it with `fahr_to_kelvin`,
+If you want to reuse the temperature in kelvins
+after you have calculated it with `fahr_to_kelvins`,
 you can store the result of the function call in a variable:
 
 ```python
-temp_kelvin = fahr_to_kelvin(212.0)
-print('temperature in Kelvin was:', temp_kelvin)
+temp_kelvins = fahr_to_kelvins(212.0)
+print('temperature in kelvins was:', temp_kelvins)
 ```
 
 ```output
-temperature in Kelvin was: 373.15
+temperature in kelvins was: 373.15
 ```
 
-The variable `temp_kelvin`, being defined outside any function,
+The variable `temp_kelvins`, being defined outside any function,
 is said to be [global](../learners/reference.md#global-variable).
 
 Inside a function, one can read the value of such global variables:
@@ -183,17 +184,17 @@ Inside a function, one can read the value of such global variables:
 ```python
 def print_temperatures():
     print('temperature in Fahrenheit was:', temp_fahr)
-    print('temperature in Kelvin was:', temp_kelvin)
+    print('temperature in kelvins was:', temp_kelvins)
 
 temp_fahr = 212.0
-temp_kelvin = fahr_to_kelvin(temp_fahr)
+temp_kelvins = fahr_to_kelvins(temp_fahr)
 
 print_temperatures()
 ```
 
 ```output
 temperature in Fahrenheit was: 212.0
-temperature in Kelvin was: 373.15
+temperature in kelvins was: 373.15
 ```
 
 ## Tidying up

--- a/episodes/08-func.md
+++ b/episodes/08-func.md
@@ -48,24 +48,24 @@ Let's start by defining a function `fahr_to_celsius` that converts temperatures
 from Fahrenheit to Celsius:
 
 ```python
-def explicit_fahr_to_celsius(temp):
+def explicit_fahr_to_celsius(temp_f):
     # Assign the converted value to a variable
-    converted = ((temp - 32) * (5/9))
+    temp_c = ((temp_f - 32) * (5/9))
     # Return the value of the new variable
-    return converted
-    
-def fahr_to_celsius(temp):
+    return temp_f
+
+def fahr_to_celsius(temp_f):
     # Return converted value more efficiently using the return
     # function without creating a new variable. This code does
     # the same thing as the previous function but it is more explicit
     # in explaining how the return command works.
-    return ((temp - 32) * (5/9))
+    return ((temp_f - 32) * (5/9))
 ```
 
 ![](fig/python-function.svg){alt='Labeled parts of a Python function definition'}
 
 The function definition opens with the keyword `def` followed by the
-name of the function (`fahr_to_celsius`) and a parenthesized list of parameter names (`temp`). The
+name of the function (`fahr_to_celsius`) and a parenthesized list of parameter names (`temp_f`). The
 [body](../learners/reference.md#body) of the function --- the
 statements that are executed when it runs --- is indented below the
 definition line.  The body concludes with a `return` keyword followed by the return value.

--- a/episodes/fig/python-function.svg
+++ b/episodes/fig/python-function.svg
@@ -1,24 +1,135 @@
-<svg height="130" width="340" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <defs>
-    <marker id="arrowhead" orient="auto" overflow="visible" refX="0" refY="0">
-      <path d="m8.7 4-10.9-4 10.9-4c-1.7 2.4-1.7 5.6 0 8z" fill-rule="evenodd" stroke="#000" stroke-linejoin="round" stroke-width=".6" transform="scale(-.6)"/>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="130"
+   width="359"
+   version="1.1"
+   id="svg16"
+   sodipodi:docname="python-function.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview16"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.8153846"
+     inkscape:cx="182.05509"
+     inkscape:cy="59.491526"
+     inkscape:window-width="1312"
+     inkscape:window-height="431"
+     inkscape:window-x="0"
+     inkscape:window-y="34"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg16" />
+  <defs
+     id="defs1">
+    <marker
+       id="arrowhead"
+       orient="auto"
+       overflow="visible"
+       refX="0"
+       refY="0">
+      <path
+         d="M 8.7,4 -2.2,0 8.7,-4 C 7,-1.6 7,1.6 8.7,4 Z"
+         fill-rule="evenodd"
+         stroke="#000000"
+         stroke-linejoin="round"
+         stroke-width="0.6"
+         transform="scale(-0.6)"
+         id="path1" />
     </marker>
   </defs>
-  <text font-family="monospace" font-size="16" text-anchor="middle" x="34.2" xml:space="preserve" y="56.3"><tspan text-anchor="start" x="34.2" y="56.3"><tspan fill="#008000" font-weight="bold">def</tspan> <tspan fill="#00f">fahr_to_celsius</tspan><tspan fill="#6e5494">(temp):</tspan></tspan><tspan text-anchor="start" x="34.2" y="85.1">    <tspan fill="#008000" font-weight="bold">return</tspan> <tspan fill="#6e5494">((temp - 32) * (5/9))</tspan></tspan></text>
-  <g fill="none" marker-end="url(#arrowhead)" pointer-events="none" stroke="#000" stroke-miterlimit="10">
-    <path d="m66.1 14.7-14.7 21.7"/>
-    <path d="m153.8 14.7-14.7 21.7"/>
-    <path d="m263.9 14.7-14.7 21.7"/>
-    <path d="m220.2 116.5 14.7-21.7"/>
-    <path d="m86.1 116.5 14.8-21.8"/>
+  <text
+     font-family="monospace"
+     font-size="16px"
+     text-anchor="middle"
+     x="34.200001"
+     xml:space="preserve"
+     y="56.299999"
+     id="text7"><tspan
+       text-anchor="start"
+       x="34.200001"
+       y="56.299999"
+       id="tspan4"><tspan
+   fill="#008000"
+   font-weight="bold"
+   id="tspan1">def</tspan> <tspan
+   fill="#0000ff"
+   id="tspan2">fahr_to_celsius</tspan><tspan
+   fill="#6e5494"
+   id="tspan3">(temp_f):</tspan></tspan><tspan
+       text-anchor="start"
+       x="34.200001"
+       y="85.099998"
+       id="tspan7">    <tspan
+   fill="#008000"
+   font-weight="bold"
+   id="tspan5">return</tspan> <tspan
+   fill="#6e5494"
+   id="tspan6">((temp_f - 32) * (5/9))</tspan></tspan></text>
+  <g
+     fill="none"
+     marker-end="url(#arrowhead)"
+     pointer-events="none"
+     stroke="#000000"
+     stroke-miterlimit="10"
+     id="g11">
+    <path
+       d="M 66.1,14.7 51.4,36.4"
+       id="path7" />
+    <path
+       d="M 153.8,14.7 139.1,36.4"
+       id="path8" />
+    <path
+       d="M 263.9,14.7 249.2,36.4"
+       id="path9" />
+    <path
+       d="M 220.2,116.5 234.9,94.8"
+       id="path10" />
+    <path
+       d="M 86.1,116.5 100.9,94.7"
+       id="path11" />
   </g>
-  <g font-size="12" font-family="sans-serif" text-anchor="middle">
-    <text x="58.3" y="10.6">def statement</text>
-    <text x="153.9" y="10.6">name</text>
-    <text x="256.1" y="10.6">parameter names</text>
-    <text x="14.9" y="82.5">body</text>
-    <text x="93.4" y="128">return statement</text>
-    <text x="227.6" y="128.4">return value</text>
+  <g
+     font-size="12px"
+     font-family="sans-serif"
+     text-anchor="middle"
+     id="g16">
+    <text
+       x="58.299999"
+       y="10.6"
+       id="text11">def statement</text>
+    <text
+       x="153.89999"
+       y="10.6"
+       id="text12">name</text>
+    <text
+       x="256.10001"
+       y="10.6"
+       id="text13">parameter names</text>
+    <text
+       x="14.9"
+       y="82.5"
+       id="text14">body</text>
+    <text
+       x="93.400002"
+       y="128"
+       id="text15">return statement</text>
+    <text
+       x="227.60001"
+       y="128.39999"
+       id="text16">return value</text>
   </g>
-  <path d="m48.9 61.9h-13.7v34.5h13.7" fill="none" stroke="#000"/>
+  <path
+     d="M 48.9,61.9 H 35.2 v 34.5 h 13.7"
+     fill="none"
+     stroke="#000000"
+     id="path16" />
 </svg>


### PR DESCRIPTION
This PR introduces a small number of related changes to the temperature examples for functions

1. Use `temp_f` rather than `temp`, to consistently identify that the input temperature for `fahr_to_celsius` is a temperature _in Fahrenheit_, since the return value will also be a temperature.
2. Use "kelvins" rather than "Kelvin"; since the kelvin is an SI unit, using lowercase and plural is correct.
